### PR TITLE
Introduce ManifestPersister interface (tracker ID 161744952)

### DIFF
--- a/pkg/kube/secrets/manifest.go
+++ b/pkg/kube/secrets/manifest.go
@@ -1,0 +1,182 @@
+package secrets
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	"k8s.io/client-go/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const manifestKeyName = "manifest"
+
+type ManifestPersister interface {
+	CreateDesiredManifestSecret(manifest manifest.Manifest) (*corev1.Secret, error)
+	DeleteManifestSecrets() error
+	// deleting a desired manifest secret
+	// decorating the secret with key/value labels
+	ListAllVersions() ([]corev1.Secret, error)
+	RetrieveVersion(version int) (*corev1.Secret, error)
+	RetrieveLatestVersion() (*corev1.Secret, error)
+}
+
+type ManifestPersisterImpl struct {
+	client         kubernetes.Interface
+	namespace      string
+	deploymentName string
+}
+
+func NewManifestPersister(client kubernetes.Interface, namespace string, deploymentName string) *ManifestPersisterImpl {
+	return &ManifestPersisterImpl{
+		client,
+		namespace,
+		deploymentName,
+	}
+}
+
+func (p *ManifestPersisterImpl) CreateDesiredManifestSecret(manifest manifest.Manifest) (*corev1.Secret, error) {
+	// First check if a secret of the same type(deployment-deploymentName) exists
+	version, err := getGreatestVersion(p)
+	if err != nil {
+		return nil, err
+	}
+
+	secretName, err := secretName(p, version+1)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.CoreV1().Secrets(p.namespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: p.namespace,
+		},
+		Data: map[string][]byte{
+			manifestKeyName: data,
+		},
+	})
+}
+
+func (p *ManifestPersisterImpl) RetrieveVersion(version int) (*corev1.Secret, error) {
+	list, err := p.ListAllVersions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, secret := range list {
+		ver, err := getVersionFromSecretName(p, secret.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if ver == version {
+			return &secret, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find the requested version: %d", version)
+}
+
+func (p *ManifestPersisterImpl) RetrieveLatestVersion() (*corev1.Secret, error) {
+	latestVersion, err := getGreatestVersion(p)
+	if err != nil {
+		return nil, err
+	}
+	return p.RetrieveVersion(latestVersion)
+}
+
+func (p *ManifestPersisterImpl) ListAllVersions() ([]corev1.Secret, error) {
+	listResp, err := p.client.CoreV1().Secrets(p.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := []corev1.Secret{}
+
+	nameRegex := regexp.MustCompile(fmt.Sprintf(`^deployment-%s-\d+$`, p.deploymentName))
+	for _, secret := range listResp.Items {
+		if nameRegex.MatchString(secret.Name) {
+			result = append(result, secret)
+		}
+	}
+	return result, nil
+}
+
+func (p *ManifestPersisterImpl) DeleteManifestSecrets() error {
+	list, err := p.ListAllVersions()
+	if err != nil {
+		return err
+	}
+
+	for _, secret := range list {
+		err := p.client.CoreV1().Secrets(p.namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getGreatestVersion(p *ManifestPersisterImpl) (int, error) {
+	list, err := p.ListAllVersions()
+	if err != nil {
+		return -1, err
+	}
+
+	var greatestVersion int
+	for _, secret := range list {
+		version, err := getVersionFromSecretName(p, secret.Name)
+		if err != nil {
+			return 0, err
+		}
+
+		if version > greatestVersion {
+			greatestVersion = version
+		}
+	}
+
+	return greatestVersion, nil
+}
+
+func secretName(p *ManifestPersisterImpl, version int) (string, error) {
+	proposedName := fmt.Sprintf("deployment-%s-%d", p.deploymentName, version)
+
+	// Check for Kubernetes name requirements (length)
+	const maxChars = 253
+	if len(proposedName) > maxChars {
+		return "", fmt.Errorf("secret name exceeds maximum number of allowed characters (actual=%d, allowed=%d)", len(proposedName), maxChars)
+	}
+
+	// Check for Kubernetes name requirements (characters)
+	if re := regexp.MustCompile(`[^a-z0-9.-]`); re.MatchString(proposedName) {
+		return "", fmt.Errorf("secret name contains invalid characters, only lower case, dot and dash are allowed")
+	}
+
+	return proposedName, nil
+}
+
+func getVersionFromSecretName(p *ManifestPersisterImpl, name string) (int, error) {
+	nameRegex := regexp.MustCompile(fmt.Sprintf(`^deployment-%s-(\d+)$`, p.deploymentName))
+	if captures := nameRegex.FindStringSubmatch(name); len(captures) > 0 {
+		number, err := strconv.Atoi(captures[1])
+		if err != nil {
+			return -1, errors.Wrapf(err, "invalid secret name %s, it does not end with a version number", name)
+		}
+
+		return number, nil
+	}
+
+	return -1, fmt.Errorf("invalid secret name %s, it does not match the naming schema", name)
+}

--- a/pkg/kube/secrets/manifest_suite_test.go
+++ b/pkg/kube/secrets/manifest_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestManifestPersistence(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, `Versioning and persistence for "desired manifests" Suite`)
+	RunSpecs(t, `Versioning and persistence for desired manifests Suite`)
 }

--- a/pkg/kube/secrets/manifest_suite_test.go
+++ b/pkg/kube/secrets/manifest_suite_test.go
@@ -1,0 +1,13 @@
+package secrets_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFoobar(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, `Versioning and persistence for "desired manifests" Suite`)
+}

--- a/pkg/kube/secrets/manifest_suite_test.go
+++ b/pkg/kube/secrets/manifest_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestFoobar(t *testing.T) {
+func TestManifestPersistence(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, `Versioning and persistence for "desired manifests" Suite`)
 }

--- a/pkg/kube/secrets/manifest_test.go
+++ b/pkg/kube/secrets/manifest_test.go
@@ -1,0 +1,181 @@
+package secrets_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "code.cloudfoundry.org/cf-operator/pkg/kube/secrets"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	"gopkg.in/yaml.v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+// Note: Assumption is that with desired manifests, a fully rendered/evaluated BOSH deployment manifest is meant.
+
+var _ = Describe(`Versioning and persistence for "desired manifests"`, func() {
+
+	exampleManifest := func(data []byte) manifest.Manifest {
+		var manifest manifest.Manifest
+		err := yaml.Unmarshal(data, &manifest)
+		Expect(err).ToNot(HaveOccurred())
+
+		return manifest
+	}
+
+	var namespace = "default"
+	var deploymentName = "fake-deployment"
+
+	Context("Creating a desired manifest secret", func() {
+		var client kubernetes.Interface
+		var persister *ManifestPersisterImpl
+		var secretName string
+
+		BeforeEach(func() {
+			client = testclient.NewSimpleClientset()
+			persister = NewManifestPersister(client, namespace, deploymentName)
+		})
+
+		It("should create a secret when there is no versioned secret of the manifest", func() {
+			createdSecret, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`---
+instance-groups:
+- name: diego
+  instances: 3  
+- name: mysql
+  instances: 2
+`)))
+
+			secretName = fmt.Sprintf("deployment-%s-%d", deploymentName, 1)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdSecret.Name).To(BeEquivalentTo(secretName))
+
+			retrievedSecret, err := client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retrievedSecret).To(BeEquivalentTo(createdSecret))
+		})
+
+		It("should create a new versioned secret when already a version exists", func() {
+			createdSecret, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`---
+instance-groups:
+- name: diego
+  instances: 3
+`)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdSecret.Name).To(BeEquivalentTo(fmt.Sprintf("deployment-%s-%d", deploymentName, 1)))
+
+			createdSecret, err = persister.CreateDesiredManifestSecret(exampleManifest([]byte(`---
+instance-groups:
+- name: diego
+  instances: 3
+- name: mysql
+  instances: 2
+`)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdSecret.Name).To(BeEquivalentTo(fmt.Sprintf("deployment-%s-%d", deploymentName, 2)))
+
+			createdSecret, err = persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdSecret.Name).To(BeEquivalentTo(fmt.Sprintf("deployment-%s-%d", deploymentName, 3)))
+		})
+
+		It("should fail to create a secret, when the deployment name contains invalid characters", func() {
+			persister = NewManifestPersister(client, namespace, "InvalidName")
+			createdSecret, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).To(HaveOccurred())
+			Expect(createdSecret).To(BeNil())
+		})
+
+		It("should fail to create a secret, when the deployment name exceeds 253 chars length", func() {
+			persister = NewManifestPersister(client, namespace, strings.Repeat("foobar", 42))
+			createdSecret, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).To(HaveOccurred())
+			Expect(createdSecret).To(BeNil())
+		})
+	})
+
+	Context("Listing secrets", func() {
+		var client kubernetes.Interface
+		var persister *ManifestPersisterImpl
+
+		BeforeEach(func() {
+			client = testclient.NewSimpleClientset()
+			persister = NewManifestPersister(client, namespace, deploymentName)
+		})
+
+		It("should give you all secrets of a deployment", func() {
+			for i := 1; i < 10; i++ {
+				_, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = NewManifestPersister(client, namespace, "another-deployment").
+					CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+				Expect(err).ToNot(HaveOccurred())
+			}
+			currentManifestSecrets, err := persister.ListAllVersions()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(currentManifestSecrets)).To(BeIdenticalTo(9))
+		})
+	})
+
+	Context("Retrieving secret versions", func() {
+		var client kubernetes.Interface
+		var persister *ManifestPersisterImpl
+
+		BeforeEach(func() {
+			client = testclient.NewSimpleClientset()
+
+			persister = NewManifestPersister(client, namespace, "cf")
+			_, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).ToNot(HaveOccurred())
+			_, err = persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should give you an specific secret version", func() {
+			versionedSecret, err := persister.RetrieveVersion(1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versionedSecret.Name).To(BeIdenticalTo(fmt.Sprintf("deployment-%s-%d", "cf", 1)))
+		})
+
+		It("should give you the latest secret version", func() {
+			versionedSecret, err := persister.RetrieveLatestVersion()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(versionedSecret.Name).To(BeIdenticalTo(fmt.Sprintf("deployment-%s-%d", "cf", 2)))
+		})
+	})
+
+	Context("Delete all versions of a secret", func() {
+		var client kubernetes.Interface
+		var persister *ManifestPersisterImpl
+
+		BeforeEach(func() {
+			client = testclient.NewSimpleClientset()
+
+			persister = NewManifestPersister(client, namespace, "cf")
+			_, err := persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).ToNot(HaveOccurred())
+			_, err = persister.CreateDesiredManifestSecret(exampleManifest([]byte(`instance-groups: []`)))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should get rid of all versions of a secret", func() {
+			currentManifestSecrets, err := persister.ListAllVersions()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(currentManifestSecrets)).To(BeIdenticalTo(2))
+
+			err = persister.DeleteManifestSecrets()
+			Expect(err).ToNot(HaveOccurred())
+
+			currentManifestSecrets, err = persister.ListAllVersions()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(currentManifestSecrets)).To(BeIdenticalTo(0))
+		})
+	})
+})

--- a/pkg/kube/secrets/manifest_test.go
+++ b/pkg/kube/secrets/manifest_test.go
@@ -143,22 +143,16 @@ var _ = Describe("DecorateManifest", func() {
 		})
 
 		It("should decorate the lastest version with the provided key and value", func() {
-			secret, err := persister.RetrieveLatestVersion()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(secret.Name).To(BeIdenticalTo(fmt.Sprintf("deployment-%s-%d", deploymentName, 2)))
-			Expect(secret.GetLabels()).To(BeEquivalentTo(map[string]string{
-				"deployment-name":    deploymentName,
-				"version":            "2",
-				"source-description": exampleSourceDescription,
-			}))
-
 			updatedSecret, err := persister.DecorateManifest("foo", "bar")
 			Expect(err).ToNot(HaveOccurred())
+
 			Expect(updatedSecret.GetLabels()).To(BeEquivalentTo(map[string]string{
-				"deployment-name":    deploymentName,
-				"version":            "2",
+				"deployment-name": deploymentName,
+				"version":         "2",
+				"foo":             "bar",
+			}))
+			Expect(updatedSecret.GetAnnotations()).To(BeEquivalentTo(map[string]string{
 				"source-description": exampleSourceDescription,
-				"foo":                "bar",
 			}))
 		})
 	})


### PR DESCRIPTION
Introduce `ManifestPersister` interface to enable exploiters to perform the following actions:
- creating a desired manifest secret
- deleting a desired manifest secret
- creating a new version of a desired manifest
- decorating the secret with key/value labels
- listing all versions
- retrieving a version of a desired manifest
- retrieving the latest version of a desired manifest

https://www.pivotaltracker.com/story/show/161744952

In order to keep the interface consistent and compact, the function names only refer to what is actually persisted: the manifest. The implementation detail that is is stored as a `secret` is visible as the return type as well as in the godoc texts.