### PR TITLE
Speed up tests by using a faster algo in credsgen tests

### DIFF
--- a/pkg/credsgen/in_memory_generator/certificate_test.go
+++ b/pkg/credsgen/in_memory_generator/certificate_test.go
@@ -26,6 +26,10 @@ var _ = Describe("InMemoryGenerator", func() {
 
 		_, log := testing.NewTestLogger()
 		generator = inmemorygenerator.NewInMemoryGenerator(log)
+		// speed up tests with a fast algo
+		g := generator.(*inmemorygenerator.InMemoryGenerator)
+		g.Algorithm = "ecdsa"
+		g.Bits = 256
 	})
 
 	Describe("GenerateCertificate", func() {


### PR DESCRIPTION
This brings down unit test times from ~15s to ~5s
