### PR TITLE
164072419 ig to extended sts jobs

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/context"
 	"code.cloudfoundry.org/cf-operator/version"
@@ -37,11 +38,11 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		namespace := viper.GetString("namespace")
-		operator.DockerOrganization = viper.GetString("docker-image-org")
-		operator.DockerRepository = viper.GetString("docker-image-repository")
+		manifest.DockerOrganization = viper.GetString("docker-image-org")
+		manifest.DockerRepository = viper.GetString("docker-image-repository")
 
 		log.Infof("Starting cf-operator %s with namespace %s", version.Version, namespace)
-		log.Infof("cf-operator docker image: %s", operator.GetOperatorDockerImage())
+		log.Infof("cf-operator docker image: %s", manifest.GetOperatorDockerImage())
 
 		ctrsConfig := &context.Config{ //Set the context to be TODO
 			CtxTimeOut: 10 * time.Second,

--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -58,6 +58,7 @@ func (m *Manifest) jobsToInitContainers(instanceName string, jobs []Job) ([]v1.C
 	if err != nil {
 		return []v1.Container{}, err
 	}
+	// prepend an init container that runs the cf-operator img
 	initContainers = append([]v1.Container{{Name: instanceName, Image: GetOperatorDockerImage()}}, initContainers...) //TODO: name of the first init container?
 	return initContainers, nil
 }

--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -7,25 +7,191 @@ import (
 	"regexp"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
 	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/version"
+	"k8s.io/api/apps/v1beta2"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// DockerOrganization is the organization which provides the operator image
+	DockerOrganization = ""
+	// DockerRepository is the repository which provides the operator image
+	DockerRepository = ""
 )
 
 // KubeConfig represents a Manifest in kube resources
 type KubeConfig struct {
-	Variables []esv1.ExtendedSecret
+	Variables   []esv1.ExtendedSecret
+	ExtendedSts []essv1.ExtendedStatefulSet
+	ExtendedJob []ejv1.ExtendedJob
 }
 
 // ConvertToKube converts a Manifest into kube resources
-func (m *Manifest) ConvertToKube() KubeConfig {
+func (m *Manifest) ConvertToKube() (KubeConfig, error) {
 	kubeConfig := KubeConfig{}
 
-	kubeConfig.Variables = m.convertVariables()
+	convertedExtSts, err := m.convertToExtendedSts()
+	if err != nil {
+		return KubeConfig{}, err
+	}
 
-	return kubeConfig
+	convertedExtJob, err := m.convertToExtendedJob()
+	if err != nil {
+		return KubeConfig{}, err
+	}
+	kubeConfig.Variables = m.convertVariables()
+	kubeConfig.ExtendedSts = convertedExtSts
+	kubeConfig.ExtendedJob = convertedExtJob
+
+	return kubeConfig, nil
 }
 
+// jobsToInitContainers creates a list of Containers for v1.PodSpec InitContainers field
+func (m *Manifest) jobsToInitContainers(instanceName string, jobs []Job) ([]v1.Container, error) {
+
+	var initContainers []v1.Container
+	initContainers, err := m.jobsToContainers(instanceName, jobs, true)
+	if err != nil {
+		return []v1.Container{}, err
+	}
+	initContainers = append([]v1.Container{{Name: instanceName, Image: GetOperatorDockerImage()}}, initContainers...) //TODO: name of the first init container?
+	return initContainers, nil
+}
+
+// jobsToContainers creates a list of Containers for v1.PodSpec Containers field
+func (m *Manifest) jobsToContainers(igName string, jobs []Job, isInitContainer bool) ([]v1.Container, error) {
+	var (
+		jobsToContainerPods []v1.Container
+		containerCmd        string
+	)
+	if isInitContainer {
+		containerCmd = "echo \"\""
+	} else {
+		containerCmd = "while true; do ping localhost;done"
+	}
+
+	for _, job := range jobs {
+		jobImage, err := m.GetReleaseImage(igName, job.Name)
+		if err != nil {
+			return []v1.Container{}, err
+		}
+		jobsToContainerPods = append(jobsToContainerPods, v1.Container{
+			Name:    job.Name,
+			Image:   jobImage,
+			Command: []string{containerCmd},
+		})
+	}
+	return jobsToContainerPods, nil
+}
+
+// serviceToExtendedSts will generate an ExtendedStatefulSet
+func (m *Manifest) serviceToExtendedSts(ig *InstanceGroup) (essv1.ExtendedStatefulSet, error) {
+
+	igName := ig.Name
+
+	listOfContainers, err := m.jobsToContainers(igName, ig.Jobs, false)
+	if err != nil {
+		return essv1.ExtendedStatefulSet{}, err
+	}
+
+	listOfInitContainers, err := m.jobsToInitContainers(igName, ig.Jobs)
+	if err != nil {
+		return essv1.ExtendedStatefulSet{}, err
+	}
+
+	extSts := essv1.ExtendedStatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: igName,
+		},
+		Spec: essv1.ExtendedStatefulSetSpec{
+			Template: v1beta2.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: igName,
+				},
+				Spec: v1beta2.StatefulSetSpec{
+					Replicas: func() *int32 { i := int32(ig.Instances); return &i }(),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: igName,
+						},
+						Spec: v1.PodSpec{
+							Containers:     listOfContainers,
+							InitContainers: listOfInitContainers,
+						},
+					},
+				},
+			},
+		},
+	}
+	return extSts, nil
+}
+
+// convertToExtendedSts will convert instance_groups which lifecycle
+// is service to ExtendedStatefulSets
+func (m *Manifest) convertToExtendedSts() ([]essv1.ExtendedStatefulSet, error) {
+	extStsList := []essv1.ExtendedStatefulSet{}
+	for _, ig := range m.InstanceGroups {
+		if ig.LifeCycle == "service" || ig.LifeCycle == "" {
+			convertedExtStatefulSet, err := m.serviceToExtendedSts(ig)
+			if err != nil {
+				return []essv1.ExtendedStatefulSet{}, err
+			}
+			extStsList = append(extStsList, convertedExtStatefulSet)
+		}
+	}
+	return extStsList, nil
+}
+
+// errandToExtendedJob will generate an ExtendedJob
+func (m *Manifest) errandToExtendedJob(ig *InstanceGroup) (ejv1.ExtendedJob, error) {
+	igName := ig.Name
+
+	listOfContainers, err := m.jobsToContainers(igName, ig.Jobs, false)
+	if err != nil {
+		return ejv1.ExtendedJob{}, err
+	}
+	listOfInitContainers, err := m.jobsToInitContainers(igName, ig.Jobs)
+	if err != nil {
+		return ejv1.ExtendedJob{}, err
+	}
+	extJob := ejv1.ExtendedJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: igName,
+		},
+		Spec: ejv1.ExtendedJobSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: igName,
+				},
+				Spec: v1.PodSpec{
+					Containers:     listOfContainers,
+					InitContainers: listOfInitContainers,
+				},
+			},
+		},
+	}
+	return extJob, nil
+}
+
+// convertToExtendedJob will convert instance_groups which lifecycle is
+// errand to ExtendedJobs
+func (m *Manifest) convertToExtendedJob() ([]ejv1.ExtendedJob, error) {
+	extJobs := []ejv1.ExtendedJob{}
+	for _, ig := range m.InstanceGroups {
+		if ig.LifeCycle == "errand" {
+			convertedExtJob, err := m.errandToExtendedJob(ig)
+			if err != nil {
+				return []ejv1.ExtendedJob{}, err
+			}
+			extJobs = append(extJobs, convertedExtJob)
+		}
+	}
+	return extJobs, nil
+}
 func (m *Manifest) convertVariables() []esv1.ExtendedSecret {
 	secrets := []esv1.ExtendedSecret{}
 
@@ -126,4 +292,9 @@ func (m *Manifest) GetReleaseImage(instanceGroupName, jobName string) (string, e
 		}
 	}
 	return "", fmt.Errorf("Release '%s' not found", job.Release)
+}
+
+// GetOperatorDockerImage returns the image name of the operator docker image
+func GetOperatorDockerImage() string {
+	return DockerOrganization + "/" + DockerRepository + ":" + version.Version
 }

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -4,10 +4,9 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/testing"
 
+	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
 )
 
 var _ = Describe("ConvertToKube", func() {
@@ -15,6 +14,8 @@ var _ = Describe("ConvertToKube", func() {
 		m          manifest.Manifest
 		kubeConfig manifest.KubeConfig
 		env        testing.Catalog
+		ig         []*manifest.InstanceGroup //TODO: avoid this
+		errandIg   []*manifest.InstanceGroup //TODO: avoid this
 	)
 
 	BeforeEach(func() {
@@ -26,7 +27,7 @@ var _ = Describe("ConvertToKube", func() {
 			m.Name = "-abc_123.?!\"§$&/()=?"
 			m.Variables[0].Name = "def-456.?!\"§$&/()=?-"
 
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(kubeConfig.Variables[0].Name).To(Equal("abc-123.def-456"))
 		})
 
@@ -34,12 +35,12 @@ var _ = Describe("ConvertToKube", func() {
 			m.Name = "foo"
 			m.Variables[0].Name = "this-is-waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay-too-long"
 
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(kubeConfig.Variables[0].Name).To(Equal("foo.this-is-waaaaaaaaaaaaaaaaaaa0bef0f482cfb7313e03e6bd86b53ef3"))
 		})
 
 		It("converts password variables", func() {
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(len(kubeConfig.Variables)).To(Equal(1))
 
 			var1 := kubeConfig.Variables[0]
@@ -53,7 +54,7 @@ var _ = Describe("ConvertToKube", func() {
 				Name: "adminkey",
 				Type: "rsa",
 			}
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(len(kubeConfig.Variables)).To(Equal(1))
 
 			var1 := kubeConfig.Variables[0]
@@ -67,7 +68,7 @@ var _ = Describe("ConvertToKube", func() {
 				Name: "adminkey",
 				Type: "ssh",
 			}
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(len(kubeConfig.Variables)).To(Equal(1))
 
 			var1 := kubeConfig.Variables[0]
@@ -88,7 +89,7 @@ var _ = Describe("ConvertToKube", func() {
 					ExtendedKeyUsage: []manifest.AuthType{manifest.ClientAuth},
 				},
 			}
-			kubeConfig = m.ConvertToKube()
+			kubeConfig, _ = m.ConvertToKube()
 			Expect(len(kubeConfig.Variables)).To(Equal(1))
 
 			var1 := kubeConfig.Variables[0]
@@ -101,6 +102,112 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(request.IsCA).To(Equal(true))
 			Expect(request.CARef.Name).To(Equal("foo-deployment.theca"))
 			Expect(request.CARef.Key).To(Equal("certificate"))
+		})
+	})
+
+	Context("convert service lifecycle to instance groups", func() {
+		JustBeforeEach(func() {
+			ig = []*manifest.InstanceGroup{
+				{Name: "ig-c", Stemcell: "default", Jobs: []manifest.Job{{Name: "nats", Release: "nats-release"}}},
+				{Name: "ig-a", Stemcell: "default", LifeCycle: "service", Jobs: []manifest.Job{{Name: "ig-a", Release: "ig-a-release"}}},
+			}
+		})
+		It("when the lifecycle is set to nothing", func() {
+			m2 := manifest.Manifest{
+				Name: "emptylc",
+				Stemcells: []*manifest.Stemcell{
+					{Alias: "default", Name: "open-suse", Version: "28.g837c5b3-30.263-7.0.0_234.gcd7d1132", OS: "opensuse-42.3"},
+				},
+				Releases: []*manifest.Release{
+					{Name: "nats-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+					{Name: "ig-a-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+				},
+				InstanceGroups: ig,
+			}
+			kubeConfig, err := m2.ConvertToKube()
+			Expect(err).ShouldNot(HaveOccurred())
+			anExtendedSts := kubeConfig.ExtendedSts[0]
+			Expect(anExtendedSts.Name).To(Equal("ig-c"))
+			//TODO: ginkgo Expect Actual statements are too long
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/nats-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.Containers[0].Command[0]).To(Equal("while true; do ping localhost;done"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[0].Image).To(Equal("/:0.0.1"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[1].Image).To(Equal("hub.docker.com/cfcontainerization/nats-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[1].Command[0]).To(Equal("echo \"\""))
+		})
+
+		It("when the lifecycle is set to service", func() {
+			m2 := manifest.Manifest{
+				Name: "emptylc",
+				Stemcells: []*manifest.Stemcell{
+					{Alias: "default", Name: "open-suse", Version: "28.g837c5b3-30.263-7.0.0_234.gcd7d1132", OS: "opensuse-42.3"},
+				},
+				Releases: []*manifest.Release{
+					{Name: "nats-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+					{Name: "ig-a-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+				},
+				InstanceGroups: ig,
+			}
+			kubeConfig, err := m2.ConvertToKube()
+			Expect(err).ShouldNot(HaveOccurred())
+			anExtendedSts := kubeConfig.ExtendedSts[1]
+			Expect(anExtendedSts.Name).To(Equal("ig-a"))
+			//TODO: ginkgo statements are too long
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/ig-a-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.Containers[0].Command[0]).To(Equal("while true; do ping localhost;done"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[0].Image).To(Equal("/:0.0.1"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[1].Image).To(Equal("hub.docker.com/cfcontainerization/ig-a-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(anExtendedSts.Spec.Template.Spec.Template.Spec.InitContainers[1].Command[0]).To(Equal("echo \"\""))
+		})
+	})
+
+	Context("convert errand lifecycle to instance groups", func() {
+		JustBeforeEach(func() {
+			errandIg = []*manifest.InstanceGroup{
+				{Name: "nats", Stemcell: "default", LifeCycle: "errand", Jobs: []manifest.Job{{Name: "nats", Release: "nats-release"}, {Name: "nats-processor", Release: "nats-processor-release"}}},
+				{Name: "api", Stemcell: "default", LifeCycle: "service", Jobs: []manifest.Job{{Name: "api", Release: "api-release"}}},
+				{Name: "router", Stemcell: "default", LifeCycle: "errand", Jobs: []manifest.Job{{Name: "router", Release: "router-release"}}},
+			}
+		})
+		It("when the lifecycle is set to errand", func() {
+			manifestWithErrands := manifest.Manifest{
+				Name: "with-errands",
+				Stemcells: []*manifest.Stemcell{
+					{Alias: "default", Name: "open-suse", Version: "28.g837c5b3-30.263-7.0.0_234.gcd7d1132", OS: "opensuse-42.3"},
+				},
+				Releases: []*manifest.Release{
+					{Name: "nats-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+					{Name: "nats-processor-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+					{Name: "api-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+					{Name: "router-release", Version: "0.62.0", URL: "hub.docker.com/cfcontainerization"},
+				},
+				InstanceGroups: errandIg,
+			}
+			kubeConfig, err := manifestWithErrands.ConvertToKube()
+			Expect(err).ShouldNot(HaveOccurred())
+			firstExtendedJob := kubeConfig.ExtendedJob[0]
+			scndExtendedJob := kubeConfig.ExtendedJob[1]
+			// TODO: ginkgo statements are too long
+			Expect(len(kubeConfig.ExtendedJob)).To(Equal(2))
+			Expect(len(kubeConfig.ExtendedJob)).ToNot(Equal(3))
+			Expect(firstExtendedJob.Name).To(Equal("nats"))
+			Expect(scndExtendedJob.Name).To(Equal("router"))
+
+			Expect(firstExtendedJob.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/nats-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(firstExtendedJob.Spec.Template.Spec.Containers[1].Image).To(Equal("hub.docker.com/cfcontainerization/nats-processor-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(firstExtendedJob.Spec.Template.Spec.Containers[0].Command[0]).To(Equal("while true; do ping localhost;done"))
+			Expect(firstExtendedJob.Spec.Template.Spec.Containers[1].Command[0]).To(Equal("while true; do ping localhost;done"))
+			Expect(firstExtendedJob.Spec.Template.Spec.InitContainers[0].Image).To(Equal("/:0.0.1"))
+			Expect(firstExtendedJob.Spec.Template.Spec.InitContainers[1].Image).To(Equal("hub.docker.com/cfcontainerization/nats-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(firstExtendedJob.Spec.Template.Spec.InitContainers[1].Command[0]).To(Equal("echo \"\""))
+			Expect(firstExtendedJob.Spec.Template.Spec.InitContainers[2].Image).To(Equal("hub.docker.com/cfcontainerization/nats-processor-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(firstExtendedJob.Spec.Template.Spec.InitContainers[2].Command[0]).To(Equal("echo \"\""))
+
+			Expect(scndExtendedJob.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/router-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(scndExtendedJob.Spec.Template.Spec.Containers[0].Command[0]).To(Equal("while true; do ping localhost;done"))
+			Expect(scndExtendedJob.Spec.Template.Spec.InitContainers[0].Image).To(Equal("/:0.0.1"))
+			Expect(scndExtendedJob.Spec.Template.Spec.InitContainers[1].Image).To(Equal("hub.docker.com/cfcontainerization/router-release-release:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-0.62.0"))
+			Expect(scndExtendedJob.Spec.Template.Spec.InitContainers[1].Command[0]).To(Equal("echo \"\""))
 		})
 	})
 

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -7,14 +7,6 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/context"
-	"code.cloudfoundry.org/cf-operator/version"
-)
-
-var (
-	// DockerOrganization is the organization which provides the operator image
-	DockerOrganization = ""
-	// DockerRepository is the repository which provides the operator image
-	DockerRepository = ""
 )
 
 // NewManager adds schemes, controllers and starts the manager
@@ -34,9 +26,4 @@ func NewManager(log *zap.SugaredLogger, ctrConfig *context.Config, cfg *rest.Con
 	// Setup all Controllers
 	err = controllers.AddToManager(log, ctrConfig, mgr)
 	return
-}
-
-// GetOperatorDockerImage returns the image name of the operator docker image
-func GetOperatorDockerImage() string {
-	return DockerOrganization + "/" + DockerRepository + ":" + version.Version
 }

--- a/pkg/kube/operator/operator_test.go
+++ b/pkg/kube/operator/operator_test.go
@@ -1,7 +1,7 @@
 package operator_test
 
 import (
-	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/version"
 
 	. "github.com/onsi/ginkgo"
@@ -12,10 +12,10 @@ var _ = Describe("operator", func() {
 	Describe("GetOperatorDockerImage", func() {
 		It("returns the location of the docker image", func() {
 			version.Version = "1.2.3"
-			operator.DockerOrganization = "foo"
-			operator.DockerRepository = "bar"
+			manifest.DockerOrganization = "foo"
+			manifest.DockerRepository = "bar"
 
-			Expect(operator.GetOperatorDockerImage()).To(Equal("foo/bar:1.2.3"))
+			Expect(manifest.GetOperatorDockerImage()).To(Equal("foo/bar:1.2.3"))
 		})
 	})
 })

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -31,6 +31,7 @@ stemcells:
 instance_groups:
 - name: redis-slave
   instances: 2
+  lifecycle: errand
   azs: [z1, z2]
   jobs:
   - name: redis-server
@@ -46,6 +47,7 @@ instance_groups:
   - z1
   - z2
   instances: 2
+  lifecycle: service
   vm_type: small-highmem
   vm_extensions:
   - 100GB_ephemeral_disk


### PR DESCRIPTION
As requested in https://www.pivotaltracker.com/n/projects/2192232/stories/164072419 

Adding main logic to convert instance groups to extended sts and instance groups to extended jobs. This includes:

- Generate a container per ig job inside a extended statefulset
- Generate an init container per ig job inside a extended statefulset
- Generate a single init container per ig, with a cf-operator img inside a extended statefulset
- Generate a container per ig job inside a extended job
- Generate an init container per ig job inside a extended job
- Generate a single init container per ig, with a cf-operator img inside a extended job
- Reuse existing functions to get container images
- Reuse existing functions to get cf operator image
- Adding test cases to validate the result struct

I needed to move the `GetOperatorDockerImage()` func, outside of the `operator.go`, so I could call it from the `manifest` pkg. Reason behind is an import cycle, to be more precise:

> the problem is that the `operator` pkg uses `code.cloudfoundry.org/cf-operator/pkg/kube/controllers` , and the `controllers` pkg uses `code.cloudfoundry.org/cf-operator/pkg/kube/controllers/boshdeployment` , which uses the `code.cloudfoundry.org/cf-operator/pkg/bosh/manifest`

I move the func inside the `kube_converter.go`