### PR TITLE
Fix client-go checksum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -131,7 +131,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20181206111255-bb0a52a3f19d h1:Be0abb3DYtN
 k8s.io/apiextensions-apiserver v0.0.0-20181206111255-bb0a52a3f19d/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d h1:MZjlsu9igBoVPZkXpIGoxI6EonqNsXXZU7hhvfQLkd4=
 k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v0.0.0-20180806134042-1f13a808da65 h1:wQUEIVcXYxsDE8RXfUufo1nfnkeH/BEPhT175YIzea4=
+k8s.io/client-go v0.0.0-20180806134042-1f13a808da65 h1:kQX7jEIMYrWV9XqFN4usRaBLzCu7fd/qsCXxbgf3+9g=
 k8s.io/client-go v0.0.0-20180806134042-1f13a808da65/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kube-openapi v0.0.0-20181024003938-96e8bb74ecdd h1:FTdmog2YAOsPyZbI5UoWJvm/4A+0AJDrkQ6ZB7fs2iI=
 k8s.io/kube-openapi v0.0.0-20181024003938-96e8bb74ecdd/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=


### PR DESCRIPTION
After merged https://github.com/cloudfoundry-incubator/cf-operator/pull/34, I ran command under go1.11.2:
```
$ GO111MODULE=on go mod vendor
go: downloading k8s.io/apimachinery v0.0.0-20180621070125-103fd098999d
go: downloading github.com/pkg/errors v0.8.0
go: downloading github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c
go: downloading k8s.io/client-go v0.0.0-20180806134042-1f13a808da65
go: downloading github.com/spf13/viper v1.2.1
go: downloading github.com/spf13/cobra v0.0.3
go: downloading sigs.k8s.io/controller-runtime v0.1.4
go: downloading github.com/spf13/pflag v1.0.3
go: downloading github.com/spf13/afero v1.1.2
go: verifying k8s.io/client-go@v0.0.0-20180806134042-1f13a808da65: checksum mismatch
        downloaded: h1:kQX7jEIMYrWV9XqFN4usRaBLzCu7fd/qsCXxbgf3+9g=
        go.sum:     h1:wQUEIVcXYxsDE8RXfUufo1nfnkeH/BEPhT175YIzea4=
```

So I updated checksum for client-go deps. 

Did you guys have same problem?