### PR TITLE
Variable secrets labelled `generated` can be overwritten

### DIFF
--- a/docs/examples/boshdeployment-with-customed-variable.yaml
+++ b/docs/examples/boshdeployment-with-customed-variable.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-manifest
+data:
+  manifest: |
+    ---
+    name: nats-manifest
+    releases:
+    - name: nats
+      version: "26"
+      url: docker.io/cfcontainerization
+      stemcell:
+        os: opensuse-42.3
+        version: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+    instance_groups:
+    - name: nats
+      instances: 1
+      jobs:
+      - name: nats
+        release: nats
+        properties:
+          nats:
+            user: admin
+            password: ((nats_password))
+            customed_password: ((customed_password))
+    variables:
+    - name: nats_password
+      type: password
+    - name: customed_password
+      type: password
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-foo
+data:
+  ops: |
+    - type: replace
+      path: /instance_groups/name=nats?/instances
+      value: 2
+---
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: BOSHDeployment
+metadata:
+  name: nats-manifest
+spec:
+  manifest:
+    ref: nats-manifest
+    type: configmap
+  ops:
+  - ref: ops-foo
+    type: configmap
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nats-manifest.var-customed-password
+type: Opaque
+stringData:
+  password: customed_password

--- a/pkg/kube/apis/extendedsecret/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedsecret/v1alpha1/types.go
@@ -1,7 +1,11 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
 )
 
 // This file is safe to edit
@@ -17,6 +21,11 @@ const (
 	Certificate Type = "certificate"
 	SSHKey      Type = "ssh"
 	RSAKey      Type = "rsa"
+)
+
+var (
+	// LabelKind is the label key for secret kind
+	LabelKind = fmt.Sprintf("%s/secret-kind", apis.GroupName)
 )
 
 // SecretReference specifies a reference to another secret


### PR DESCRIPTION
From the description, ExtendedSecert reconciler should run as below:

* Check if the secret was already created and then check if this secret could be generated
  * If the secret  was created **and** could not be generated,  reconciler skip reconciling
  * If the secret  was not created **or** could be generated,  reconciler would create/overwrite a new secret

[#165054299](https://www.pivotaltracker.com/story/show/165054299)

Thanks