### PR TITLE
Ensure only yaml is used for the data gathering

### DIFF
--- a/cmd/internal/dgather.go
+++ b/cmd/internal/dgather.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -386,12 +385,12 @@ func GetConsumersAndRenderERB(mStruct *manifest.Manifest, baseDir string, jobRel
 	}
 
 	// marshall the whole manifest Structure
-	manifestResolved, err := json.Marshal(mStruct)
+	manifestResolved, err := yaml.Marshal(mStruct)
 	if err != nil {
 		return err
 	}
 
-	_ = ioutil.WriteFile("/tmp/deployment.json", manifestResolved, 0644)
+	_ = ioutil.WriteFile("/tmp/deployment.yml", manifestResolved, 0644)
 
 	return nil
 }

--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Dgather", func() {
 			}
 
 			Expect(consumeFromDopplerExists).To(BeTrue())
-			for i, instance := range jobConsumesFromDoppler.Instances.([]manifest.JobInstance) {
+			for i, instance := range jobConsumesFromDoppler.Instances {
 				Expect(instance.Index).To(Equal(i))
 				Expect(instance.Address).To(Equal(fmt.Sprintf("doppler-%v-doppler.default.svc.cluster.local", i)))
 				Expect(instance.ID).To(Equal(fmt.Sprintf("doppler-%v-doppler", i)))

--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "code.cloudfoundry.org/cf-operator/cmd/internal"
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/testing"
 	. "github.com/onsi/gomega/gstruct"
@@ -215,7 +214,7 @@ var _ = Describe("Dgather", func() {
 			//   ...
 
 			// For the first instance
-			bpmProcesses := propertiesInstance.BPM.(*bpm.Config).Processes[0]
+			bpmProcesses := propertiesInstance.BPM.Processes[0]
 			Expect(bpmProcesses.Env["FOOBARWITHLINKVALUES"]).To(Equal("10001"))
 			Expect(bpmProcesses.Env["FOOBARWITHLINKNESTEDVALUES"]).To(Equal("7765"))
 
@@ -226,12 +225,12 @@ var _ = Describe("Dgather", func() {
 
 			// For the second instance
 			propertiesInstance = jobBoshContainerizationPropertiesInstances.([]manifest.JobInstance)[1]
-			bpmProcesses = propertiesInstance.BPM.(*bpm.Config).Processes[0]
+			bpmProcesses = propertiesInstance.BPM.Processes[0]
 			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-1-loggregator_trafficcontroller.default.svc.cluster.local"))
 
 			// For the third instance
 			propertiesInstance = jobBoshContainerizationPropertiesInstances.([]manifest.JobInstance)[2]
-			bpmProcesses = propertiesInstance.BPM.(*bpm.Config).Processes[0]
+			bpmProcesses = propertiesInstance.BPM.Processes[0]
 			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-2-loggregator_trafficcontroller.default.svc.cluster.local"))
 
 			// For the fourth instance

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
-	github.com/hashicorp/hcl v1.0.0
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0 // indirect
@@ -45,7 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.2.1
 	github.com/stretchr/testify v1.3.0 // indirect
-	github.com/viovanov/bosh-template-go v0.0.0-20190316043651-198df7e6635e
+	github.com/viovanov/bosh-template-go v0.0.0-20190321101457-83c0228bc835
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"gopkg.in/yaml.v2"
 )
 
@@ -12,7 +13,7 @@ type JobInstance struct {
 	Index       int         `yaml:"index"`
 	Instance    int         `yaml:"instance"`
 	Name        string      `yaml:"name"`
-	BPM         interface{} `yaml:"bpm"`
+	BPM         *bpm.Config `yaml:"bpm"`
 	Fingerprint interface{} `yaml:"fingerprint"`
 }
 

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -2,27 +2,21 @@ package manifest
 
 // JobInstance for data gathering
 type JobInstance struct {
-	Address     string      `json:"address"`
-	AZ          string      `json:"az"`
-	ID          string      `json:"id"`
-	Index       int         `json:"index"`
-	Instance    int         `json:"instance"`
-	Name        string      `json:"name"`
-	BPM         interface{} `json:"bpm"`
-	Fingerprint interface{} `json:"fingerprint"`
+	Address     string      `yaml:"address"`
+	AZ          string      `yaml:"az"`
+	ID          string      `yaml:"id"`
+	Index       int         `yaml:"index"`
+	Instance    int         `yaml:"instance"`
+	Name        string      `yaml:"name"`
+	BPM         interface{} `yaml:"bpm"`
+	Fingerprint interface{} `yaml:"fingerprint"`
 }
 
-// Link ...
-type Link struct {
-	Name       string      `yaml:"name"`
+// JobLink describes links inside a job properties
+// bosh_containerization.
+type JobLink struct {
 	Instances  interface{} `yaml:"instances"`
 	Properties interface{} `yaml:"properties"`
-}
-
-// JobLink ...
-type JobLink struct {
-	Instances  interface{} `json:"instances"`
-	Properties interface{} `json:"properties"`
 }
 
 // JobSpec describes the contents of "job.MF" files


### PR DESCRIPTION
- Struct fields should use yaml, not json
- Final manifest should be marshall with yaml
- update go.mod file
- This is also due to the changes in bosh-templates-go, see [commit 83c0228bc](https://github.com/viovanov/bosh-template-go/commit/83c0228bc83589cbf2e6a55494943cc04952935e)