### PR TITLE
Mimic kubectl behavior for kube config loading

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"fmt"
 	golog "log"
 	"os"
-	"os/user"
-	"path/filepath"
 	"time"
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	kubeConfig "code.cloudfoundry.org/cf-operator/pkg/kube/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/context"
 	"code.cloudfoundry.org/cf-operator/version"
@@ -18,8 +16,6 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // from https://github.com/kubernetes/client-go/issues/345
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
@@ -34,10 +30,14 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		defer log.Sync()
 
-		kubeConfig, err := getKubeConfig()
+		restConfig, err := kubeConfig.NewGetter(log).Get(viper.GetString("kubeconfig"))
 		if err != nil {
 			log.Fatal(err)
 		}
+		if err := kubeConfig.NewChecker(log).Check(restConfig); err != nil {
+			log.Fatal(err)
+		}
+
 		namespace := viper.GetString("namespace")
 		manifest.DockerOrganization = viper.GetString("docker-image-org")
 		manifest.DockerRepository = viper.GetString("docker-image-repository")
@@ -60,7 +60,7 @@ var rootCmd = &cobra.Command{
 			WebhookServerPort: webhookPort,
 			Fs:                afero.NewOsFs(),
 		}
-		mgr, err := operator.NewManager(log, ctrsConfig, kubeConfig, manager.Options{Namespace: namespace})
+		mgr, err := operator.NewManager(log, ctrsConfig, restConfig, manager.Options{Namespace: namespace})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -108,27 +108,4 @@ func initConfig() {
 		golog.Fatalf("cannot initialize ZAP logger: %v", err)
 	}
 	log = logger.Sugar()
-}
-
-func getKubeConfig() (*rest.Config, error) {
-	kubeconfig := viper.GetString("kubeconfig")
-
-	if len(kubeconfig) > 0 {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
-	}
-
-	// If no explicit location, try the in-cluster config
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-
-	// If no in-cluster config, try the default location in the user's home directory
-	if usr, err := user.Current(); err == nil {
-		if c, err := clientcmd.BuildConfigFromFlags(
-			"", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("could not locate a kubeconfig")
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.2 // indirect
+	github.com/spf13/afero v1.1.2
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/pkg/kube/config/checker.go
+++ b/pkg/kube/config/checker.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Checker is the interface that wraps the Check method that checks if cfg can be used to connect to
+// the Kubernetes cluster.
+type Checker interface {
+	Check(cfg *rest.Config) error
+}
+
+// NewChecker constructs a default checker that satisfies the Checker interface.
+func NewChecker(log *zap.SugaredLogger) Checker {
+	return &checker{
+		log: log,
+
+		createClientSet:    kubernetes.NewForConfig,
+		checkServerVersion: checkServerVersion,
+	}
+}
+
+type checker struct {
+	log *zap.SugaredLogger
+
+	createClientSet    func(c *rest.Config) (*kubernetes.Clientset, error)
+	checkServerVersion func(d discovery.ServerVersionInterface) error
+}
+
+func (c *checker) Check(cfg *rest.Config) error {
+	c.log.Info("Checking kube config")
+	clientset, err := c.createClientSet(cfg)
+	if err != nil {
+		return &checkConfigError{err}
+	}
+	err = c.checkServerVersion(clientset.Discovery())
+	if err != nil {
+		return &checkConfigError{err}
+	}
+	return nil
+}
+
+type checkConfigError struct {
+	err error
+}
+
+func (e *checkConfigError) Error() string {
+	return fmt.Sprintf("invalid kube config: %v", e.err)
+}
+
+func checkServerVersion(d discovery.ServerVersionInterface) error {
+	_, err := d.ServerVersion()
+	return err
+}

--- a/pkg/kube/config/checker_test.go
+++ b/pkg/kube/config/checker_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Checker", func() {
+	Describe("NewDefaultChecker constructor", func() {
+		It("returns a checker", func() {
+			c := NewChecker(nil)
+			_, ok := c.(*checker)
+			Expect(ok).To(Equal(true))
+		})
+	})
+
+	type checkCase struct {
+		checker checker
+
+		cfg         *rest.Config
+		expectedErr error
+	}
+
+	DescribeTable(
+		"Check method",
+		func(c checkCase) {
+			logger := zap.NewNop()
+			defer logger.Sync()
+			c.checker.log = logger.Sugar()
+
+			actualErr := c.checker.Check(c.cfg)
+			if c.expectedErr == nil {
+				Expect(actualErr).To(BeNil())
+			} else {
+				Expect(actualErr).To(Equal(c.expectedErr))
+			}
+		},
+		Entry(
+			"should fail when creating the k8s clientset fails",
+			checkCase{
+				checker: checker{
+					createClientSet: func(c *rest.Config) (*kubernetes.Clientset, error) {
+						return nil, fmt.Errorf("error from createClientSet")
+					},
+				},
+				expectedErr: &checkConfigError{fmt.Errorf("error from createClientSet")},
+			},
+		),
+		Entry(
+			"should fail when checking the server version fails",
+			checkCase{
+				checker: checker{
+					createClientSet: func(c *rest.Config) (*kubernetes.Clientset, error) {
+						return &kubernetes.Clientset{}, nil
+					},
+					checkServerVersion: func(d discovery.ServerVersionInterface) error {
+						return fmt.Errorf("error from checkServerVersion")
+					},
+				},
+				expectedErr: &checkConfigError{fmt.Errorf("error from checkServerVersion")},
+			},
+		),
+		Entry(
+			"should succeed with no errors",
+			checkCase{
+				checker: checker{
+					createClientSet: func(c *rest.Config) (*kubernetes.Clientset, error) {
+						return &kubernetes.Clientset{}, nil
+					},
+					checkServerVersion: func(d discovery.ServerVersionInterface) error {
+						return nil
+					},
+				},
+			},
+		),
+	)
+
+	Describe("checkConfigError", func() {
+		It("Error() should construct the error correctly", func() {
+			err := checkConfigError{fmt.Errorf("some error")}
+			Expect(err.Error()).To(Equal(fmt.Sprintf("invalid kube config: some error")))
+		})
+	})
+
+	Describe("checkServerVersion", func() {
+		It("should call the ServerVersion method and return only the error from it", func() {
+			expectedErr := fmt.Errorf("error from ServerVersion")
+			actualErr := checkServerVersion(&discoveryMock{expectedErr})
+			Expect(actualErr).To(Equal(expectedErr))
+		})
+	})
+})
+
+type discoveryMock struct {
+	err error
+}
+
+func (d *discoveryMock) ServerVersion() (*version.Info, error) {
+	return nil, d.err
+}

--- a/pkg/kube/config/getter.go
+++ b/pkg/kube/config/getter.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Getter is the interface that wraps the Get method that returns the Kubernetes configuration used
+// to communicate with it using its API.
+type Getter interface {
+	Get(customConfigPath string) (*rest.Config, error)
+}
+
+// NewGetter constructs a default getter that satisfies the Getter interface.
+func NewGetter(log *zap.SugaredLogger) Getter {
+	return &getter{
+		log: log,
+
+		inClusterConfig:          rest.InClusterConfig,
+		lookupEnv:                os.LookupEnv,
+		readFile:                 ioutil.ReadFile,
+		restConfigFromKubeConfig: clientcmd.RESTConfigFromKubeConfig,
+		currentUser:              user.Current,
+		defaultRESTConfig:        clientcmd.DefaultClientConfig.ClientConfig,
+	}
+}
+
+type getter struct {
+	log *zap.SugaredLogger
+
+	inClusterConfig          func() (*rest.Config, error)
+	lookupEnv                func(key string) (string, bool)
+	readFile                 func(filename string) ([]byte, error)
+	restConfigFromKubeConfig func(configBytes []byte) (*rest.Config, error)
+	currentUser              func() (*user.User, error)
+	defaultRESTConfig        func() (*rest.Config, error)
+}
+
+func (g *getter) Get(customConfigPath string) (*rest.Config, error) {
+	configPath := customConfigPath
+
+	if configPath == "" {
+		// If no explicit location, try the in-cluster config.
+		_, okHost := g.lookupEnv("KUBERNETES_SERVICE_HOST")
+		_, okPort := g.lookupEnv("KUBERNETES_SERVICE_PORT")
+		if okHost && okPort {
+			c, err := g.inClusterConfig()
+			if err == nil {
+				g.log.Info("Using in-cluster kube config")
+				return c, nil
+			} else if !os.IsNotExist(err) {
+				return nil, &getConfigError{err}
+			}
+		}
+
+		// If no in-cluster config, set the config path to the user's ~/.kube directory.
+		usr, err := g.currentUser()
+		if err != nil {
+			return nil, &getConfigError{err}
+		}
+		configPath = filepath.Join(usr.HomeDir, ".kube", "config")
+	}
+
+	b, err := g.readFile(configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, &getConfigError{err}
+		}
+
+		// If neither the custom config path, nor the user's ~/.kube directory config path exist, use a
+		// default config.
+		c, err := g.defaultRESTConfig()
+		if err != nil {
+			return nil, &getConfigError{err}
+		}
+		g.log.Infof("%s does not exist, using default kube config", configPath)
+		return c, nil
+	}
+
+	c, err := g.restConfigFromKubeConfig(b)
+	if err != nil {
+		return nil, &getConfigError{err}
+	}
+	g.log.Infof("Using kube config '%s'", configPath)
+	return c, nil
+}
+
+type getConfigError struct {
+	err error
+}
+
+func (e *getConfigError) Error() string {
+	return fmt.Sprintf("failed to get kube config: %v", e.err)
+}

--- a/pkg/kube/config/getter_test.go
+++ b/pkg/kube/config/getter_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Getter", func() {
+	Describe("NewDefaultGetter constructor", func() {
+		It("returns a getter", func() {
+			g := NewGetter(nil)
+			_, ok := g.(*getter)
+			Expect(ok).To(Equal(true))
+		})
+	})
+
+	type getCase struct {
+		getter getter
+
+		customConfigPath string
+		expectedConfig   *rest.Config
+		expectedErr      error
+	}
+
+	DescribeTable(
+		"Get method",
+		func(c getCase) {
+			logger := zap.NewNop()
+			defer logger.Sync()
+			c.getter.log = logger.Sugar()
+
+			actualConfig, actualErr := c.getter.Get(c.customConfigPath)
+			if c.expectedConfig == nil {
+				Expect(actualConfig).To(BeNil())
+			} else {
+				Expect(actualConfig).To(Equal(c.expectedConfig))
+			}
+			if c.expectedErr == nil {
+				Expect(actualErr).To(BeNil())
+			} else {
+				Expect(actualErr).To(Equal(c.expectedErr))
+			}
+		},
+		Entry(
+			"should fail when loading the in-cluster config fails",
+			getCase{
+				getter: getter{
+					inClusterConfig: func() (*rest.Config, error) {
+						return nil, fmt.Errorf("error from inClusterConfig")
+					},
+					lookupEnv: func(_ string) (string, bool) {
+						return "", true
+					},
+				},
+				expectedErr: &getConfigError{fmt.Errorf("error from inClusterConfig")},
+			},
+		),
+		Entry(
+			"should succeed when loading the in-cluster config",
+			getCase{
+				getter: getter{
+					inClusterConfig: func() (*rest.Config, error) {
+						return &rest.Config{Host: "in.cluster.config.com"}, nil
+					},
+					lookupEnv: func(_ string) (string, bool) {
+						return "", true
+					},
+				},
+				expectedConfig: &rest.Config{Host: "in.cluster.config.com"},
+			},
+		),
+		Entry(
+			"should fail when fetching the current user executing the program fails",
+			getCase{
+				getter: getter{
+					lookupEnv: func(_ string) (string, bool) {
+						return "", false
+					},
+					currentUser: func() (*user.User, error) {
+						return nil, fmt.Errorf("error from currentUser")
+					},
+				},
+				expectedErr: &getConfigError{fmt.Errorf("error from currentUser")},
+			},
+		),
+		Entry(
+			"should fail when reading the config from ~/.kube fails",
+			getCase{
+				getter: getter{
+					lookupEnv: func(_ string) (string, bool) {
+						return "", false
+					},
+					currentUser: func() (*user.User, error) {
+						return &user.User{HomeDir: filepath.Join("home", "johndoe")}, nil
+					},
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("home", "johndoe", ".kube", "config")))
+						return nil, fmt.Errorf("error from readFile that isn't NotExist")
+					},
+				},
+				expectedErr: &getConfigError{fmt.Errorf("error from readFile that isn't NotExist")},
+			},
+		),
+		Entry(
+			"should fail when creating the output rest config from ~/.kube fails",
+			getCase{
+				getter: getter{
+					lookupEnv: func(_ string) (string, bool) {
+						return "", false
+					},
+					currentUser: func() (*user.User, error) {
+						return &user.User{HomeDir: filepath.Join("home", "johndoe")}, nil
+					},
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("home", "johndoe", ".kube", "config")))
+						return []byte{0xaa, 0xcc, 0xff}, nil
+					},
+					restConfigFromKubeConfig: func(configBytes []byte) (*rest.Config, error) {
+						Expect(configBytes).To(Equal([]byte{0xaa, 0xcc, 0xff}))
+						return nil, fmt.Errorf("error from restConfigFromKubeConfig")
+					},
+				},
+				expectedErr: &getConfigError{fmt.Errorf("error from restConfigFromKubeConfig")},
+			},
+		),
+		Entry(
+			"should succeed when creating the output rest config from ~/.kube",
+			getCase{
+				getter: getter{
+					lookupEnv: func(_ string) (string, bool) {
+						return "", false
+					},
+					currentUser: func() (*user.User, error) {
+						return &user.User{HomeDir: filepath.Join("home", "johndoe")}, nil
+					},
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("home", "johndoe", ".kube", "config")))
+						return []byte{0x00, 0x10, 0x20}, nil
+					},
+					restConfigFromKubeConfig: func(configBytes []byte) (*rest.Config, error) {
+						Expect(configBytes).To(Equal([]byte{0x00, 0x10, 0x20}))
+						return &rest.Config{Host: "home.kube.config.com"}, nil
+					},
+				},
+				expectedConfig: &rest.Config{Host: "home.kube.config.com"},
+			},
+		),
+		Entry(
+			"should fail when reading the config from the provided config path fails",
+			getCase{
+				getter: getter{
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("path", "to", ".kube", "config")))
+						return nil, fmt.Errorf("error from readFile that isn't NotExist")
+					},
+				},
+				customConfigPath: filepath.Join("path", "to", ".kube", "config"),
+				expectedErr:      &getConfigError{fmt.Errorf("error from readFile that isn't NotExist")},
+			},
+		),
+		Entry(
+			"should fail when creating the output rest config from the provided config path fails",
+			getCase{
+				getter: getter{
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("path", "to", ".kube", "config")))
+						return []byte{0xaa, 0xcc, 0xff}, nil
+					},
+					restConfigFromKubeConfig: func(configBytes []byte) (*rest.Config, error) {
+						Expect(configBytes).To(Equal([]byte{0xaa, 0xcc, 0xff}))
+						return nil, fmt.Errorf("error from restConfigFromKubeConfig")
+					},
+				},
+				customConfigPath: filepath.Join("path", "to", ".kube", "config"),
+				expectedErr:      &getConfigError{fmt.Errorf("error from restConfigFromKubeConfig")},
+			},
+		),
+		Entry(
+			"should succeed when creating the output rest config from the provided config path",
+			getCase{
+				getter: getter{
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("path", "to", ".kube", "config")))
+						return []byte{0x00, 0x10, 0x20}, nil
+					},
+					restConfigFromKubeConfig: func(configBytes []byte) (*rest.Config, error) {
+						Expect(configBytes).To(Equal([]byte{0x00, 0x10, 0x20}))
+						return &rest.Config{Host: "provided.kube.config.com"}, nil
+					},
+				},
+				customConfigPath: filepath.Join("path", "to", ".kube", "config"),
+				expectedConfig:   &rest.Config{Host: "provided.kube.config.com"},
+			},
+		),
+		Entry(
+			"should fail when creating the output rest config fails using the default REST config",
+			getCase{
+				getter: getter{
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("path", "to", ".kube", "config")))
+						return nil, os.ErrNotExist
+					},
+					defaultRESTConfig: func() (*rest.Config, error) {
+						return nil, fmt.Errorf("error from defaultRESTConfig")
+					},
+				},
+				customConfigPath: filepath.Join("path", "to", ".kube", "config"),
+				expectedErr:      &getConfigError{fmt.Errorf("error from defaultRESTConfig")},
+			},
+		),
+		Entry(
+			"should succeed when creating the output rest config using the default REST config",
+			getCase{
+				getter: getter{
+					readFile: func(filename string) ([]byte, error) {
+						Expect(filename).To(Equal(filepath.Join("path", "to", ".kube", "config")))
+						return nil, os.ErrNotExist
+					},
+					defaultRESTConfig: func() (*rest.Config, error) {
+						return &rest.Config{Host: "default.rest.config.com"}, nil
+					},
+				},
+				customConfigPath: filepath.Join("path", "to", ".kube", "config"),
+				expectedConfig:   &rest.Config{Host: "default.rest.config.com"},
+			},
+		),
+	)
+
+	Describe("getConfigError", func() {
+		It("Error() should construct the error correctly", func() {
+			err := getConfigError{fmt.Errorf("some error")}
+			Expect(err.Error()).To(Equal(fmt.Sprintf("failed to get kube config: some error")))
+		})
+	})
+})

--- a/pkg/kube/config/suite_test.go
+++ b/pkg/kube/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube Config Suite")
+}


### PR DESCRIPTION
## Description

Rewrote getKubeConfig functionality, checking for the proper errors and falling back to other loading strategies if the error is the expected one.

Injected all the dependencies to test all cases.

Added a checking functionality to verify if the kube config is valid.

[#164586431](https://www.pivotaltracker.com/story/show/164586431)

## Test plan

- Set `KUBECONFIG` to a valid config.
- Unset `KUBECONFIG` and pass the valid config through `--kubeconfig`.
- Have `KUBECONFIG` unset, and don't pass `--kubeconfig`, but still have `~/.kube/config` as a valid config file.
- Move `~/.kube/config` to another location temporarily. It should load a default rest configuration pointing to `http://localhost:8080`.