### PR TITLE
Collection of fixes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,8 @@ They require access to a Kubernetes, preferably `minikube`.
 
 Integration tests start our operator directly, bypassing the command line.
 
-The `environment` package provides helpers to start the operator, get the kubeconfig as well as defining and creating test objects.
+The `environment` package provides helpers to start the operator, get the kubeconfig and use the clients to create objects.
+In `testing` the `catalog` defines test objects.
 
 Integration tests use a special logger, which does not log to stdout and whose messages can be accessed as a an array by calling `env.AllLogMessages()`.
 

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -10,8 +10,7 @@ var _ = Describe("Deploy", func() {
 		podName := "diego-pod"
 
 		AfterEach(func() {
-			err := env.WaitForPodsDelete(env.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+			env.WaitForPodsDelete(env.Namespace)
 		})
 
 		It("should deploy a pod", func() {

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -27,7 +27,7 @@ type StopFunc func()
 // cluster used in the tests
 type Environment struct {
 	Machine
-	Catalog
+	testing.Catalog
 	mgr        manager.Manager
 	kubeConfig *rest.Config
 	log        *zap.SugaredLogger

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -226,8 +226,8 @@ func (m *Machine) PodLabeled(namespace string, name string, desiredLabel, desire
 }
 
 // ContainExpectedEvent return true if events contain target resource event
-func (m *Machine) ContainExpectedEvent(events *[]corev1.Event, reason string, message string) bool {
-	for _, event := range *events {
+func (m *Machine) ContainExpectedEvent(events []corev1.Event, reason string, message string) bool {
+	for _, event := range events {
 		if event.Reason == reason && strings.Contains(event.Message, message) {
 			return true
 		}
@@ -237,20 +237,20 @@ func (m *Machine) ContainExpectedEvent(events *[]corev1.Event, reason string, me
 }
 
 // GetBOSHDeploymentEvents gets target resource events
-func (m *Machine) GetBOSHDeploymentEvents(namespace string, name string, id string) (*[]corev1.Event, error) {
+func (m *Machine) GetBOSHDeploymentEvents(namespace string, name string, id string) ([]corev1.Event, error) {
 	fieldSelector := fields.Set{"involvedObject.name": name, "involvedObject.uid": id}.AsSelector().String()
 	err := m.WaitForBOSHDeploymentEvent(namespace, fieldSelector)
 	if err != nil {
-		return &[]corev1.Event{}, err
+		return []corev1.Event{}, err
 	}
 
 	events := m.Clientset.CoreV1().Events(namespace)
 
 	list, err := events.List(metav1.ListOptions{FieldSelector: fieldSelector})
 	if err != nil {
-		return &[]corev1.Event{}, err
+		return []corev1.Event{}, err
 	}
-	return &list.Items, nil
+	return list.Items, nil
 }
 
 // WaitForBOSHDeploymentEvent gets desired event

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -1,9 +1,9 @@
-package environment
+package testing
 
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	bdcv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"


### PR DESCRIPTION
* Remove pointer to slice, is always a reference
* fix flaky test, by not expecting clean up to succeed (in time), we'll delete the namespace anyhow
* test objects will be reused by unit tests