### PR TITLE
Bump Golang to 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12rc1 AS build
+FROM golang:1.12 AS build
 COPY . /go/src/code.cloudfoundry.org/cf-operator
 RUN cd /go/src/code.cloudfoundry.org/cf-operator && \
     GO111MODULE=on make build && \


### PR DESCRIPTION
We can now compile our binary in Docker with Golang 1.12.