### PR TITLE
Fix BOSHDeployment reconcile

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -116,5 +116,35 @@ instance-group:
 password: |
   fake-password`))
 		})
+
+		It("should show a json format", func() {
+			wd, err := os.Getwd()
+			Expect(err).ToNot(HaveOccurred())
+
+			manifestPath := filepath.Join(wd, "../testing/assets/manifest.yaml")
+			varsDir := filepath.Join(wd, "../testing/assets/vars")
+
+			session, err := act("variable-interpolation", "-m", manifestPath, "-v", varsDir, "-f", "json")
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session.Out).Should(Say(`{"instance-group":{"key1":"baz\\n","key2":"foo\\n","key3":"bar\\n"},"password":"fake-password\\n"}`))
+		})
+
+		It("should show a encode format", func() {
+			wd, err := os.Getwd()
+			Expect(err).ToNot(HaveOccurred())
+
+			manifestPath := filepath.Join(wd, "../testing/assets/manifest.yaml")
+			varsDir := filepath.Join(wd, "../testing/assets/vars")
+
+			session, err := act("variable-interpolation", "-m", manifestPath, "-v", varsDir, "-f", "encode")
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session.Out).Should(Say(`{"interpolated-manifest":"aW5zdGFuY2UtZ3JvdXA6CiAga2V5MTogfAogICAgYmF6CiAga2V5MjogfAogICAgZm9vCiAga2V5MzogfAogICAgYmFyCnBhc3N3b3JkOiB8CiAgZmFrZS1wYXNzd29yZAo="}`))
+
+			encodeKey := "e2e-manifest"
+			session, err = act("variable-interpolation", "-m", manifestPath, "-v", varsDir, "-f", "encode", "--encode-key", encodeKey)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session.Out).Should(Say(`{"` + encodeKey + `":"aW5zdGFuY2UtZ3JvdXA6CiAga2V5MTogfAogICAgYmF6CiAga2V5MjogfAogICAgZm9vCiAga2V5MzogfAogICAgYmFyCnBhc3N3b3JkOiB8CiAgZmFrZS1wYXNzd29yZAo="}`))
+
+		})
 	})
 })

--- a/pkg/kube/apis/boshdeployment/v1alpha1/types.go
+++ b/pkg/kube/apis/boshdeployment/v1alpha1/types.go
@@ -14,11 +14,12 @@ import (
 
 // Valid values for ref types
 const (
-	ManifestSpecName string = "manifest"
-	OpsSpecName      string = "ops"
-	ConfigMapType    string = "configmap"
-	SecretType       string = "secret"
-	URLType          string = "url"
+	ManifestSpecName        string = "manifest"
+	OpsSpecName             string = "ops"
+	ConfigMapType           string = "configmap"
+	SecretType              string = "secret"
+	URLType                 string = "url"
+	InterpolatedManifestKey string = "interpolated-manifest.yaml"
 )
 
 var (

--- a/pkg/kube/controllers/boshdeployment/reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/reconciler.go
@@ -336,6 +336,7 @@ func (r *ReconcileBOSHDeployment) createVariableInterpolationExJob(ctx context.C
 		if err != nil {
 			return errors.Wrap(err, "could not create temp manifest secret")
 		}
+		foundSecret = tempManifestSecret
 	} else {
 		foundSecret.Data = map[string][]byte{}
 		foundSecret.StringData = map[string]string{


### PR DESCRIPTION
1. Fixed empty manifest secret issue when creaing variables-interpolation-job: 
    ```
    Failed to create job 'variables-interpolation-job': Job.batch "job-variablesinterpolationjob-72d7d756cf4ffbdb" is invalid: [spec.template.spec.volumes[0].secret.secretName: Required value, spec.template.spec.volumes[0].name: Required value, spec.template.spec.containers[0].volumeMounts[0].name: Required value, spec.template.spec.containers[0].volumeMounts[0].name: Not found: ""]
    ```

2. Supported encode format for variable interpolation command
    After using cf-operator as entrypoint, the job could not reach succeeded.
    ```
    $ kubectl logs job-variablesinterpolationjob-9497e41eaeccfd2b-tntnv
    Error: unknown command "variable-interpolation --manifest /var/run/secrets/manifest.yaml --variables-dir /var/run/secrets/variables | base64 | tr -d '\n' | echo \"{\\\"interpolated-manifest.yaml\\\":\\\"$(</dev/stdin)\\\"}\"" for "cf-operator"
    ```
    So I moved base64 encoding processing to var-init command.


Thanks
