### PR TITLE
EJobs delete pods

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 go.sum
-vendor/
 tmp/
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.12 AS build
 COPY . /go/src/code.cloudfoundry.org/cf-operator
+ARG GO111MODULE="on"
+ENV GO111MODULE $GO111MODULE
 RUN cd /go/src/code.cloudfoundry.org/cf-operator && \
-    GO111MODULE=on make build && \
+    make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 
 FROM opensuse/leap:15.0

--- a/bin/build-image
+++ b/bin/build-image
@@ -17,4 +17,4 @@ fi
 
 set -e
 
-docker build "${GIT_ROOT}" -f "${GIT_ROOT}/Dockerfile" -t ${OPERATOR_DOCKER_ORGANIZATION}/cf-operator:${VERSION_TAG}
+docker build "${GIT_ROOT}" -f "${GIT_ROOT}/Dockerfile" --build-arg GO111MODULE="$GO111MODULE" -t ${OPERATOR_DOCKER_ORGANIZATION}/cf-operator:${VERSION_TAG}

--- a/docs/examples/exjob_auto-errand-deletes-pod.yaml
+++ b/docs/examples/exjob_auto-errand-deletes-pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: ExtendedJob
+metadata:
+  name: deletes-pod-1
+spec:
+  template:
+    metadata:
+      labels:
+        delete: pod
+    spec:
+      containers:
+      - command:
+        - sleep
+        - "5"
+        image: busybox
+        name: busybox
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 1
+  trigger:
+    strategy: once

--- a/pkg/kube/controllers/extendedjob/job_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/job_reconciler.go
@@ -83,8 +83,8 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 	}
 	if parentName == "" {
-		r.log.Errorf("Could not find parent ExtendedJob for Job %s", request.NamespacedName)
-		return reconcile.Result{}, fmt.Errorf("could not find parent ExtendedJob for Job %s", request.NamespacedName)
+		r.log.Errorf("Could not find parent ExtendedJob for Job '%s'", request.NamespacedName)
+		return reconcile.Result{}, fmt.Errorf("could not find parent ExtendedJob for Job '%s'", request.NamespacedName)
 	}
 
 	ej := ejapi.ExtendedJob{}
@@ -96,10 +96,10 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 	// Persist output if needed
 	if !reflect.DeepEqual(ejapi.Output{}, ej.Spec.Output) && ej.Spec.Output != nil {
 		if instance.Status.Succeeded == 1 || (instance.Status.Failed == 1 && ej.Spec.Output.WriteOnFailure) {
-			r.log.Infof("Persisting output of job %s", instance.Name)
+			r.log.Infof("Persisting output of job '%s'", instance.Name)
 			err = r.persistOutput(ctx, instance, ej.Spec.Output)
 			if err != nil {
-				r.log.Errorf("Could not persist output: %s", err)
+				r.log.Errorf("Could not persist output: '%s'", err)
 				return reconcile.Result{}, err
 			}
 		} else if instance.Status.Failed == 1 && !ej.Spec.Output.WriteOnFailure {
@@ -111,23 +111,23 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	// Delete Job if it succeeded
 	if instance.Status.Succeeded == 1 {
-		r.log.Infof("Deleting succeeded job %s", instance.Name)
+		r.log.Infof("Deleting succeeded job '%s'", instance.Name)
 		err = r.client.Delete(ctx, instance)
 		if err != nil {
-			r.log.Errorf("Cannot delete succeeded job: %s", err)
+			r.log.Errorf("Cannot delete succeeded job: '%s'", err)
 		}
 
 		if d, ok := instance.Spec.Template.Labels["delete"]; ok {
 			if d == "pod" {
 				pod, err := r.jobPod(ctx, instance.Name, instance.GetNamespace())
 				if err != nil {
-					r.log.Errorf("Cannot find job's pod: %s", err)
+					r.log.Errorf("Cannot find job's pod: '%s'", err)
 					return reconcile.Result{}, nil
 				}
 				r.log.Infof("Deleting succeeded job's pod '%s'", pod.Name)
 				err = r.client.Delete(ctx, pod)
 				if err != nil {
-					r.log.Errorf("Cannot delete succeeded job's pod: %s", err)
+					r.log.Errorf("Cannot delete succeeded job's pod: '%s'", err)
 				}
 			}
 		}

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -958,6 +958,26 @@ func (c *Catalog) InterpolateBOSHDeployment(name, manifestRef, opsRef string, se
 	}
 }
 
+// LabelTriggeredExtendedJob allows customization of labels triggers
+func (c *Catalog) LabelTriggeredExtendedJob(name string, state ejv1.PodState, ml labels.Set, me []*ejv1.Requirement, cmd []string) *ejv1.ExtendedJob {
+	return &ejv1.ExtendedJob{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: ejv1.ExtendedJobSpec{
+			Trigger: ejv1.Trigger{
+				Strategy: "podstate",
+				PodState: &ejv1.PodStateTrigger{
+					When: state,
+					Selector: &ejv1.Selector{
+						MatchLabels:      &ml,
+						MatchExpressions: me,
+					},
+				},
+			},
+			Template: c.CmdPodTemplate(cmd),
+		},
+	}
+}
+
 // DefaultExtendedJob default values
 func (c *Catalog) DefaultExtendedJob(name string) *ejv1.ExtendedJob {
 	return c.LabelTriggeredExtendedJob(
@@ -1035,26 +1055,6 @@ func (c *Catalog) OutputExtendedJob(name string, template corev1.PodTemplateSpec
 				OutputType:   "json",
 				SecretLabels: map[string]string{"label-key": "label-value", "label-key2": "label-value2"},
 			},
-		},
-	}
-}
-
-// LabelTriggeredExtendedJob allows customization of labels triggers
-func (c *Catalog) LabelTriggeredExtendedJob(name string, state ejv1.PodState, ml labels.Set, me []*ejv1.Requirement, cmd []string) *ejv1.ExtendedJob {
-	return &ejv1.ExtendedJob{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: ejv1.ExtendedJobSpec{
-			Trigger: ejv1.Trigger{
-				Strategy: "podstate",
-				PodState: &ejv1.PodStateTrigger{
-					When: state,
-					Selector: &ejv1.Selector{
-						MatchLabels:      &ml,
-						MatchExpressions: me,
-					},
-				},
-			},
-			Template: c.CmdPodTemplate(cmd),
 		},
 	}
 }


### PR DESCRIPTION
EJobs can now delete the pod  of a successful job, if the label 'delete' is set to 'pod' in the ejobs pod template.

Using `delete: yes` or `delete: true` turns into a boolean and seems to break controller runtimes expectations:
`sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1alpha1.ExtendedJob: v1alpha1.ExtendedJobList.Items: []v1alpha1.ExtendedJob: v1alpha1.ExtendedJob.Spec: v1alpha1.ExtendedJobSpec.Template: v1.PodTemplateSpec.ObjectMeta: v1.ObjectMeta.Labels: ReadString: expects " or n, but found t, error found in #10 byte of ...|"delete":true}},"spe|..., bigger context ...|pec":{"template":{"metadata":{"labels":{"delete":true}},"spec":{"containers":[{"command":["sleep","5|...`

Maybe `delete: "true"` is possible, but seems error-prone for the user.

[#164729061](https://www.pivotaltracker.com/story/show/164729061)