### PR TITLE
Add new subcommands for the cf-operator cli

### DIFF
--- a/cmd/internal/dgather.go
+++ b/cmd/internal/dgather.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// dataGatherCmd represents the dataGather command
+var dataGatherCmd = &cobra.Command{
+	Use:   "data-gather [flags]",
+	Short: "Gathers data of a bosh manifest",
+	Long: `Gathers data of a manifest.
+
+This will retrieve information of an instance-group
+inside a bosh manifest.
+
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// All flag values should be reachable via the viper.GetString("viper_flag")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dataGatherCmd)
+
+	dataGatherCmd.Flags().StringP("manifest", "m", "", "path to a bosh manifest")
+	dataGatherCmd.Flags().String("desired-namespace", "", "the kubernetes namespace") //TODO: can we reuse the global ns flag
+	dataGatherCmd.Flags().StringP("base-dir", "b", "", "a path to the base directory")
+	dataGatherCmd.Flags().StringP("instance-group", "g", "", "the instance-group")
+
+	// This will get the values from any set ENV var, but always
+	// the values provided via the flags have more precedence.
+	viper.AutomaticEnv()
+	viper.BindPFlag("manifest", dataGatherCmd.Flags().Lookup("manifest"))
+	viper.BindPFlag("desired_namespace", dataGatherCmd.Flags().Lookup("desired-namespace"))
+	viper.BindPFlag("base_dir", dataGatherCmd.Flags().Lookup("base-dir"))
+	viper.BindPFlag("instance_group", dataGatherCmd.Flags().Lookup("instance-group"))
+}

--- a/cmd/internal/trender.go
+++ b/cmd/internal/trender.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/spf13/viper"
+
+	"github.com/spf13/cobra"
+)
+
+// templateRenderCmd represents the dataGather command
+var templateRenderCmd = &cobra.Command{
+	Use:   "template-render [flags]",
+	Short: "Renders a bosh manifest",
+	Long: `Renders a bosh manifest.
+
+This will render a provided manifest instance-group
+and will generate the output into the specified output
+directory.
+
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Note: for retrieving the values of the job-dir flag, use viper.GetStringSlice("job_dir"))
+		// All other flag values should be reachable via the viper.GetString("viper_flag")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(templateRenderCmd)
+	templateRenderCmd.Flags().StringSliceP("job-dir", "j", []string{}, "path to the job dirs. The flag can be specify multiple times")
+	templateRenderCmd.Flags().StringP("instance-group-manifest", "i", "", "location of the ig manifest")
+	templateRenderCmd.Flags().StringP("output-dir", "d", "", "path to a directory to store the output")
+
+	// This will get the values from any set ENV var, but always
+	// the values provided via the flags have more precedence.
+	viper.AutomaticEnv()
+	viper.BindPFlag("job_dir", templateRenderCmd.Flags().Lookup("job-dir"))
+	viper.BindPFlag("instance_group_manifest", templateRenderCmd.Flags().Lookup("instance-group-manifest"))
+	viper.BindPFlag("output_dir", templateRenderCmd.Flags().Lookup("output-dir"))
+
+}

--- a/cmd/internal/varinterpolation.go
+++ b/cmd/internal/varinterpolation.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// variableInterpolationCmd represents the variableInterpolation command
+var variableInterpolationCmd = &cobra.Command{
+	Use:   "variable-interpolation [flags]",
+	Short: "Interpolate variables",
+	Long: `Interpolate variables of a manifest:
+
+This will interpolate all the variables found in a 
+manifest into kubernetes resources.
+
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// All flag values should be reachable via the viper.GetString("viper_flag")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(variableInterpolationCmd)
+	variableInterpolationCmd.Flags().StringP("manifest", "m", "", "path to a bosh manifest")
+	variableInterpolationCmd.Flags().StringP("variables-dir", "v", "", "path to the variables dir")
+
+	// This will get the values from any set ENV var, but always
+	// the values provided via the flags have more precedence.
+	viper.AutomaticEnv()
+
+	viper.BindPFlag("manifest", variableInterpolationCmd.Flags().Lookup("manifest"))
+	viper.BindPFlag("variables_dir", variableInterpolationCmd.Flags().Lookup("variables-dir"))
+}


### PR DESCRIPTION
template-render cmd, with the following optional flags:
  - `--job-dir` (can be specified multiple times)
  - `--instance-group-manifest`
  - `--output-dir`

data-gather cmd, with the following optional flags:
  - `--manifest`
  - `--desired-namespace`
  - `--base-dir`
  - `--instance-group`

variable-interpolation cmd, with the following optional flags:
  - `--manifest`
  - `--variables-dir`