### PR TITLE
Implement auto-errand jobs

### DIFF
--- a/integration/extended_job_test.go
+++ b/integration/extended_job_test.go
@@ -25,6 +25,23 @@ var _ = Describe("ExtendedJob", func() {
 		}
 	}
 
+	Context("when using an auto-errand job", func() {
+		AfterEach(func() {
+			env.WaitForPodsDelete(env.Namespace)
+		})
+
+		It("immediately starts the job", func() {
+			ej := env.AutoErrandExtendedJob("extendedjob")
+			_, tearDown, err := env.CreateExtendedJob(env.Namespace, ej)
+			Expect(err).NotTo(HaveOccurred())
+			defer tearDown()
+
+			jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+			Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
+			Expect(jobs).To(HaveLen(1))
+		})
+	})
+
 	Context("when using manually triggered errand job", func() {
 		AfterEach(func() {
 			env.WaitForPodsDelete(env.Namespace)

--- a/pkg/kube/controllers/extendedjob/errand_controller.go
+++ b/pkg/kube/controllers/extendedjob/errand_controller.go
@@ -24,7 +24,7 @@ func AddErrand(log *zap.SugaredLogger, mgr manager.Manager) error {
 	p := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			exJob := e.Object.(*ejv1.ExtendedJob)
-			return exJob.Spec.Run == ejv1.RunNow
+			return exJob.Spec.Run == ejv1.RunNow || exJob.Spec.Run == ejv1.RunOnce
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -58,12 +58,14 @@ func (r *ErrandReconciler) Reconcile(request reconcile.Request) (result reconcil
 		return
 	}
 
-	// set Run back to manually
-	extJob.Spec.Run = ejv1.RunManually
-	err = r.client.Update(context.TODO(), extJob)
-	if err != nil {
-		r.log.Errorf("Failed to revert to 'Run=manually' on job '%s': %s", extJob.Name, err)
-		return
+	if extJob.Spec.Run == ejv1.RunNow {
+		// set Run back to manually for errand jobs
+		extJob.Spec.Run = ejv1.RunManually
+		err = r.client.Update(context.TODO(), extJob)
+		if err != nil {
+			r.log.Errorf("Failed to revert to 'Run=manually' on job '%s': %s", extJob.Name, err)
+			return
+		}
 	}
 
 	err = r.createJob(*extJob)

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -592,3 +592,15 @@ func (c *Catalog) ErrandExtendedJob(name string) ejv1.ExtendedJob {
 		},
 	}
 }
+
+// ErrandExtendedJob default values
+func (c *Catalog) AutoErrandExtendedJob(name string) ejv1.ExtendedJob {
+	cmd := []string{"sleep", "1"}
+	return ejv1.ExtendedJob{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: ejv1.ExtendedJobSpec{
+			Run:      ejv1.RunOnce,
+			Template: c.CmdPodTemplate(cmd),
+		},
+	}
+}


### PR DESCRIPTION
Auto-errands are ExtendedJobs which are triggered as soon as they are
created by specifying `run: once` in the spec.