### PR TITLE
Add script to apply our custom resource definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ helm:
 
 export CFO_NAMESPACE ?= default
 up:
-	kubectl apply -f deploy/helm/cf-operator/templates/fissile_v1alpha1_boshdeployment_crd.yaml
-	kubectl apply -f deploy/helm/cf-operator/templates/fissile_v1alpha1_extendedstatefulset_crd.yaml
+	bin/apply-crds
 	@echo watching namespace ${CFO_NAMESPACE}
 	go run cmd/cf-operator/main.go
 

--- a/bin/apply-crds
+++ b/bin/apply-crds
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+kubectl apply -f deploy/helm/cf-operator/templates/fissile_v1alpha1_boshdeployment_crd.yaml
+kubectl apply -f deploy/helm/cf-operator/templates/fissile_v1alpha1_extendedstatefulset_crd.yaml

--- a/bin/test-e2e
+++ b/bin/test-e2e
@@ -10,8 +10,8 @@ remove_namespace() {
 }
 trap remove_namespace EXIT
 
-# we could create CRD from Go
-kubectl apply -f  deploy/helm/cf-operator/templates/
+bin/apply-crds
+
 kubectl get customresourcedefinitions
 kubectl create namespace "$TEST_NAMESPACE"
 

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -10,8 +10,8 @@ remove_namespace() {
 }
 trap remove_namespace EXIT
 
-# we could create CRD from Go
-kubectl apply -f  deploy/helm/cf-operator/templates/
+bin/apply-crds
+
 kubectl get customresourcedefinitions
 kubectl create namespace "$TEST_NAMESPACE"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -143,6 +143,7 @@ Our Concourse pipeline definitions are kept in the [https://github.com/cloudfoun
 - add the new group to `addToSchemes` in `pkg/controllers/controller.go`.
 - add the new controller to `addToManagerFuncs` in the same file.
 - create a custom resource definition in `deploy/helm/cf-operator/templates/`
+- add the custom resource definition to `bin/apply-crds`
 
 ### Testing
 


### PR DESCRIPTION
* remove repetition of CRDs in every script
* avoid pod errors by not applying the whole unrendered template directory
* mention new script in the docs, so we don't forget