### PR TITLE
Improve unit and integration test

### DIFF
--- a/bin/test-integration
+++ b/bin/test-integration
@@ -1,8 +1,9 @@
 #!/bin/sh
-set -e
+set -eu
 
 
-export TEST_NAMESPACE="test$(date +%s)"
+TEST_NAMESPACE="test$(date +%s)"
+export TEST_NAMESPACE
 
 remove_namespace() {
   kubectl delete namespace "$TEST_NAMESPACE"

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-ginkgo -p -r -skipPackage integration,e2e
+ginkgo -p -r --randomizeAllSpecs -failOnPending --trace -skipPackage integration,e2e

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // from https://github.com/kubernetes/client-go/issues/345
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -97,7 +98,7 @@ func (e *Environment) setupCFOperator() (err error) {
 }
 
 func (e *Environment) setupKube() (err error) {
-	location := os.Getenv("KUBE_CONFIG")
+	location := os.Getenv("KUBECONFIG")
 	if location == "" {
 		location = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}


### PR DESCRIPTION
This includes:
- Enforce bash `-u` setting, for unset variables into `test-integration`
- Ensure `set -e` can work correctly, by exporting `TEST_NAMESPACE`
  separately from the assignment, in the `test-integration`
- Run unit-tests in a random way, failing on pending tests and using trace
  to print full stack when failures occur.
- integration tests revealed an issue when authenticating to the cluster
  using OIDC, where client-go cannot import those packages.
  Error was:
  ```
  panic: No Auth Provider found for name "oidc"
  ```
  Workaround is to import oidc where the auth happens as follows:
    - _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"