### PR TITLE
extendedjob errands

### DIFF
--- a/docs/examples/exjob_errand.yaml
+++ b/docs/examples/exjob_errand.yaml
@@ -1,0 +1,16 @@
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: ExtendedJob
+metadata:
+  name: manual-sleep
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - sleep
+        - "15"
+        image: busybox
+        name: busybox
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 1
+  run: manually

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -565,3 +565,10 @@ func (m *Machine) CreateExtendedJob(namespace string, job ejv1.ExtendedJob) (*ej
 		client.Delete(job.GetName(), &metav1.DeleteOptions{})
 	}, err
 }
+
+// UpdateExtendedJob updates an extended job
+func (m *Machine) UpdateExtendedJob(namespace string, exJob ejv1.ExtendedJob) error {
+	client := m.VersionedClientset.Extendedjob().ExtendedJobs(namespace)
+	_, err := client.Update(&exJob)
+	return err
+}

--- a/pkg/kube/apis/extendedjob/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedjob/v1alpha1/types.go
@@ -13,11 +13,23 @@ import (
 // ExtendedJobSpec defines the desired state of ExtendedJob
 type ExtendedJobSpec struct {
 	Output               Output                 `json:"output,omitempty"`
-	Run                  string                 `json:"run,omitempty"`
+	Run                  Run                    `json:"run,omitempty"`
 	Triggers             Triggers               `json:"triggers,omitempty"`
 	Template             corev1.PodTemplateSpec `json:"template"`
 	UpdateOnConfigChange bool                   `json:"updateOnConfigChange,omitempty"`
 }
+
+// Run is used if the job is not triggered
+type Run string
+
+const (
+	// RunManually is the default for errand jobs
+	RunManually Run = "manually"
+	// RunNow instructs the controller to run the job now
+	RunNow Run = "now"
+	// RunOnce jobs run only once, when created
+	RunOnce Run = "once"
+)
 
 // Output contains options to persist job output
 type Output struct {

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -18,6 +18,7 @@ import (
 var addToManagerFuncs = []func(*zap.SugaredLogger, manager.Manager) error{
 	boshdeployment.Add,
 	extendedjob.Add,
+	extendedjob.AddErrand,
 	extendedsecret.Add,
 	extendedstatefulset.Add,
 }

--- a/pkg/kube/controllers/extendedjob/errand_controller.go
+++ b/pkg/kube/controllers/extendedjob/errand_controller.go
@@ -1,0 +1,44 @@
+package extendedjob
+
+import (
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// AddErrand creates a new ExtendedJob controller and adds it to the Manager
+func AddErrand(log *zap.SugaredLogger, mgr manager.Manager) error {
+	f := controllerutil.SetControllerReference
+	r := NewErrandReconciler(log, mgr, f)
+	c, err := controller.New("extendedjob-errand-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+	// Only trigger if Spec.Run is 'now'
+	p := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			exJob := e.Object.(*ejv1.ExtendedJob)
+			return exJob.Spec.Run == ejv1.RunNow
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldExJob := e.ObjectOld.(*ejv1.ExtendedJob)
+			newExJob := e.ObjectNew.(*ejv1.ExtendedJob)
+			run := newExJob.Spec.Run == ejv1.RunNow && oldExJob.Spec.Run == ejv1.RunManually
+			return run
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &ejv1.ExtendedJob{}}, &handler.EnqueueRequestForObject{}, p)
+	return err
+}

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -1,0 +1,113 @@
+package extendedjob
+
+import (
+	"context"
+	"fmt"
+
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
+	"go.uber.org/zap"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ reconcile.Reconciler = &ErrandReconciler{}
+
+// NewErrandReconciler returns a new reconciler for errand jobs
+func NewErrandReconciler(
+	log *zap.SugaredLogger,
+	mgr manager.Manager,
+	f setOwnerReferenceFunc,
+) reconcile.Reconciler {
+	return &ErrandReconciler{
+		client:            mgr.GetClient(),
+		log:               log,
+		recorder:          mgr.GetRecorder("extendedjob errand reconciler"),
+		scheme:            mgr.GetScheme(),
+		setOwnerReference: f,
+	}
+}
+
+// ErrandReconciler implements the Reconciler interface
+type ErrandReconciler struct {
+	client            client.Client
+	log               *zap.SugaredLogger
+	recorder          record.EventRecorder
+	scheme            *runtime.Scheme
+	setOwnerReference setOwnerReferenceFunc
+}
+
+// Reconcile starts jobs for extended jobs of the type errand with Run being set to 'now' manually
+func (r *ErrandReconciler) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
+	extJob := &ejv1.ExtendedJob{}
+	err = r.client.Get(context.TODO(), request.NamespacedName, extJob)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// do not requeue, extended job is probably deleted
+			r.log.Infof("Failed to find extended job '%s', not retrying: %s", request.NamespacedName, err)
+			err = nil
+			return
+		}
+		// Error reading the object - requeue the request.
+		r.log.Errorf("Failed to get the extended job '%s': %s", request.NamespacedName, err)
+		return
+	}
+
+	// set Run back to manually
+	extJob.Spec.Run = ejv1.RunManually
+	err = r.client.Update(context.TODO(), extJob)
+	if err != nil {
+		r.log.Errorf("Failed to revert to 'Run=manually' on job '%s': %s", extJob.Name, err)
+		return
+	}
+
+	err = r.createJob(*extJob)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			r.log.Infof("Skip '%s' triggered manually: already running", extJob.Name)
+			// we don't want to requeue the job
+			err = nil
+		} else {
+			r.log.Errorf("Failed to create job '%s': %s", extJob.Name, err)
+		}
+		return
+	}
+	r.log.Infof("Created errand job for '%s'", extJob.Name)
+
+	return
+}
+
+func (r *ErrandReconciler) createJob(extJob ejv1.ExtendedJob) error {
+	name := fmt.Sprintf("job-%s-%s", truncate(extJob.Name, 30), randSuffix(extJob.Name))
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: extJob.Namespace,
+			Labels:    map[string]string{"extendedjob": "true"},
+		},
+		Spec: batchv1.JobSpec{Template: extJob.Spec.Template},
+	}
+
+	err := r.client.Create(context.TODO(), job)
+	if err != nil {
+		return err
+	}
+
+	err = r.setOwnerReference(&extJob, job, r.scheme)
+	if err != nil {
+		r.log.Errorf("Failed to set owner reference on job for '%s': %s", extJob.Name, err)
+	}
+
+	err = r.client.Update(context.TODO(), job)
+	if err != nil {
+		r.log.Errorf("Failed to update job '%s' with owner reference for '%s': %s", name, extJob.Name, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
@@ -1,0 +1,207 @@
+package extendedjob_test
+
+import (
+	"context"
+	"fmt"
+
+	. "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedjob"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
+	"code.cloudfoundry.org/cf-operator/testing"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	crc "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("ErrandReconciler", func() {
+	Describe("Run", func() {
+		var (
+			env        testing.Catalog
+			logs       *observer.ObservedLogs
+			log        *zap.SugaredLogger
+			mgr        *fakes.FakeManager
+			request    reconcile.Request
+			reconciler reconcile.Reconciler
+
+			runtimeObjects             []runtime.Object
+			exJob                      ejv1.ExtendedJob
+			setOwnerReferenceCallCount int
+		)
+
+		newRequest := func(exJob ejv1.ExtendedJob) reconcile.Request {
+			return reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      exJob.Name,
+					Namespace: exJob.Namespace,
+				},
+			}
+		}
+
+		exjobGetStub := func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
+			exJob.DeepCopyInto(obj.(*ejv1.ExtendedJob))
+			return nil
+		}
+
+		setOwnerReference := func(owner, object metav1.Object, scheme *runtime.Scheme) error {
+			setOwnerReferenceCallCount++
+			return nil
+		}
+
+		JustBeforeEach(func() {
+			reconciler = NewErrandReconciler(
+				log,
+				mgr,
+				setOwnerReference,
+			)
+		})
+
+		act := func() (reconcile.Result, error) {
+			return reconciler.Reconcile(request)
+		}
+
+		BeforeEach(func() {
+			controllers.AddToScheme(scheme.Scheme)
+			logs, log = testing.NewTestLogger()
+			mgr = &fakes.FakeManager{}
+			setOwnerReferenceCallCount = 0
+		})
+
+		Context("when client fails", func() {
+			var client fakes.FakeClient
+
+			BeforeEach(func() {
+				client = fakes.FakeClient{}
+				mgr.GetClientReturns(&client)
+
+				exJob = env.ErrandExtendedJob("fake-exjob")
+				client.GetCalls(exjobGetStub)
+				request = newRequest(exJob)
+			})
+
+			Context("and the extended job does not exist", func() {
+				BeforeEach(func() {
+					client.GetReturns(apierrors.NewNotFound(schema.GroupResource{}, "fake-error"))
+				})
+
+				It("should log and return, don't requeue", func() {
+					result, err := act()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+					Expect(logs.FilterMessageSnippet("Failed to find extended job '/fake-exjob', not retrying:  \"fake-error\" not found").Len()).To(Equal(1))
+				})
+			})
+
+			Context("to get the extended job", func() {
+				BeforeEach(func() {
+					client.GetReturns(fmt.Errorf("fake-error"))
+				})
+
+				It("should log and return, requeue", func() {
+					_, err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(logs.FilterMessageSnippet("Failed to get the extended job '/fake-exjob': fake-error").Len()).To(Equal(1))
+				})
+			})
+
+			Context("when client fails to update extended job", func() {
+				BeforeEach(func() {
+					client.UpdateReturns(fmt.Errorf("fake-error"))
+				})
+
+				It("should return and try to requeue", func() {
+					_, err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(logs.FilterMessageSnippet("Failed to revert to 'Run=manually' on job 'fake-exjob': fake-error").Len()).To(Equal(1))
+					Expect(client.CreateCallCount()).To(Equal(0))
+					Expect(setOwnerReferenceCallCount).To(Equal(0))
+				})
+			})
+
+			Context("when client fails to create jobs", func() {
+				BeforeEach(func() {
+					client.CreateReturns(fmt.Errorf("fake-error"))
+				})
+
+				It("should log create error and requeue", func() {
+					_, err := act()
+					Expect(logs.FilterMessageSnippet("Failed to create job 'fake-exjob': fake-error").Len()).To(Equal(1))
+					Expect(err).To(HaveOccurred())
+					Expect(client.CreateCallCount()).To(Equal(1))
+					Expect(setOwnerReferenceCallCount).To(Equal(0))
+				})
+			})
+
+			Context("when client fails to create jobs because it already exists", func() {
+				BeforeEach(func() {
+					client.CreateReturns(apierrors.NewAlreadyExists(schema.GroupResource{}, "fake-error"))
+				})
+
+				It("should log skip message and not requeue", func() {
+					result, err := act()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Requeue).To(BeFalse())
+
+					Expect(logs.FilterMessageSnippet("Skip 'fake-exjob' triggered manually: already running").Len()).To(Equal(1))
+					Expect(client.CreateCallCount()).To(Equal(1))
+					Expect(setOwnerReferenceCallCount).To(Equal(0))
+				})
+			})
+
+		})
+
+		Context("when extended job is reconciled", func() {
+			var (
+				client crc.Client
+			)
+
+			BeforeEach(func() {
+				exJob = env.ErrandExtendedJob("fake-pod")
+				runtimeObjects = []runtime.Object{
+					&exJob,
+				}
+				client = fake.NewFakeClient(runtimeObjects...)
+				mgr.GetClientReturns(client)
+
+				request = newRequest(exJob)
+			})
+
+			It("should set run back and create a job", func() {
+				Expect(exJob.Spec.Run).To(Equal(ejv1.RunNow))
+
+				result, err := act()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+
+				obj := &batchv1.JobList{}
+				err = client.List(context.TODO(), &crc.ListOptions{}, obj)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(obj.Items).To(HaveLen(1))
+
+				client.Get(
+					context.TODO(),
+					types.NamespacedName{
+						Name:      exJob.Name,
+						Namespace: exJob.Namespace,
+					},
+					&exJob,
+				)
+				Expect(exJob.Spec.Run).To(Equal(ejv1.RunManually))
+
+			})
+		})
+	})
+})

--- a/pkg/kube/controllers/extendedjob/trigger_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/trigger_reconciler.go
@@ -150,12 +150,16 @@ func (r *TriggerReconciler) createJob(extJob ejv1.ExtendedJob, podName string) e
 // k8s allows 63 chars, but the pod will have -\d{6} appended
 // IDEA: maybe use pod.Uid instead of rand
 func jobName(extJobName, podName string) string {
+	hashID := randSuffix(fmt.Sprintf("%s-%s", extJobName, podName))
+	return fmt.Sprintf("job-%s-%s-%s", truncate(extJobName, 15), truncate(podName, 15), hashID)
+}
+
+func randSuffix(str string) string {
 	randBytes := make([]byte, 16)
 	rand.Read(randBytes)
 	a := fnv.New64()
-	a.Write([]byte(fmt.Sprintf("%s-%s-%s", extJobName, podName, string(randBytes))))
-	hashID := hex.EncodeToString(a.Sum(nil))
-	return fmt.Sprintf("job-%s-%s-%s", truncate(extJobName, 15), truncate(podName, 15), hashID)
+	a.Write([]byte(str + string(randBytes)))
+	return hex.EncodeToString(a.Sum(nil))
 }
 
 func truncate(name string, max int) string {

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -490,3 +490,15 @@ func (c *Catalog) LabelTriggeredExtendedJob(name string, state ejv1.PodState, ml
 		},
 	}
 }
+
+// ErrandExtendedJob default values
+func (c *Catalog) ErrandExtendedJob(name string) ejv1.ExtendedJob {
+	cmd := []string{"sleep", "1"}
+	return ejv1.ExtendedJob{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: ejv1.ExtendedJobSpec{
+			Run:      ejv1.RunNow,
+			Template: c.CmdPodTemplate(cmd),
+		},
+	}
+}


### PR DESCRIPTION
Add support for manually triggered jobs (https://github.com/cloudfoundry-incubator/cf-operator/blob/master/docs/controllers/extendedjob.md#errand-jobs)

This depends on the pod state PR #74 