### PR TITLE
cmd kube switches

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,14 +56,11 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
-	rootCmd.PersistentFlags().StringP("master", "m", "", "Kubernetes API server address")
 	rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace to watch for BOSH deployments")
 	viper.BindPFlag("kubeconfig", rootCmd.PersistentFlags().Lookup("kubeconfig"))
-	viper.BindPFlag("masterURL", rootCmd.PersistentFlags().Lookup("master"))
 	viper.BindPFlag("namespace", rootCmd.PersistentFlags().Lookup("namespace"))
 	viper.BindEnv("kubeconfig")
 	viper.BindEnv("namespace", "CFO_NAMESPACE")
-	viper.BindEnv("masterURL", "CFO_MASTER_URL")
 }
 
 // initConfig is executed before running commands
@@ -77,10 +74,9 @@ func initConfig() {
 
 func getKubeConfig() (*rest.Config, error) {
 	kubeconfig := viper.GetString("kubeconfig")
-	masterURL := viper.GetString("masterURL")
 
 	if len(kubeconfig) > 0 {
-		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
 	}
 
 	// If no explicit location, try the in-cluster config

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -30,7 +30,6 @@ var _ = Describe("CLI", func() {
 			Eventually(session.Out).Should(Say(`Flags:
   -h, --help                help for cf-operator
   -c, --kubeconfig string   Path to a kubeconfig, not required in-cluster
-  -m, --master string       Kubernetes API server address
   -n, --namespace string    Namespace to watch for BOSH deployments \(default "default"\)
 
 `))

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -54,27 +54,55 @@ var _ = Describe("CLI", func() {
 			Eventually(session.Err).Should(Say(`Starting cf-operator with namespace default`))
 		})
 
-		Context("when using environment variables", func() {
-			BeforeEach(func() {
-				os.Setenv("CFO_NAMESPACE", "env-test")
+		Context("when specifying namespace", func() {
+			Context("via environment variables", func() {
+				BeforeEach(func() {
+					os.Setenv("CFO_NAMESPACE", "env-test")
+				})
+
+				AfterEach(func() {
+					os.Setenv("CFO_NAMESPACE", "")
+				})
+
+				It("should start for namespace", func() {
+					session, err := act()
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session.Err).Should(Say(`Starting cf-operator with namespace env-test`))
+				})
 			})
 
-			AfterEach(func() {
-				os.Setenv("CFO_NAMESPACE", "")
-			})
-
-			It("should start for namespace", func() {
-				session, err := act()
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(session.Err).Should(Say(`Starting cf-operator with namespace env-test`))
+			Context("via using switches", func() {
+				It("should start for namespace", func() {
+					session, err := act("--namespace", "switch-test")
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session.Err).Should(Say(`Starting cf-operator with namespace switch-test`))
+				})
 			})
 		})
 
-		Context("when using switches", func() {
-			It("should start for namespace", func() {
-				session, err := act("--namespace", "switch-test")
-				Expect(err).ToNot(HaveOccurred())
-				Eventually(session.Err).Should(Say(`Starting cf-operator with namespace switch-test`))
+		Context("when specifying kubeconfig", func() {
+			Context("via environment variables", func() {
+				BeforeEach(func() {
+					os.Setenv("KUBECONFIG", "invalid")
+				})
+
+				AfterEach(func() {
+					os.Setenv("KUBECONFIG", "")
+				})
+
+				It("should use specified config", func() {
+					session, err := act()
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session.Err).Should(Say(`stat invalid: no such file or directory`))
+				})
+			})
+
+			Context("via switches", func() {
+				It("should use specified config", func() {
+					session, err := act("--kubeconfig", "invalid")
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session.Err).Should(Say(`stat invalid: no such file or directory`))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Remove `--master` URL command line switch as discussed.

Also add a test for supported `--kubeconfig` switch and ENV var