### PR TITLE
Qu1queee/165014546 bpm per job

### DIFF
--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -3,13 +3,15 @@ package cmd_test
 import (
 	"fmt"
 
-	. "code.cloudfoundry.org/cf-operator/cmd/internal"
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
-	"code.cloudfoundry.org/cf-operator/testing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/zap"
+
+	. "code.cloudfoundry.org/cf-operator/cmd/internal"
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
+	"code.cloudfoundry.org/cf-operator/testing"
 )
 
 var _ = Describe("Dgather", func() {
@@ -19,6 +21,11 @@ var _ = Describe("Dgather", func() {
 		env testing.Catalog
 		log *zap.SugaredLogger
 	)
+
+	BeforeEach(func() {
+		m = env.ElaboratedBOSHManifest()
+		_, log = helper.NewTestLogger()
+	})
 
 	Context("helper functions to override job specs from manifest", func() {
 		It("should find a property value in the manifest job properties section (constructed example)", func() {
@@ -149,9 +156,6 @@ var _ = Describe("Dgather", func() {
 	Context("resolve links between providers and consumers", func() {
 		BeforeEach(func() {
 			m = env.BOSHManifestWithProviderAndConsumer()
-			logger := zap.NewNop()
-			defer logger.Sync()
-			log = logger.Sugar()
 		})
 
 		It("should get all required data if the job consumes a link", func() {
@@ -197,12 +201,8 @@ var _ = Describe("Dgather", func() {
 	})
 
 	Context("rendering ERB files", func() {
-
 		BeforeEach(func() {
 			m = env.BOSHManifestWithProviderAndConsumer()
-			logger := zap.NewNop()
-			defer logger.Sync()
-			log = logger.Sugar()
 		})
 
 		It("should render complex ERB files", func() {
@@ -215,7 +215,7 @@ var _ = Describe("Dgather", func() {
 			jobBoshContainerizationPropertiesInstances := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.Instances
 			Expect(len(jobBoshContainerizationPropertiesInstances)).To(Equal(4))
 
-			Expect(jobBoshContainerizationPropertiesInstances[0].Fingerprint).ToNot(BeEmpty())
+			Expect(jobBoshContainerizationPropertiesInstances[0].Fingerprint).To(BeNil())
 
 			// in ERB files, there are test environment variables like these:
 			//   FOOBARWITHLINKVALUES: <%= link('doppler').p("fooprop") %>

--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -206,8 +206,6 @@ var _ = Describe("Dgather", func() {
 			jobBoshContainerizationPropertiesInstances := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.Instances
 			Expect(len(jobBoshContainerizationPropertiesInstances)).To(Equal(4))
 
-			propertiesInstance := jobBoshContainerizationPropertiesInstances[0]
-
 			// in ERB files, there are test environment variables like these:
 			//   FOOBARWITHLINKVALUES: <%= link('doppler').p("fooprop") %>
 			//   FOOBARWITHLINKNESTEDVALUES: <%= link('doppler').p("doppler.grpc_port") %>
@@ -217,7 +215,7 @@ var _ = Describe("Dgather", func() {
 			//   ...
 
 			// For the first instance
-			bpmProcesses := propertiesInstance.BPM.Processes[0]
+			bpmProcesses := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
 
 			Expect(bpmProcesses.Env["FOOBARWITHLINKVALUES"]).To(Equal("10001"))
 			Expect(bpmProcesses.Env["FOOBARWITHLINKNESTEDVALUES"]).To(Equal("7765"))
@@ -227,19 +225,16 @@ var _ = Describe("Dgather", func() {
 			Expect(bpmProcesses.Env["FOOBARWITHSPECDEPLOYMENT"]).To(Equal("cf"))
 
 			// For the second instance
-			propertiesInstance = jobBoshContainerizationPropertiesInstances[1]
-			bpmProcesses = propertiesInstance.BPM.Processes[0]
-			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-1-loggregator_trafficcontroller.default.svc.cluster.local"))
+			bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
+			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
 
 			// For the third instance
-			propertiesInstance = jobBoshContainerizationPropertiesInstances[2]
-			bpmProcesses = propertiesInstance.BPM.Processes[0]
-			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-2-loggregator_trafficcontroller.default.svc.cluster.local"))
+			bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
+			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
 
 			// For the fourth instance
-			propertiesInstance = jobBoshContainerizationPropertiesInstances[3]
-			bpmProcesses = propertiesInstance.BPM.Processes[0]
-			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-3-loggregator_trafficcontroller.default.svc.cluster.local"))
+			bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
+			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
 		})
 	})
 })

--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -206,6 +206,8 @@ var _ = Describe("Dgather", func() {
 			jobBoshContainerizationPropertiesInstances := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.Instances
 			Expect(len(jobBoshContainerizationPropertiesInstances)).To(Equal(4))
 
+			Expect(jobBoshContainerizationPropertiesInstances[0].Fingerprint).ToNot(BeEmpty())
+
 			// in ERB files, there are test environment variables like these:
 			//   FOOBARWITHLINKVALUES: <%= link('doppler').p("fooprop") %>
 			//   FOOBARWITHLINKNESTEDVALUES: <%= link('doppler').p("doppler.grpc_port") %>
@@ -235,6 +237,7 @@ var _ = Describe("Dgather", func() {
 			// For the fourth instance
 			bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
 			Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
+
 		})
 	})
 })

--- a/cmd/internal/dgather_test.go
+++ b/cmd/internal/dgather_test.go
@@ -215,8 +215,6 @@ var _ = Describe("Dgather", func() {
 			jobBoshContainerizationPropertiesInstances := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.Instances
 			Expect(len(jobBoshContainerizationPropertiesInstances)).To(Equal(4))
 
-			Expect(jobBoshContainerizationPropertiesInstances[0].Fingerprint).To(BeNil())
-
 			// in ERB files, there are test environment variables like these:
 			//   FOOBARWITHLINKVALUES: <%= link('doppler').p("fooprop") %>
 			//   FOOBARWITHLINKNESTEDVALUES: <%= link('doppler').p("doppler.grpc_port") %>

--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -844,10 +844,10 @@ func (m *Manifest) ApplyBPMInfo(kubeConfig *KubeConfig, allResolvedProperties ma
 		if len(boshJob.Properties.BOSHContainerization.Instances) < 1 {
 			return errors.New("containerization data has no instances")
 		}
-		if len(boshJob.Properties.BOSHContainerization.Instances[0].BPM.Processes) < 1 {
+		if len(boshJob.Properties.BOSHContainerization.BPM.Processes) < 1 {
 			return errors.New("bpm info has no processes")
 		}
-		process := boshJob.Properties.BOSHContainerization.Instances[0].BPM.Processes[0]
+		process := boshJob.Properties.BOSHContainerization.BPM.Processes[0]
 
 		container.Command = []string{process.Executable}
 		container.Args = process.Args

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -12,7 +12,6 @@ type JobInstance struct {
 	Index       int                    `yaml:"index"`
 	Instance    int                    `yaml:"instance"`
 	Name        string                 `yaml:"name"`
-	BPM         bpm.Config             `yaml:"bpm"`
 	Fingerprint interface{}            `yaml:"fingerprint"`
 	Network     map[string]interface{} `yaml:"networks"`
 	IP          string                 `yaml:"ip"`

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -6,15 +6,14 @@ import (
 
 // JobInstance for data gathering
 type JobInstance struct {
-	Address     string                 `yaml:"address"`
-	AZ          string                 `yaml:"az"`
-	ID          string                 `yaml:"id"`
-	Index       int                    `yaml:"index"`
-	Instance    int                    `yaml:"instance"`
-	Name        string                 `yaml:"name"`
-	Fingerprint interface{}            `yaml:"fingerprint"`
-	Network     map[string]interface{} `yaml:"networks"`
-	IP          string                 `yaml:"ip"`
+	Address  string                 `yaml:"address"`
+	AZ       string                 `yaml:"az"`
+	ID       string                 `yaml:"id"`
+	Index    int                    `yaml:"index"`
+	Instance int                    `yaml:"instance"`
+	Name     string                 `yaml:"name"`
+	Network  map[string]interface{} `yaml:"networks"`
+	IP       string                 `yaml:"ip"`
 }
 
 // Link with name for rendering


### PR DESCRIPTION

Modify job BPM rendering:
- Avoid adding a BPM object per job instance
- Generate a single BPM object per job
- Validate if all job instances have the same BPM object. This will be
  processed for validation, but at the end, the job instance will not
  stick with a BPM object.
- Refactor test cases for BPM rendering.
- Work some pending TODO´s.

@viovanov could you take a look on this, if this is the intended behaviour, I will then add another commit to modify the docs.