### PR TITLE
Simplify code for data gathering and rendering, by:

### DIFF
--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -295,7 +295,7 @@ func (m *Manifest) dataGatheringJob(namespace string) (*ejv1.ExtendedJob, error)
 			}
 			// Create an init container that copies sources
 			// TODO: destination should also contain release name, to prevent overwrites
-			initContainers = append(initContainers, m.JobSpecCopierContainer(boshJob.Name, releaseName, releaseImage, generateVolumeName("data-gathering")))
+			initContainers = append(initContainers, m.JobSpecCopierContainer(releaseName, releaseImage, generateVolumeName("data-gathering")))
 		}
 
 		// One container per Instance Group
@@ -409,7 +409,7 @@ func (m *Manifest) jobsToInitContainers(igName string, jobs []Job, namespace str
 		if err != nil {
 			return []v1.Container{}, err
 		}
-		initContainers = append(initContainers, m.JobSpecCopierContainer(job.Name, job.Release, releaseImage, "rendering-data"))
+		initContainers = append(initContainers, m.JobSpecCopierContainer(job.Release, releaseImage, "rendering-data"))
 
 	}
 
@@ -863,11 +863,11 @@ func (m *Manifest) ApplyBPMInfo(kubeConfig *KubeConfig, allResolvedProperties ma
 }
 
 // JobSpecCopierContainer will return a v1.Container{} with the populated field
-func (m *Manifest) JobSpecCopierContainer(containerName string, releaseName string, releaseImage string, volumeMountName string) v1.Container {
+func (m *Manifest) JobSpecCopierContainer(releaseName string, releaseImage string, volumeMountName string) v1.Container {
 
 	inContainerReleasePath := filepath.Join("/var/vcap/all-releases/jobs-src", releaseName)
 	initContainers := v1.Container{
-		Name:  fmt.Sprintf("spec-copier-%s", containerName),
+		Name:  fmt.Sprintf("spec-copier-%s", releaseName),
 		Image: releaseImage,
 		VolumeMounts: []v1.VolumeMount{
 			{

--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -288,31 +288,14 @@ func (m *Manifest) dataGatheringJob(namespace string) (*ejv1.ExtendedJob, error)
 			}
 			doneSpecCopyingReleases[releaseName] = true
 
-			inContainerReleasePath := filepath.Join("/var/vcap/data-gathering/jobs-src/", releaseName)
-
 			// Get the docker image for the release
 			releaseImage, err := m.GetReleaseImage(ig.Name, boshJob.Name)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to calculate release image for data gathering")
 			}
-
 			// Create an init container that copies sources
 			// TODO: destination should also contain release name, to prevent overwrites
-			initContainers = append(initContainers, v1.Container{
-				Name:  fmt.Sprintf("spec-copier-%s", releaseName),
-				Image: releaseImage,
-				VolumeMounts: []v1.VolumeMount{
-					{
-						Name:      generateVolumeName("data-gathering"),
-						MountPath: "/var/vcap/data-gathering",
-					},
-				},
-				Command: []string{
-					"bash",
-					"-c",
-					fmt.Sprintf(`mkdir -p "%s" && cp -ar /var/vcap/jobs-src/* "%s"`, inContainerReleasePath, inContainerReleasePath),
-				},
-			})
+			initContainers = append(initContainers, m.JobSpecCopierContainer(boshJob.Name, releaseName, releaseImage, generateVolumeName("data-gathering")))
 		}
 
 		// One container per Instance Group
@@ -330,7 +313,7 @@ func (m *Manifest) dataGatheringJob(namespace string) (*ejv1.ExtendedJob, error)
 				},
 				{
 					Name:      generateVolumeName("data-gathering"),
-					MountPath: "/var/vcap/data-gathering",
+					MountPath: "/var/vcap/all-releases",
 				},
 			},
 			Env: []v1.EnvVar{
@@ -344,7 +327,7 @@ func (m *Manifest) dataGatheringJob(namespace string) (*ejv1.ExtendedJob, error)
 				},
 				{
 					Name:  "BASE_DIR",
-					Value: "/var/vcap/data-gathering",
+					Value: "/var/vcap/all-releases",
 				},
 				{
 					Name:  "INSTANCE_GROUP_NAME",
@@ -426,19 +409,8 @@ func (m *Manifest) jobsToInitContainers(igName string, jobs []Job, namespace str
 		if err != nil {
 			return []v1.Container{}, err
 		}
+		initContainers = append(initContainers, m.JobSpecCopierContainer(job.Name, job.Release, releaseImage, "rendering-data"))
 
-		inContainerReleasePath := filepath.Join("/var/vcap/rendering/jobs-src/", job.Release)
-		initContainers = append(initContainers, v1.Container{
-			Name:  fmt.Sprintf("spec-copier-%s", job.Name),
-			Image: releaseImage,
-			VolumeMounts: []v1.VolumeMount{
-				{
-					Name:      "rendering-data",
-					MountPath: "/var/vcap/rendering",
-				},
-			},
-			Command: []string{"bash", "-c", fmt.Sprintf(`mkdir -p "%s" && cp -ar /var/vcap/jobs-src/* "%s"`, inContainerReleasePath, inContainerReleasePath)},
-		})
 	}
 
 	_, resolvedPropertiesSecretName := m.CalculateEJobOutputSecretPrefixAndName(
@@ -450,7 +422,7 @@ func (m *Manifest) jobsToInitContainers(igName string, jobs []Job, namespace str
 	volumeMounts := []v1.VolumeMount{
 		{
 			Name:      "rendering-data",
-			MountPath: "/var/vcap/rendering",
+			MountPath: "/var/vcap/all-releases",
 		},
 		{
 			Name:      "jobs-dir",
@@ -478,7 +450,7 @@ func (m *Manifest) jobsToInitContainers(igName string, jobs []Job, namespace str
 			},
 			{
 				Name:  "JOBS_DIR",
-				Value: "/var/vcap/rendering",
+				Value: "/var/vcap/all-releases",
 			},
 		},
 		Command: []string{"/bin/sh"},
@@ -507,7 +479,7 @@ func (m *Manifest) jobsToContainers(igName string, jobs []Job, namespace string)
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "rendering-data",
-					MountPath: "/var/vcap/rendering",
+					MountPath: "/var/vcap/all-releases",
 				},
 				{
 					Name:      "jobs-dir",
@@ -888,4 +860,27 @@ func (m *Manifest) ApplyBPMInfo(kubeConfig *KubeConfig, allResolvedProperties ma
 		}
 	}
 	return nil
+}
+
+// JobSpecCopierContainer will return a v1.Container{} with the populated field
+func (m *Manifest) JobSpecCopierContainer(containerName string, releaseName string, releaseImage string, volumeMountName string) v1.Container {
+
+	inContainerReleasePath := filepath.Join("/var/vcap/all-releases/jobs-src", releaseName)
+	initContainers := v1.Container{
+		Name:  fmt.Sprintf("spec-copier-%s", containerName),
+		Image: releaseImage,
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      volumeMountName,
+				MountPath: "/var/vcap/all-releases",
+			},
+		},
+		Command: []string{
+			"bash",
+			"-c",
+			fmt.Sprintf(`mkdir -p "%s" && cp -ar /var/vcap/jobs-src/* "%s"`, inContainerReleasePath, inContainerReleasePath),
+		},
+	}
+
+	return initContainers
 }

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -105,6 +105,19 @@ var _ = Describe("ConvertToKube", func() {
 		})
 	})
 
+	Context("when invoking the data gathering job", func() {
+		It("verify job init containers fields", func() {
+			kubeConfig, err := m.ConvertToKube("foo")
+			Expect(err).ShouldNot(HaveOccurred())
+			jobDG := kubeConfig.DataGatheringJob.Spec.Template.Spec
+			// Test init containers in the datagathering job
+			Expect(jobDG.InitContainers[0].Name).To(Equal("spec-copier-redis-server"))
+			Expect(jobDG.InitContainers[1].Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
+			Expect(jobDG.InitContainers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
+			Expect(jobDG.InitContainers[1].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
+		})
+	})
+
 	Context("when the lifecycle is set to service", func() {
 		It("converts the instance group to an ExtendedStatefulset", func() {
 			kubeConfig, err := m.ConvertToKube("foo")
@@ -121,6 +134,7 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(anExtendedSts.Spec.Containers[0].Name).To(Equal("cflinuxfs3-rootfs-setup"))
 
 			// Test init containers in the extended statefulset
+			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
 			Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/cflinuxfs3:opensuse-15.0-28.g837c5b3-30.263-7.0.0_233.gde0accd0-0.62.0"))
 			Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
 			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
@@ -129,17 +143,17 @@ var _ = Describe("ConvertToKube", func() {
 
 			// Test shared volume setup
 			Expect(anExtendedSts.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(anExtendedSts.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(anExtendedSts.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(specCopierInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 
 			// Test the renderer container setup
 			Expect(rendererInitContainer.Env[0].Name).To(Equal("INSTANCE_GROUP_NAME"))
 			Expect(rendererInitContainer.Env[0].Value).To(Equal("diego-cell"))
 			Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(rendererInitContainer.VolumeMounts[1].Name).To(Equal("jobs-dir"))
 			Expect(rendererInitContainer.VolumeMounts[1].MountPath).To(Equal("/var/vcap/jobs"))
 			Expect(rendererInitContainer.VolumeMounts[2].Name).To(Equal("ig-resolved"))
@@ -166,6 +180,7 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(anExtendedJob.Spec.Template.Spec.Containers[0].Command).To(BeNil())
 
 			// Test init containers in the extended job
+			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis-server"))
 			Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
 			Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
 			Expect(rendererInitContainer.Image).To(Equal("/:"))
@@ -173,11 +188,11 @@ var _ = Describe("ConvertToKube", func() {
 
 			// Test shared volume setup
 			Expect(anExtendedJob.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(anExtendedJob.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(anExtendedJob.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(specCopierInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
-			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/rendering"))
+			Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 
 			// Test mounting the resolved instance group properties in the renderer container
 			Expect(rendererInitContainer.Env[0].Name).To(Equal("INSTANCE_GROUP_NAME"))

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -111,8 +111,8 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			jobDG := kubeConfig.DataGatheringJob.Spec.Template.Spec
 			// Test init containers in the datagathering job
-			Expect(jobDG.InitContainers[0].Name).To(Equal("spec-copier-redis-server"))
-			Expect(jobDG.InitContainers[1].Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
+			Expect(jobDG.InitContainers[0].Name).To(Equal("spec-copier-redis"))
+			Expect(jobDG.InitContainers[1].Name).To(Equal("spec-copier-cflinuxfs3"))
 			Expect(jobDG.InitContainers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 			Expect(jobDG.InitContainers[1].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 		})
@@ -134,10 +134,10 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(anExtendedSts.Spec.Containers[0].Name).To(Equal("cflinuxfs3-rootfs-setup"))
 
 			// Test init containers in the extended statefulset
-			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
+			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 			Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/cflinuxfs3:opensuse-15.0-28.g837c5b3-30.263-7.0.0_233.gde0accd0-0.62.0"))
 			Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
-			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3-rootfs-setup"))
+			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 			Expect(rendererInitContainer.Image).To(Equal("/:"))
 			Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))
 
@@ -180,7 +180,7 @@ var _ = Describe("ConvertToKube", func() {
 			Expect(anExtendedJob.Spec.Template.Spec.Containers[0].Command).To(BeNil())
 
 			// Test init containers in the extended job
-			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis-server"))
+			Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis"))
 			Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
 			Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
 			Expect(rendererInitContainer.Image).To(Equal("/:"))


### PR DESCRIPTION
- Appending to initContainers via a single method
- Remove duplication of code
- Add missing test cases for the initContainers of the data
  gathering kubeConverter job