### PR TITLE
Reconciler context

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
+
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
 
@@ -37,7 +40,11 @@ var rootCmd = &cobra.Command{
 
 		log.Infof("Starting cf-operator with namespace %s", namespace)
 
-		mgr, err := operator.NewManager(log, kubeConfig, manager.Options{Namespace: namespace})
+		ctrsConfig := &controllersconfig.ControllersConfig{ //Set the context to be TODO
+			CtxTimeOut: 10 * time.Second,
+			CtxType:    controllersconfig.NewBackgroundContext(),
+		}
+		mgr, err := operator.NewManager(log, ctrsConfig, kubeConfig, manager.Options{Namespace: namespace})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
 	"code.cloudfoundry.org/cf-operator/testing"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
@@ -33,6 +34,7 @@ type Environment struct {
 	stop       chan struct{}
 
 	Log          *zap.SugaredLogger
+	CtrsConfig   *controllersconfig.ControllersConfig
 	ObservedLogs *observer.ObservedLogs
 	Namespace    string
 }
@@ -41,6 +43,10 @@ type Environment struct {
 func NewEnvironment() *Environment {
 	return &Environment{
 		Namespace: "",
+		CtrsConfig: &controllersconfig.ControllersConfig{ //Set the context to be TODO
+			CtxTimeOut: 10 * time.Second,
+			CtxType:    controllersconfig.NewBackgroundContext(),
+		},
 		Machine: Machine{
 			pollTimeout:  30 * time.Second,
 			pollInterval: 500 * time.Millisecond,
@@ -96,7 +102,7 @@ func (e *Environment) setupCFOperator() (err error) {
 		return
 	}
 
-	e.mgr, err = operator.NewManager(e.Log, e.kubeConfig, manager.Options{Namespace: e.Namespace})
+	e.mgr, err = operator.NewManager(e.Log, e.CtrsConfig, e.kubeConfig, manager.Options{Namespace: e.Namespace})
 	return
 }
 

--- a/pkg/kube/clientcontext/clientcontext.go
+++ b/pkg/kube/clientcontext/clientcontext.go
@@ -1,0 +1,34 @@
+package clientcontext
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	timeOutInMiliseconds int = 500
+)
+
+//NewContext returns a non-nil empty context, for usage
+//when it is unclear which context to use.
+func NewContext() context.Context {
+	return context.TODO()
+}
+
+//NewBackgroundContext returns a top level context that
+//has no values and deadline
+func NewBackgroundContext() context.Context {
+	return context.Background()
+}
+
+//WithValue returns a copy of parent where the value associated
+//with the key is val
+func WithValue(parent context.Context, key interface{}, val interface{}) context.Context {
+	return context.WithValue(parent, key, val)
+}
+
+//NewBackgroundContextWithTimeout returns a context that if
+//cancelled it will release resources associated with it.
+func NewBackgroundContextWithTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(NewBackgroundContext(), time.Duration(timeOutInMiliseconds)*time.Millisecond)
+}

--- a/pkg/kube/controllers/boshdeployment/controller.go
+++ b/pkg/kube/controllers/boshdeployment/controller.go
@@ -11,12 +11,13 @@ import (
 
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdc "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 )
 
 // Add creates a new BOSHDeployment Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
-	r := NewReconciler(log, mgr, bdm.NewResolver(mgr.GetClient(), bdm.NewInterpolator()), controllerutil.SetControllerReference)
+func Add(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager) error {
+	r := NewReconciler(log, ctrConfig, mgr, bdm.NewResolver(mgr.GetClient(), bdm.NewInterpolator()), controllerutil.SetControllerReference)
 
 	// Create a new controller
 	c, err := controller.New("boshdeployment-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/kube/controllers/boshdeployment/reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/reconciler.go
@@ -17,7 +17,7 @@ import (
 
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdc "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/clientcontext"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 )
 
 // Check that ReconcileBOSHDeployment implements the reconcile.Reconciler interface
@@ -26,9 +26,10 @@ var _ reconcile.Reconciler = &ReconcileBOSHDeployment{}
 type setReferenceFunc func(owner, object metav1.Object, scheme *runtime.Scheme) error
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(log *zap.SugaredLogger, mgr manager.Manager, resolver bdm.Resolver, srf setReferenceFunc) reconcile.Reconciler {
+func NewReconciler(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager, resolver bdm.Resolver, srf setReferenceFunc) reconcile.Reconciler {
 	return &ReconcileBOSHDeployment{
 		log:          log,
+		ctrConfig:    ctrConfig,
 		client:       mgr.GetClient(),
 		scheme:       mgr.GetScheme(),
 		recorder:     mgr.GetRecorder("RECONCILER RECORDER"),
@@ -47,6 +48,7 @@ type ReconcileBOSHDeployment struct {
 	resolver     bdm.Resolver
 	setReference setReferenceFunc
 	log          *zap.SugaredLogger
+	ctrConfig    *controllersconfig.ControllersConfig
 }
 
 // Reconcile reads that state of the cluster for a BOSHDeployment object and makes changes based on the state read
@@ -60,7 +62,8 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 	// Fetch the BOSHDeployment instance
 	instance := &bdc.BOSHDeployment{}
 
-	ctx, cancel := clientcontext.NewBackgroundContextWithTimeout()
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := controllersconfig.NewBackgroundContextWithTimeout(r.ctrConfig.CtxType, r.ctrConfig.CtxTimeOut)
 	defer cancel()
 
 	err := r.client.Get(ctx, request.NamespacedName, instance)

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -9,13 +9,14 @@ import (
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
 	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
 	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/boshdeployment"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedjob"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedsecret"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedstatefulset"
 )
 
-var addToManagerFuncs = []func(*zap.SugaredLogger, manager.Manager) error{
+var addToManagerFuncs = []func(*zap.SugaredLogger, *controllersconfig.ControllersConfig, manager.Manager) error{
 	boshdeployment.Add,
 	extendedjob.Add,
 	extendedjob.AddErrand,
@@ -31,9 +32,9 @@ var addToSchemes = runtime.SchemeBuilder{
 }
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(log *zap.SugaredLogger, m manager.Manager) error {
+func AddToManager(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, m manager.Manager) error {
 	for _, f := range addToManagerFuncs {
-		if err := f(log, m); err != nil {
+		if err := f(log, ctrConfig, m); err != nil {
 			return err
 		}
 	}

--- a/pkg/kube/controllers/extendedjob/controller.go
+++ b/pkg/kube/controllers/extendedjob/controller.go
@@ -1,6 +1,7 @@
 package extendedjob
 
 import (
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -18,10 +19,10 @@ import (
 )
 
 // Add creates a new ExtendedJob controller and adds it to the Manager
-func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
+func Add(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager) error {
 	query := NewQuery(mgr.GetClient())
 	f := controllerutil.SetControllerReference
-	r := NewTriggerReconciler(log, mgr, query, f)
+	r := NewTriggerReconciler(log, ctrConfig, mgr, query, f)
 	c, err := controller.New("extendedjob-trigger-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
@@ -65,7 +66,7 @@ func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
 		return errors.Wrap(err, "Could not get kube client")
 	}
 	podLogGetter := NewPodLogGetter(client)
-	jobReconciler, err := NewJobReconciler(log, mgr, podLogGetter)
+	jobReconciler, err := NewJobReconciler(log, ctrConfig, mgr, podLogGetter)
 	jobController, err := controller.New("extendedjob-job-controller", mgr, controller.Options{Reconciler: jobReconciler})
 	if err != nil {
 		return err

--- a/pkg/kube/controllers/extendedjob/errand_controller.go
+++ b/pkg/kube/controllers/extendedjob/errand_controller.go
@@ -2,6 +2,7 @@ package extendedjob
 
 import (
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -13,9 +14,9 @@ import (
 )
 
 // AddErrand creates a new ExtendedJob controller and adds it to the Manager
-func AddErrand(log *zap.SugaredLogger, mgr manager.Manager) error {
+func AddErrand(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager) error {
 	f := controllerutil.SetControllerReference
-	r := NewErrandReconciler(log, mgr, f)
+	r := NewErrandReconciler(log, ctrConfig, mgr, f)
 	c, err := controller.New("extendedjob-errand-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err

--- a/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
@@ -3,8 +3,10 @@ package extendedjob_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedjob"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -33,6 +35,7 @@ var _ = Describe("ErrandReconciler", func() {
 			env        testing.Catalog
 			logs       *observer.ObservedLogs
 			log        *zap.SugaredLogger
+			ctrsConfig *controllersconfig.ControllersConfig
 			mgr        *fakes.FakeManager
 			request    reconcile.Request
 			reconciler reconcile.Reconciler
@@ -64,6 +67,7 @@ var _ = Describe("ErrandReconciler", func() {
 		JustBeforeEach(func() {
 			reconciler = NewErrandReconciler(
 				log,
+				ctrsConfig,
 				mgr,
 				setOwnerReference,
 			)
@@ -77,6 +81,10 @@ var _ = Describe("ErrandReconciler", func() {
 			controllers.AddToScheme(scheme.Scheme)
 			logs, log = testing.NewTestLogger()
 			mgr = &fakes.FakeManager{}
+			ctrsConfig = &controllersconfig.ControllersConfig{ //Set the context to be TODO
+				CtxTimeOut: 10 * time.Second,
+				CtxType:    controllersconfig.NewContext(),
+			}
 			setOwnerReferenceCallCount = 0
 		})
 

--- a/pkg/kube/controllers/extendedjob/job_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/job_reconciler_test.go
@@ -2,10 +2,12 @@ package extendedjob_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -32,6 +34,7 @@ var _ = Describe("ReconcileExtendedJob", func() {
 		reconciler   reconcile.Reconciler
 		request      reconcile.Request
 		log          *zap.SugaredLogger
+		ctrsConfig   *controllersconfig.ControllersConfig
 		client       *cfakes.FakeClient
 		podLogGetter *cfakes.FakePodLogGetter
 		ejob         *ejapi.ExtendedJob
@@ -46,6 +49,10 @@ var _ = Describe("ReconcileExtendedJob", func() {
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 		core, _ := observer.New(zapcore.InfoLevel)
 		log = zap.New(core).Sugar()
+		ctrsConfig = &controllersconfig.ControllersConfig{ //Set the context to be TODO
+			CtxTimeOut: 10 * time.Second,
+			CtxType:    controllersconfig.NewContext(),
+		}
 
 		client = &cfakes.FakeClient{}
 		client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
@@ -72,7 +79,7 @@ var _ = Describe("ReconcileExtendedJob", func() {
 	})
 
 	JustBeforeEach(func() {
-		reconciler, _ = ej.NewJobReconciler(log, manager, podLogGetter)
+		reconciler, _ = ej.NewJobReconciler(log, ctrsConfig, manager, podLogGetter)
 		ejob, job, pod = env.DefaultExtendedJobWithSucceededJob("foo")
 	})
 

--- a/pkg/kube/controllers/extendedjob/trigger_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/trigger_reconciler_test.go
@@ -3,7 +3,9 @@ package extendedjob_test
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	. "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedjob"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,6 +33,7 @@ var _ = Describe("TriggerReconciler", func() {
 		var (
 			env        testing.Catalog
 			logs       *observer.ObservedLogs
+			ctrsConfig *controllersconfig.ControllersConfig
 			log        *zap.SugaredLogger
 			mgr        *fakes.FakeManager
 			query      *fakes.FakeQuery
@@ -72,6 +75,7 @@ var _ = Describe("TriggerReconciler", func() {
 		JustBeforeEach(func() {
 			reconciler = NewTriggerReconciler(
 				log,
+				ctrsConfig,
 				mgr,
 				query,
 				setOwnerReference,
@@ -85,6 +89,10 @@ var _ = Describe("TriggerReconciler", func() {
 		BeforeEach(func() {
 			controllers.AddToScheme(scheme.Scheme)
 			logs, log = testing.NewTestLogger()
+			ctrsConfig = &controllersconfig.ControllersConfig{ //Set the context to be TODO
+				CtxTimeOut: 10 * time.Second,
+				CtxType:    controllersconfig.NewContext(),
+			}
 			mgr = &fakes.FakeManager{}
 			query = &fakes.FakeQuery{}
 			setOwnerReferenceCallCount = 0
@@ -218,6 +226,7 @@ var _ = Describe("TriggerReconciler", func() {
 				It("should log and continue", func() {
 					reconciler = NewTriggerReconciler(
 						log,
+						ctrsConfig,
 						mgr,
 						query,
 						setOwnerReferenceFail,

--- a/pkg/kube/controllers/extendedsecret/controller.go
+++ b/pkg/kube/controllers/extendedsecret/controller.go
@@ -11,11 +11,12 @@ import (
 
 	credsgen "code.cloudfoundry.org/cf-operator/pkg/credsgen/in_memory_generator"
 	es "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 )
 
 // Add creates a new ExtendedSecrets Controller and adds it to the Manager
-func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
-	r := NewReconciler(log, mgr, credsgen.NewInMemoryGenerator(log), controllerutil.SetControllerReference)
+func Add(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager) error {
+	r := NewReconciler(log, ctrConfig, mgr, credsgen.NewInMemoryGenerator(log), controllerutil.SetControllerReference)
 
 	// Create a new controller
 	c, err := controller.New("extendedsecret-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/kube/controllers/extendedsecret/reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/reconciler_test.go
@@ -2,6 +2,7 @@ package extendedsecret_test
 
 import (
 	"context"
+	"time"
 
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
 	generatorfakes "code.cloudfoundry.org/cf-operator/pkg/credsgen/fakes"
@@ -9,6 +10,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned/scheme"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 	escontroller "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedsecret"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 
 	cfakes "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
 	"go.uber.org/zap"
@@ -33,6 +35,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 		reconciler       reconcile.Reconciler
 		request          reconcile.Request
 		log              *zap.SugaredLogger
+		ctrsConfig       *controllersconfig.ControllersConfig
 		client           *cfakes.FakeClient
 		generator        *generatorfakes.FakeGenerator
 		es               *esapi.ExtendedSecret
@@ -45,6 +48,10 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 		core, _ := observer.New(zapcore.InfoLevel)
 		log = zap.New(core).Sugar()
+		ctrsConfig = &controllersconfig.ControllersConfig{ //Set the context to be TODO
+			CtxTimeOut: 10 * time.Second,
+			CtxType:    controllersconfig.NewContext(),
+		}
 		es = &esapi.ExtendedSecret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -70,7 +77,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 	})
 
 	JustBeforeEach(func() {
-		reconciler = escontroller.NewReconciler(log, manager, generator, setReferenceFunc)
+		reconciler = escontroller.NewReconciler(log, ctrsConfig, manager, generator, setReferenceFunc)
 	})
 
 	Context("if the resource can not be resolved", func() {

--- a/pkg/kube/controllers/extendedstatefulset/controller.go
+++ b/pkg/kube/controllers/extendedstatefulset/controller.go
@@ -10,12 +10,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 )
 
 // Add creates a new ExtendedStatefulSet controller and adds it to the Manager
-func Add(log *zap.SugaredLogger, mgr manager.Manager) error {
+func Add(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, mgr manager.Manager) error {
 	log.Info("Creating the ExtendedStatefulSet controller")
-	r := NewReconciler(log, mgr, controllerutil.SetControllerReference)
+	r := NewReconciler(log, ctrConfig, mgr, controllerutil.SetControllerReference)
 
 	// Create a new controller
 	c, err := controller.New("extendedstatefulset-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/kube/controllers/extendedstatefulset/reconciler_test.go
+++ b/pkg/kube/controllers/extendedstatefulset/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 	exssc "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedstatefulset"
 	cfakes "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
 
 	. "github.com/onsi/ginkgo"
@@ -36,6 +37,7 @@ var _ = Describe("ReconcileExtendedStatefulSet", func() {
 		reconciler reconcile.Reconciler
 		request    reconcile.Request
 		log        *zap.SugaredLogger
+		ctrsConfig *controllersconfig.ControllersConfig
 	)
 
 	BeforeEach(func() {
@@ -46,10 +48,15 @@ var _ = Describe("ReconcileExtendedStatefulSet", func() {
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 		core, _ := observer.New(zapcore.InfoLevel)
 		log = zap.New(core).Sugar()
+
+		ctrsConfig = &controllersconfig.ControllersConfig{ //Set the context to be TODO
+			CtxTimeOut: 10 * time.Second,
+			CtxType:    controllersconfig.NewContext(),
+		}
 	})
 
 	JustBeforeEach(func() {
-		reconciler = exssc.NewReconciler(log, manager, controllerutil.SetControllerReference)
+		reconciler = exssc.NewReconciler(log, ctrsConfig, manager, controllerutil.SetControllerReference)
 	})
 
 	Describe("Reconcile", func() {

--- a/pkg/kube/controllersconfig/controllersconfig.go
+++ b/pkg/kube/controllersconfig/controllersconfig.go
@@ -1,13 +1,16 @@
-package clientcontext
+package controllersconfig
 
 import (
 	"context"
 	"time"
 )
 
-const (
-	timeOutInMiliseconds int = 500
-)
+//ControllersConfig controls the behaviour of
+//different controllers
+type ControllersConfig struct {
+	CtxTimeOut time.Duration
+	CtxType    context.Context
+}
 
 //NewContext returns a non-nil empty context, for usage
 //when it is unclear which context to use.
@@ -29,6 +32,6 @@ func WithValue(parent context.Context, key interface{}, val interface{}) context
 
 //NewBackgroundContextWithTimeout returns a context that if
 //cancelled it will release resources associated with it.
-func NewBackgroundContextWithTimeout() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(NewBackgroundContext(), time.Duration(timeOutInMiliseconds)*time.Millisecond)
+func NewBackgroundContextWithTimeout(ctx context.Context, ctxTimeOut time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, ctxTimeOut)
 }

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -5,11 +5,12 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllersconfig"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 )
 
 // NewManager adds schemes, controllers and starts the manager
-func NewManager(log *zap.SugaredLogger, cfg *rest.Config, options manager.Options) (mgr manager.Manager, err error) {
+func NewManager(log *zap.SugaredLogger, ctrConfig *controllersconfig.ControllersConfig, cfg *rest.Config, options manager.Options) (mgr manager.Manager, err error) {
 	mgr, err = manager.New(cfg, options)
 	if err != nil {
 		return
@@ -23,6 +24,6 @@ func NewManager(log *zap.SugaredLogger, cfg *rest.Config, options manager.Option
 	}
 
 	// Setup all Controllers
-	err = controllers.AddToManager(log, mgr)
+	err = controllers.AddToManager(log, ctrConfig, mgr)
 	return
 }


### PR DESCRIPTION
This PR defines a context to use when any controller Reconciler invokes the controller runtime client(mainly for CRUD operations or to simply get a client). So far, we have been using a `context.TODO`, but this PR intends to use a `Background` context, with a customize `timeout`.The `context` can be also customize, depending on where it is being call, for example, for unit tests, I set the context to be a `TODO` one, the rest is just `Background`.

Introduce a new pkg call `controllersconfig` that defines:

- Configuration for controllers based on `ControllersConfig{}` structure, that could be used in the future, if new parameters are required. At the moment it only consists of:
  - `CtxTimeOut` field that defines the timeout when setting up the context
  - `CtxType` field that defines the context type, e.g. `Background` or `TODO`, the ability of setting this fields, is useful when doing unit tests,because it allows the user to switch between context types.
  - Originally, the idea of `ControllersConfig{}`, was intended to be part of the `manager.Options`, but I was not able to find a [field](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L85-L137) where I could put this structure.

I also added an integration test into the `deploy_test.go`, that :
- sets the ctx timeout to 1 nanosecond, and expects an error when waiting for a pod deployment, due
  to the timeout being reached.

All unit-tests are refactored, and make use of a TODO context, while I think that the fake client we use there, does not use the ctx at all.

This should cover tracker [card](https://www.pivotaltracker.com/story/show/163416660)