### PR TITLE
Implement variable-interpolation subcommand

### DIFF
--- a/cmd/internal/varinterpolation.go
+++ b/cmd/internal/varinterpolation.go
@@ -1,9 +1,21 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
+	"github.com/cppforlife/go-patch/patch"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 )
+
+type Variables map[string]interface{}
 
 // variableInterpolationCmd represents the variableInterpolation command
 var variableInterpolationCmd = &cobra.Command{
@@ -15,9 +27,7 @@ This will interpolate all the variables found in a
 manifest into kubernetes resources.
 
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		// All flag values should be reachable via the viper.GetString("viper_flag")
-	},
+	RunE: runVariableInterpolationCmd,
 }
 
 func init() {
@@ -31,4 +41,73 @@ func init() {
 
 	viper.BindPFlag("manifest", variableInterpolationCmd.Flags().Lookup("manifest"))
 	viper.BindPFlag("variables_dir", variableInterpolationCmd.Flags().Lookup("variables-dir"))
+}
+
+func runVariableInterpolationCmd(cmd *cobra.Command, args []string) error {
+	defer log.Sync()
+
+	var vars []boshtpl.Variables
+
+	manifestFile := viper.GetString("manifest")
+	variablesDir := viper.GetString("variables_dir")
+
+	if _, err := os.Stat(manifestFile); os.IsNotExist(err) {
+		return errors.Errorf("no such file: %s", manifestFile)
+	}
+
+	info, err := os.Stat(variablesDir)
+	if os.IsNotExist(err) || !info.IsDir() {
+		return errors.Errorf("no such directory: %s", variablesDir)
+	}
+
+	// Read files
+	log.Debugf("Reading manifest file: %s", manifestFile)
+	mBytes, err := ioutil.ReadFile(manifestFile)
+	if err != nil {
+		return errors.Wrapf(err, "could not read manifest file")
+	}
+
+	err = filepath.Walk(variablesDir, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			extension := filepath.Ext(strings.TrimSpace(path))
+			if extension == ".yml" || extension == ".yaml" {
+				log.Debugf("Reading variables file: %s", path)
+				varBytes, err := ioutil.ReadFile(path)
+				if err != nil {
+					log.Fatal(errors.Wrapf(err, "could not read variables file"))
+				}
+				staticVars := boshtpl.StaticVariables{}
+
+				err = yaml.Unmarshal(varBytes, &staticVars)
+				if err != nil {
+					return errors.Wrapf(err, "could not deserialize variables: %s", string(varBytes))
+				}
+
+				vars = append(vars, staticVars)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "could not read variables directory")
+	}
+
+	multiVars := boshtpl.NewMultiVars(vars)
+	tpl := boshtpl.NewTemplate(mBytes)
+
+	// Following options are empty for cf-operator
+	op := patch.Ops{}
+	evalOpts := boshtpl.EvaluateOpts{
+		ExpectAllKeys:     false,
+		ExpectAllVarsUsed: false,
+	}
+
+	bytes, err := tpl.Evaluate(multiVars, op, evalOpts)
+	if err != nil {
+		return errors.Wrapf(err, "could not evaluate variables")
+	}
+
+	fmt.Println("---\n# Manifest:")
+	fmt.Println(string(bytes))
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,15 @@ module code.cloudfoundry.org/cf-operator
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
+	github.com/bmatcuk/doublestar v1.1.1 // indirect
+	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7
+	github.com/cloudfoundry/bosh-cli v5.4.0+incompatible
+	github.com/cloudfoundry/bosh-utils v0.0.0-20190206192830-9a0affed2bf1 // indirect
 	github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/gogo/protobuf v1.1.1 // indirect
@@ -32,7 +36,7 @@ require (
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0
-	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect


### PR DESCRIPTION
[#164357145](https://www.pivotaltracker.com/story/show/164357145)

Hi,

This story was implemented by bosh-cli interploate command sub-functionaliy.

And below is an example:

```
---
$ cat manifest.yaml 
---
name: ((name))
instance-group:
  key1: ((value1))
  key2: ((value2))
  key3: ((value3))

$ cat ./vars/v1.yaml 
---
name: test
value1: baz

$ cat ./vars/v2.yml 
---
value2: foo
value3: bar

$ ./cf-operator variable-interpolation -m manifest.yaml -v ./vars
# Manifest:
instance-group:
  key1: baz
  key2: foo
  key3: bar
name: test
```

Best,
@edwardstudy

