### PR TITLE
Try to remove long timeouts from tests

### DIFF
--- a/bin/test-integration
+++ b/bin/test-integration
@@ -13,7 +13,7 @@ TEST_NAMESPACE=${TEST_NAMESPACE:-"test$(date +%s)"}
 export TEST_NAMESPACE
 
 remove_namespace() {
-  kubectl delete namespace "$TEST_NAMESPACE"
+  kubectl delete namespace --wait=false --grace-period=60 "$TEST_NAMESPACE"
 }
 trap remove_namespace EXIT
 
@@ -22,4 +22,4 @@ bin/apply-crds
 kubectl get customresourcedefinitions
 kubectl get namespace "$TEST_NAMESPACE" || kubectl create namespace "$TEST_NAMESPACE"
 
-ginkgo integration/
+ginkgo --slowSpecThreshold=50 integration/

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -41,9 +41,7 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// check for pod
-			err = env.WaitForPod(env.Namespace, podName)
-			Expect(err).To(HaveOccurred(), "error waiting for pod from deployment")
+			Expect(env.WaitForLogMsg(env.ObservedLogs, "extendedstatefulsets: context deadline exceeded")).NotTo(HaveOccurred())
 			env.CtrsConfig.CtxTimeOut = 10 * time.Second
 		})
 

--- a/integration/extended_secret_test.go
+++ b/integration/extended_secret_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ExtendedSecret", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for generated secret
-			secret, err := env.GetSecret(env.Namespace, "generated-password-secret")
+			secret, err := env.CollectSecret(env.Namespace, "generated-password-secret")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secret.Data["password"]).To(MatchRegexp("^\\w{64}$"))
 
@@ -59,7 +59,7 @@ var _ = Describe("ExtendedSecret", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for generated secret
-			secret, err := env.GetSecret(env.Namespace, "generated-rsa-secret")
+			secret, err := env.CollectSecret(env.Namespace, "generated-rsa-secret")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
 			Expect(secret.Data["public_key"]).To(ContainSubstring("PUBLIC KEY"))
@@ -82,7 +82,7 @@ var _ = Describe("ExtendedSecret", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for generated secret
-			secret, err := env.GetSecret(env.Namespace, "generated-ssh-secret")
+			secret, err := env.CollectSecret(env.Namespace, "generated-ssh-secret")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
 			Expect(secret.Data["public_key"]).To(ContainSubstring("ssh-rsa "))
@@ -131,7 +131,7 @@ var _ = Describe("ExtendedSecret", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for generated secret
-			secret, err := env.GetSecret(env.Namespace, "generated-cert-secret")
+			secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secret.Data["certificate"]).To(ContainSubstring("BEGIN CERTIFICATE"))
 			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))

--- a/integration/extended_statefulset_test.go
+++ b/integration/extended_statefulset_test.go
@@ -173,8 +173,8 @@ var _ = Describe("ExtendedStatefulSet", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for pod
-			err = env.WaitForPods(env.Namespace, "wrongpod=yes")
-			Expect(err).To(HaveOccurred())
+			err = env.WaitForPodFailures(env.Namespace, "wrongpod=yes")
+			Expect(err).NotTo(HaveOccurred())
 
 			ess, err = env.GetExtendedStatefulSet(env.Namespace, ess.GetName())
 			Expect(err).NotTo(HaveOccurred())
@@ -188,8 +188,8 @@ var _ = Describe("ExtendedStatefulSet", func() {
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			// check for pod
-			err = env.WaitForPods(env.Namespace, "wrongpod=yes")
-			Expect(err).To(HaveOccurred())
+			err = env.WaitForPodFailures(env.Namespace, "wrongpod=yes")
+			Expect(err).NotTo(HaveOccurred())
 
 			// check that old statefulset is deleted
 			ess, err = env.GetExtendedStatefulSet(env.Namespace, ess.GetName())

--- a/pkg/testhelper/test_helper.go
+++ b/pkg/testhelper/test_helper.go
@@ -2,6 +2,8 @@
 // pointers to values.
 package testhelper
 
+import "encoding/json"
+
 // Int32 returns a pointer to the int32 value provided
 func Int32(v int32) *int32 {
 	return &v
@@ -20,4 +22,14 @@ func String(v string) *string {
 // Bool returns a pointer to the bool value provided
 func Bool(v bool) *bool {
 	return &v
+}
+
+// IndentedJSON returns data structure pretty printed as JSON
+func IndentedJSON(data interface{}) string {
+	txt, err := json.MarshalIndent(data, "", "    ")
+	if err != nil {
+		return "failed to marshal JSON"
+	}
+
+	return string(txt)
 }


### PR DESCRIPTION
Remove long timeouts from tests

* improve namespace clean up, bin/test-integration doesn't have to wait
  for it.
* report integration test that take more than 50s for being slow.
* add WaitForPodFailures to check for container errors quickly.
* GetSecret fails immediately, CollectSecret waits for secret to appear.
* add debug helper to output indented json.

[#164794393](https://www.pivotaltracker.com/story/show/164794393)