### PR TITLE
Do not hardcode values in InMemoryGenerator

### DIFF
--- a/pkg/credsgen/in_memory_generator/certificate_test.go
+++ b/pkg/credsgen/in_memory_generator/certificate_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
-	"code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
+	inmemorygenerator "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("InMemoryGenerator", func() {
 	var (
-		generator credsgen.Generator = inmemorygenerator.InMemoryGenerator{}
+		generator credsgen.Generator = inmemorygenerator.NewInMemoryGenerator()
 	)
 
 	Describe("GenerateCertificate", func() {

--- a/pkg/credsgen/in_memory_generator/in_memory_generator.go
+++ b/pkg/credsgen/in_memory_generator/in_memory_generator.go
@@ -2,9 +2,13 @@ package inmemorygenerator
 
 // InMemoryGenerator represents a secret generator that generates everything
 // by itself, using no 3rd party tools
-type InMemoryGenerator struct{}
+type InMemoryGenerator struct {
+	Bits      int    // Key bits
+	Expiry    int    // Expiration (days)
+	Algorithm string // Algorithm type
+}
 
-// NewInMemoryGenerator creates an InMemoryGenerator
+// NewInMemoryGenerator creates a default InMemoryGenerator
 func NewInMemoryGenerator() *InMemoryGenerator {
-	return &InMemoryGenerator{}
+	return &InMemoryGenerator{Bits: 4096, Expiry: 365, Algorithm: "rsa"}
 }

--- a/pkg/credsgen/in_memory_generator/in_memory_generator_test.go
+++ b/pkg/credsgen/in_memory_generator/in_memory_generator_test.go
@@ -1,0 +1,36 @@
+package inmemorygenerator_test
+
+import (
+	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
+	inmemorygenerator "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InMemoryGenerator", func() {
+	var (
+		defaultGenerator credsgen.Generator = inmemorygenerator.NewInMemoryGenerator()
+	)
+
+	Describe("NewInMemoryGenerator", func() {
+		Context("object defaults", func() {
+			It("succeds if the default type is inmemorygenerator.InMemoryGenerator", func() {
+				t, ok := defaultGenerator.(*inmemorygenerator.InMemoryGenerator)
+				Expect(ok).To(BeTrue())
+				Expect(t).To(Equal(defaultGenerator))
+			})
+
+			It("succeds if the default generator is 4096 bits", func() {
+				Expect(defaultGenerator.(*inmemorygenerator.InMemoryGenerator).Bits).To(Equal(4096))
+			})
+
+			It("succeds if the default generator is rsa", func() {
+				Expect(defaultGenerator.(*inmemorygenerator.InMemoryGenerator).Algorithm).To(Equal("rsa"))
+			})
+
+			It("succeds if the default generator certs expires in 365 days", func() {
+				Expect(defaultGenerator.(*inmemorygenerator.InMemoryGenerator).Expiry).To(Equal(365))
+			})
+		})
+	})
+})

--- a/pkg/credsgen/in_memory_generator/rsa_key.go
+++ b/pkg/credsgen/in_memory_generator/rsa_key.go
@@ -16,7 +16,7 @@ func (g InMemoryGenerator) GenerateRSAKey(name string) (credsgen.RSAKey, error) 
 	log.Println("Generating RSA key ", name)
 
 	// generate private key
-	private, err := rsa.GenerateKey(rand.Reader, 4096)
+	private, err := rsa.GenerateKey(rand.Reader, g.Bits)
 	if err != nil {
 		return credsgen.RSAKey{}, errors.Wrap(err, "Generating private key")
 	}

--- a/pkg/credsgen/in_memory_generator/rsa_key_test.go
+++ b/pkg/credsgen/in_memory_generator/rsa_key_test.go
@@ -2,14 +2,14 @@ package inmemorygenerator_test
 
 import (
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
-	"code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
+	inmemorygenerator "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("InMemoryGenerator", func() {
 	var (
-		generator credsgen.Generator = inmemorygenerator.InMemoryGenerator{}
+		generator credsgen.Generator = inmemorygenerator.NewInMemoryGenerator()
 	)
 
 	Describe("GenerateRSAKey", func() {

--- a/pkg/credsgen/in_memory_generator/ssh_key.go
+++ b/pkg/credsgen/in_memory_generator/ssh_key.go
@@ -16,7 +16,7 @@ func (g InMemoryGenerator) GenerateSSHKey(name string) (credsgen.SSHKey, error) 
 	log.Println("Generating SSH key ", name)
 
 	// generate private key
-	private, err := rsa.GenerateKey(rand.Reader, 4096)
+	private, err := rsa.GenerateKey(rand.Reader, g.Bits)
 	if err != nil {
 		return credsgen.SSHKey{}, err
 	}

--- a/pkg/credsgen/in_memory_generator/ssh_key_test.go
+++ b/pkg/credsgen/in_memory_generator/ssh_key_test.go
@@ -2,14 +2,14 @@ package inmemorygenerator_test
 
 import (
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
-	"code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
+	inmemorygenerator "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("InMemoryGenerator", func() {
 	var (
-		generator credsgen.Generator = inmemorygenerator.InMemoryGenerator{}
+		generator credsgen.Generator = inmemorygenerator.NewInMemoryGenerator()
 	)
 
 	Describe("GenerateSSHKey", func() {


### PR DESCRIPTION
Allows to setup different values for the generator, and adapts tests to
use the default constructor for more consistency.

Imho it's easier to create custom objects that are overriding defaults on-need.