### PR TITLE
Services configuration for instance groups

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -152,7 +152,7 @@ Our Concourse pipeline definitions are kept in the [cf-operator-ci](https://gith
 
 ## Create-Or-Update pattern
 
-A pattern that comes up quite often is that an object needs to be updated if it already exists or created if it doesn't. `controller-runtime` provides the `controller-util` package which has a `CreateOrUpdate` function that can help with that. It takes a skeleton object and a reconcile function that is caleld in both the create and the update case:
+A pattern that comes up quite often is that an object needs to be updated if it already exists or created if it doesn't. `controller-runtime` provides the `controller-util` package which has a `CreateOrUpdate` function that can help with that. It takes a skeleton object and a reconcile function that is called in both the create and the update case:
 
 ```go
 tempManifestSecret := &corev1.Secret{

--- a/docs/examples/bosh-deployment/boshdeployment.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment.yaml
@@ -24,6 +24,11 @@ data:
           nats:
             user: admin
             password: ((nats_password))
+          bosh_containerization:
+            ports:
+            - name: "nats"
+              protocol: "TCP"
+              internal: 4222
     variables:
     - name: nats_password
       type: password

--- a/docs/examples/bosh-deployment/boshdeployment.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment.yaml
@@ -29,6 +29,9 @@ data:
             - name: "nats"
               protocol: "TCP"
               internal: 4222
+            - name: "nats-routes"
+              protocol: TCP
+              internal: 4223
     variables:
     - name: nats_password
       type: password

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,6 +58,10 @@ the interface used for the default route:
 
     export CF_OPERATOR_WEBHOOK_HOST=$(ip -4 a s dev `ip r l 0/0 | cut -f5 -d' '` | grep -oP 'inet \K\S+(?=/)')
 
+And in case of minikube on Darwin, using following command to export the IP:
+
+    export CF_OPERATOR_WEBHOOK_HOST=$(ifconfig `route -n get 0.0.0.0 2>/dev/null | awk '/interface: / {print $2}'` | awk '/inet /{gsub(/\//," ");print $2}')
+
 ### Upload Operator Image
 
 Template rendering for BOSH jobs is done at deployment time by the operator

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"code.cloudfoundry.org/cf-operator/integration/environment"
+	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 )
 
 var _ = Describe("Deploy", func() {
@@ -38,7 +39,7 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
 			Expect(svc.Spec.Ports)
 			Expect(svc.Spec.Selector).To(Equal(map[string]string{
-				"instance-group": "nats",
+				bdm.LabelInstanceGroupName: "nats",
 			}))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -9,13 +9,15 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/integration/environment"
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
 )
 
 var _ = Describe("Deploy", func() {
 	Context("when correctly setup", func() {
 		podName := "test-nats-v1-0"
 		stsName := "test-nats-v1"
-		svcName := "test-nats-headless"
+		headlessSvcName := "test-nats"
+		clusterIpSvcName := "test-nats-0"
 
 		AfterEach(func() {
 			Expect(env.WaitForPodsDelete(env.Namespace)).To(Succeed())
@@ -34,12 +36,24 @@ var _ = Describe("Deploy", func() {
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for pod from deployment")
 
-			// check for service
-			svc, err := env.GetService(env.Namespace, svcName)
+			// check for services
+			svc, err := env.GetService(env.Namespace, headlessSvcName)
 			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
 			Expect(svc.Spec.Ports)
 			Expect(svc.Spec.Selector).To(Equal(map[string]string{
 				bdm.LabelInstanceGroupName: "nats",
+			}))
+			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
+			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(4222)))
+
+			svc, err = env.GetService(env.Namespace, clusterIpSvcName)
+			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
+			Expect(svc.Spec.Ports)
+			Expect(svc.Spec.Selector).To(Equal(map[string]string{
+				bdm.LabelInstanceGroupName: "nats",
+				essv1.LabelAZIndex:         "0",
+				essv1.LabelPodOrdinal:      "0",
 			}))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -894,3 +894,13 @@ func (m *Machine) TearDownAll(funcs []TearDownFunc) error {
 	}
 	return nil
 }
+
+// GetService gets target Service
+func (m *Machine) GetService(namespace string, name string) (*corev1.Service, error) {
+	svc, err := m.Clientset.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return svc, errors.Wrapf(err, "failed to get service '%s'", svc)
+	}
+
+	return svc, nil
+}

--- a/integration/lifecycle_test.go
+++ b/integration/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"code.cloudfoundry.org/cf-operator/integration/environment"
+	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdcv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 )
 
@@ -38,7 +39,7 @@ var _ = Describe("Lifecycle", func() {
 			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
 			Expect(svc.Spec.Ports)
 			Expect(svc.Spec.Selector).To(Equal(map[string]string{
-				"instance-group": "nats",
+				bdm.LabelInstanceGroupName: "nats",
 			}))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))

--- a/integration/lifecycle_test.go
+++ b/integration/lifecycle_test.go
@@ -1,11 +1,12 @@
 package integration_test
 
 import (
-	"code.cloudfoundry.org/cf-operator/integration/environment"
-	bdcv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"code.cloudfoundry.org/cf-operator/integration/environment"
+	bdcv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 )
 
 var _ = Describe("Lifecycle", func() {
@@ -31,6 +32,17 @@ var _ = Describe("Lifecycle", func() {
 
 			err = env.WaitForPod(env.Namespace, "testcr-nats-v1-0")
 			Expect(err).NotTo(HaveOccurred(), "error waiting for pod from initial deployment")
+
+			// check for service
+			svc, err := env.GetService(env.Namespace, "testcr-nats-headless")
+			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
+			Expect(svc.Spec.Ports)
+			Expect(svc.Spec.Selector).To(Equal(map[string]string{
+				"instance-group": "nats",
+			}))
+			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
+			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(4222)))
 		})
 	})
 

--- a/pkg/bosh/manifest/data_gatherer.go
+++ b/pkg/bosh/manifest/data_gatherer.go
@@ -150,7 +150,7 @@ func (dg *DataGatherer) CollectReleaseSpecsAndProviderLinks(baseDir string) (map
 			// Generate instance spec for each ig instance
 			// This will be stored inside the current job under
 			// job.properties.bosh_containerization
-			jobsInstances := jobInstances(dg.namespace, *instanceGroup, job.Name, spec)
+			jobsInstances := jobInstances(dg.namespace, dg.manifest.Name, *instanceGroup, job.Name, spec)
 
 			// set jobs.properties.bosh_containerization.instances with the ig instances
 			instanceGroup.Jobs[jobIdx].Properties.BOSHContainerization.Instances = jobsInstances
@@ -450,12 +450,12 @@ func lookUpJobRelease(releases []*Release, jobRelease string) bool {
 	return false
 }
 
-func jobInstances(namespace string, instanceGroup InstanceGroup, jobName string, spec JobSpec) []JobInstance {
+func jobInstances(namespace string, deploymentName string, instanceGroup InstanceGroup, jobName string, spec JobSpec) []JobInstance {
 	var jobsInstances []JobInstance
 	for i := 0; i < instanceGroup.Instances; i++ {
 
 		// TODO: Understand whether there are negative side-effects to using this
-		// default
+		//   default
 		azs := []string{""}
 		if len(instanceGroup.AZs) > 0 {
 			azs = instanceGroup.AZs
@@ -465,9 +465,11 @@ func jobInstances(namespace string, instanceGroup InstanceGroup, jobName string,
 			index := len(jobsInstances)
 			name := fmt.Sprintf("%s-%s", instanceGroup.Name, jobName)
 			id := fmt.Sprintf("%s-%d-%s", instanceGroup.Name, index, jobName)
+			// All jobs in same instance group will use same service
+			serviceName := fmt.Sprintf("%s-%s-%d", deploymentName, instanceGroup.Name, index)
 
 			// TODO: not allowed to hardcode svc.cluster.local
-			address := fmt.Sprintf("%s.%s.svc.cluster.local", id, namespace)
+			address := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace)
 
 			jobsInstances = append(jobsInstances, JobInstance{
 				Address:  address,

--- a/pkg/bosh/manifest/data_gatherer_test.go
+++ b/pkg/bosh/manifest/data_gatherer_test.go
@@ -121,10 +121,10 @@ var _ = Describe("DataGatherer", func() {
 				jobInstancesRedis := m.InstanceGroups[0].Jobs[0].Properties.BOSHContainerization.Instances
 
 				compareToFakeRedis := []JobInstance{
-					{Address: "redis-slave-0-redis-server.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-0-redis-server", Index: 0, Instance: 0, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-1-redis-server.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-1-redis-server", Index: 1, Instance: 0, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-2-redis-server.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-2-redis-server", Index: 2, Instance: 1, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-3-redis-server.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-3-redis-server", Index: 3, Instance: 1, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-0.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-0-redis-server", Index: 0, Instance: 0, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-1.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-1-redis-server", Index: 1, Instance: 0, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-2.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-2-redis-server", Index: 2, Instance: 1, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-3.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-3-redis-server", Index: 3, Instance: 1, Name: "redis-slave-redis-server"},
 				}
 				Expect(jobInstancesRedis).To(BeEquivalentTo(compareToFakeRedis))
 
@@ -134,10 +134,10 @@ var _ = Describe("DataGatherer", func() {
 				jobInstancesCell := m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.Instances
 
 				compareToFakeCell := []JobInstance{
-					{Address: "diego-cell-0-cflinuxfs3-rootfs-setup.default.svc.cluster.local", AZ: "z1", ID: "diego-cell-0-cflinuxfs3-rootfs-setup", Index: 0, Instance: 0, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
-					{Address: "diego-cell-1-cflinuxfs3-rootfs-setup.default.svc.cluster.local", AZ: "z2", ID: "diego-cell-1-cflinuxfs3-rootfs-setup", Index: 1, Instance: 0, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
-					{Address: "diego-cell-2-cflinuxfs3-rootfs-setup.default.svc.cluster.local", AZ: "z1", ID: "diego-cell-2-cflinuxfs3-rootfs-setup", Index: 2, Instance: 1, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
-					{Address: "diego-cell-3-cflinuxfs3-rootfs-setup.default.svc.cluster.local", AZ: "z2", ID: "diego-cell-3-cflinuxfs3-rootfs-setup", Index: 3, Instance: 1, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
+					{Address: "foo-deployment-diego-cell-0.default.svc.cluster.local", AZ: "z1", ID: "diego-cell-0-cflinuxfs3-rootfs-setup", Index: 0, Instance: 0, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
+					{Address: "foo-deployment-diego-cell-1.default.svc.cluster.local", AZ: "z2", ID: "diego-cell-1-cflinuxfs3-rootfs-setup", Index: 1, Instance: 0, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
+					{Address: "foo-deployment-diego-cell-2.default.svc.cluster.local", AZ: "z1", ID: "diego-cell-2-cflinuxfs3-rootfs-setup", Index: 2, Instance: 1, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
+					{Address: "foo-deployment-diego-cell-3.default.svc.cluster.local", AZ: "z2", ID: "diego-cell-3-cflinuxfs3-rootfs-setup", Index: 3, Instance: 1, Name: "diego-cell-cflinuxfs3-rootfs-setup"},
 				}
 				Expect(jobInstancesCell).To(BeEquivalentTo(compareToFakeCell))
 			})
@@ -147,10 +147,10 @@ var _ = Describe("DataGatherer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(providerLinks)).To(BeEquivalentTo(1))
 				expectedInstances := []JobInstance{
-					{Address: "redis-slave-0-redis-server.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-0-redis-server", Index: 0, Instance: 0, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-1-redis-server.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-1-redis-server", Index: 1, Instance: 0, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-2-redis-server.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-2-redis-server", Index: 2, Instance: 1, Name: "redis-slave-redis-server"},
-					{Address: "redis-slave-3-redis-server.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-3-redis-server", Index: 3, Instance: 1, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-0.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-0-redis-server", Index: 0, Instance: 0, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-1.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-1-redis-server", Index: 1, Instance: 0, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-2.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-2-redis-server", Index: 2, Instance: 1, Name: "redis-slave-redis-server"},
+					{Address: "foo-deployment-redis-slave-3.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-3-redis-server", Index: 3, Instance: 1, Name: "redis-slave-redis-server"},
 				}
 				expectedProperties := map[string]interface{}{
 					"port":     6379,
@@ -192,7 +192,7 @@ var _ = Describe("DataGatherer", func() {
 
 					for i, instance := range jobConsumesFromDoppler.Instances {
 						Expect(instance.Index).To(Equal(i))
-						Expect(instance.Address).To(Equal(fmt.Sprintf("doppler-%v-doppler.default.svc.cluster.local", i)))
+						Expect(instance.Address).To(Equal(fmt.Sprintf("cf-doppler-%v.default.svc.cluster.local", i)))
 						Expect(instance.ID).To(Equal(fmt.Sprintf("doppler-%v-doppler", i)))
 					}
 					Expect(jobConsumesFromDoppler.Properties).To(BeEquivalentTo(expectedProperties))
@@ -240,21 +240,21 @@ var _ = Describe("DataGatherer", func() {
 				Expect(bpmProcesses.Env["FOOBARWITHLINKVALUES"]).To(Equal("10001"))
 				Expect(bpmProcesses.Env["FOOBARWITHLINKNESTEDVALUES"]).To(Equal("7765"))
 				Expect(bpmProcesses.Env["FOOBARWITHLINKINSTANCESAZ"]).To(Equal("z1"))
-				Expect(bpmProcesses.Env["FOOBARWITHLINKINSTANCESADDRESS"]).To(Equal("doppler-0-doppler.default.svc.cluster.local"))
-				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
+				Expect(bpmProcesses.Env["FOOBARWITHLINKINSTANCESADDRESS"]).To(Equal("cf-doppler-0.default.svc.cluster.local"))
+				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("cf-log-api-0.default.svc.cluster.local"))
 				Expect(bpmProcesses.Env["FOOBARWITHSPECDEPLOYMENT"]).To(Equal("cf"))
 
 				// For the second instance
 				bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
-				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
+				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("cf-log-api-0.default.svc.cluster.local"))
 
 				// For the third instance
 				bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
-				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
+				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("cf-log-api-0.default.svc.cluster.local"))
 
 				// For the fourth instance
 				bpmProcesses = m.InstanceGroups[1].Jobs[0].Properties.BOSHContainerization.BPM.Processes[0]
-				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-0-loggregator_trafficcontroller.default.svc.cluster.local"))
+				Expect(bpmProcesses.Env["FOOBARWITHSPECADDRESS"]).To(Equal("cf-log-api-0.default.svc.cluster.local"))
 
 			})
 		})

--- a/pkg/bosh/manifest/kube_converter.go
+++ b/pkg/bosh/manifest/kube_converter.go
@@ -558,7 +558,7 @@ func (m *Manifest) serviceToExtendedSts(ig *InstanceGroup, namespace string) (es
 			Name:      fmt.Sprintf("%s-%s", m.Name, igName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"instance-group": igName,
+				LabelInstanceGroupName: igName,
 			},
 		},
 		Spec: essv1.ExtendedStatefulSetSpec{
@@ -620,13 +620,13 @@ func (m *Manifest) serviceToKubeService(ig *InstanceGroup, eSts *essv1.ExtendedS
 				Name:      names.ServiceName(m.Name, igName),
 				Namespace: namespace,
 				Labels: map[string]string{
-					"instance-group": igName,
+					LabelInstanceGroupName: igName,
 				},
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: ports,
 				Selector: map[string]string{
-					"instance-group": igName,
+					LabelInstanceGroupName: igName,
 				},
 				ClusterIP: "None",
 			},
@@ -725,7 +725,7 @@ func (m *Manifest) errandToExtendedJob(ig *InstanceGroup, namespace string) (ejv
 			Name:      fmt.Sprintf("%s-%s", m.Name, igName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"instance-group": igName,
+				LabelInstanceGroupName: igName,
 			},
 		},
 		Spec: ejv1.ExtendedJobSpec{
@@ -902,7 +902,7 @@ func (m *Manifest) ApplyBPMInfo(kubeConfig *KubeConfig, allResolvedProperties ma
 
 	for idx := range kubeConfig.InstanceGroups {
 		igSts := &(kubeConfig.InstanceGroups[idx])
-		igName := igSts.Labels["instance-group"]
+		igName := igSts.Labels[LabelInstanceGroupName]
 
 		// Go through each container
 		for idx := range igSts.Spec.Template.Spec.Template.Spec.Containers {
@@ -917,7 +917,7 @@ func (m *Manifest) ApplyBPMInfo(kubeConfig *KubeConfig, allResolvedProperties ma
 
 	for idx := range kubeConfig.Errands {
 		igJob := &(kubeConfig.Errands[idx])
-		igName := igJob.Labels["instance-group"]
+		igName := igJob.Labels[LabelInstanceGroupName]
 
 		for idx := range igJob.Spec.Template.Spec.Containers {
 			container := &(igJob.Spec.Template.Spec.Containers[idx])

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/testing"
 )
 
@@ -182,19 +183,80 @@ var _ = Describe("kube converter", func() {
 				Expect(rendererInitContainer.VolumeMounts[2].Name).To(Equal("ig-resolved"))
 				Expect(rendererInitContainer.VolumeMounts[2].MountPath).To(Equal("/var/run/secrets/resolved-properties/diego-cell"))
 
-				// Test the service for the extended statefulSet
-				aService := kubeConfig.Services[0]
-				Expect(aService.Name).To(Equal(fmt.Sprintf("%s-%s-headless", m.Name, anExtendedSts.Name)))
-				Expect(aService.Spec.Selector).To(Equal(map[string]string{
+				// Test services for the extended statefulSet
+				service0 := kubeConfig.Services[0]
+				Expect(service0.Name).To(Equal(fmt.Sprintf("%s-%s-0", m.Name, anExtendedSts.Name)))
+				Expect(service0.Spec.Selector).To(Equal(map[string]string{
 					manifest.LabelInstanceGroupName: anExtendedSts.Name,
+					essv1.LabelAZIndex:              "0",
+					essv1.LabelPodOrdinal:           "0",
 				}))
-				Expect(aService.Spec.Ports).To(Equal([]corev1.ServicePort{
+				Expect(service0.Spec.Ports).To(Equal([]corev1.ServicePort{
 					{
 						Name:     "rep-server",
 						Protocol: corev1.ProtocolTCP,
 						Port:     1801,
 					},
 				}))
+
+				service1 := kubeConfig.Services[1]
+				Expect(service1.Name).To(Equal(fmt.Sprintf("%s-%s-1", m.Name, anExtendedSts.Name)))
+				Expect(service1.Spec.Selector).To(Equal(map[string]string{
+					manifest.LabelInstanceGroupName: anExtendedSts.Name,
+					essv1.LabelAZIndex:              "1",
+					essv1.LabelPodOrdinal:           "0",
+				}))
+				Expect(service1.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:     "rep-server",
+						Protocol: corev1.ProtocolTCP,
+						Port:     1801,
+					},
+				}))
+
+				service2 := kubeConfig.Services[2]
+				Expect(service2.Name).To(Equal(fmt.Sprintf("%s-%s-2", m.Name, anExtendedSts.Name)))
+				Expect(service2.Spec.Selector).To(Equal(map[string]string{
+					manifest.LabelInstanceGroupName: anExtendedSts.Name,
+					essv1.LabelAZIndex:              "0",
+					essv1.LabelPodOrdinal:           "1",
+				}))
+				Expect(service2.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:     "rep-server",
+						Protocol: corev1.ProtocolTCP,
+						Port:     1801,
+					},
+				}))
+
+				service3 := kubeConfig.Services[3]
+				Expect(service3.Name).To(Equal(fmt.Sprintf("%s-%s-3", m.Name, anExtendedSts.Name)))
+				Expect(service3.Spec.Selector).To(Equal(map[string]string{
+					manifest.LabelInstanceGroupName: anExtendedSts.Name,
+					essv1.LabelAZIndex:              "1",
+					essv1.LabelPodOrdinal:           "1",
+				}))
+				Expect(service3.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:     "rep-server",
+						Protocol: corev1.ProtocolTCP,
+						Port:     1801,
+					},
+				}))
+
+				headlessService := kubeConfig.Services[4]
+				Expect(headlessService.Name).To(Equal(fmt.Sprintf("%s-%s", m.Name, anExtendedSts.Name)))
+				Expect(headlessService.Spec.Selector).To(Equal(map[string]string{
+					manifest.LabelInstanceGroupName: anExtendedSts.Name,
+				}))
+				Expect(headlessService.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:     "rep-server",
+						Protocol: corev1.ProtocolTCP,
+						Port:     1801,
+					},
+				}))
+				Expect(headlessService.Spec.ClusterIP).To(Equal("None"))
 			})
 		})
 

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -186,7 +186,7 @@ var _ = Describe("kube converter", func() {
 				aService := kubeConfig.Services[0]
 				Expect(aService.Name).To(Equal(fmt.Sprintf("%s-%s-headless", m.Name, anExtendedSts.Name)))
 				Expect(aService.Spec.Selector).To(Equal(map[string]string{
-					"instance-group": anExtendedSts.Name,
+					manifest.LabelInstanceGroupName: anExtendedSts.Name,
 				}))
 				Expect(aService.Spec.Ports).To(Equal([]corev1.ServicePort{
 					{

--- a/pkg/bosh/manifest/kube_converter_test.go
+++ b/pkg/bosh/manifest/kube_converter_test.go
@@ -1,13 +1,16 @@
 package manifest_test
 
 import (
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
-	"code.cloudfoundry.org/cf-operator/testing"
+	"fmt"
 
-	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	corev1 "k8s.io/api/core/v1"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/testing"
 )
 
 var _ = Describe("kube converter", func() {
@@ -139,7 +142,7 @@ var _ = Describe("kube converter", func() {
 		})
 
 		Context("when the lifecycle is set to service", func() {
-			It("converts the instance group to an ExtendedStatefulset", func() {
+			It("converts the instance group to an ExtendedStatefulSet", func() {
 				kubeConfig, err := m.ConvertToKube("foo")
 				Expect(err).ShouldNot(HaveOccurred())
 				anExtendedSts := kubeConfig.InstanceGroups[0].Spec.Template.Spec.Template
@@ -148,12 +151,12 @@ var _ = Describe("kube converter", func() {
 				specCopierInitContainer := anExtendedSts.Spec.InitContainers[0]
 				rendererInitContainer := anExtendedSts.Spec.InitContainers[1]
 
-				// Test containers in the extended statefulset
+				// Test containers in the extended statefulSet
 				Expect(anExtendedSts.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/cflinuxfs3:opensuse-15.0-28.g837c5b3-30.263-7.0.0_233.gde0accd0-0.62.0"))
 				Expect(anExtendedSts.Spec.Containers[0].Command).To(BeNil())
 				Expect(anExtendedSts.Spec.Containers[0].Name).To(Equal("cflinuxfs3-rootfs-setup"))
 
-				// Test init containers in the extended statefulset
+				// Test init containers in the extended statefulSet
 				Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 				Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/cflinuxfs3:opensuse-15.0-28.g837c5b3-30.263-7.0.0_233.gde0accd0-0.62.0"))
 				Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
@@ -178,6 +181,20 @@ var _ = Describe("kube converter", func() {
 				Expect(rendererInitContainer.VolumeMounts[1].MountPath).To(Equal("/var/vcap/jobs"))
 				Expect(rendererInitContainer.VolumeMounts[2].Name).To(Equal("ig-resolved"))
 				Expect(rendererInitContainer.VolumeMounts[2].MountPath).To(Equal("/var/run/secrets/resolved-properties/diego-cell"))
+
+				// Test the service for the extended statefulSet
+				aService := kubeConfig.Services[0]
+				Expect(aService.Name).To(Equal(fmt.Sprintf("%s-%s-headless", m.Name, anExtendedSts.Name)))
+				Expect(aService.Spec.Selector).To(Equal(map[string]string{
+					"instance-group": anExtendedSts.Name,
+				}))
+				Expect(aService.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:     "rep-server",
+						Protocol: corev1.ProtocolTCP,
+						Port:     1801,
+					},
+				}))
 			})
 		})
 

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -69,6 +69,14 @@ type BOSHContainerization struct {
 	Instances []JobInstance      `yaml:"instances"`
 	Release   string             `yaml:"release"`
 	BPM       bpm.Config         `yaml:"bpm"`
+	Ports     []Port             `yaml:"ports"`
+}
+
+// Port represents the port to be opened up for this job
+type Port struct {
+	Name     string `yaml:"name"`
+	Protocol string `yaml:"protocol"`
+	Internal int    `yaml:"internal"`
 }
 
 // JobProperties represents the properties map of a Job

--- a/pkg/kube/apis/extendedstatefulset/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedstatefulset/v1alpha1/types.go
@@ -33,6 +33,8 @@ var (
 	LabelAZIndex = fmt.Sprintf("%s/az-index", apis.GroupName)
 	// LabelAZName is the name of available zone
 	LabelAZName = fmt.Sprintf("%s/az-name", apis.GroupName)
+	// LabelPodOrdinal is the index of pod ordinal
+	LabelPodOrdinal = fmt.Sprintf("%s/pod-ordinal", apis.GroupName)
 )
 
 // ExtendedStatefulSetSpec defines the desired state of ExtendedStatefulSet

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -644,6 +644,7 @@ func (r *ReconcileBOSHDeployment) deployInstanceGroups(ctx context.Context, inst
 		}
 	}
 
+	log.Debugf(ctx, "Get result: %v",kubeConfigs.Services)
 	for _, svc := range kubeConfigs.Services {
 		// Set BOSHDeployment instance as the owner and controller
 		if err := r.setReference(instance, &svc, r.scheme); err != nil {

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -535,6 +535,8 @@ func (r *ReconcileBOSHDeployment) createVariableInterpolationEJob(ctx context.Co
 		if !ok {
 			return fmt.Errorf("object is not an ExtendedJob")
 		}
+
+		exstEJob.Labels = varIntEJob.Labels
 		exstEJob.Spec = varIntEJob.Spec
 		return nil
 	})
@@ -566,6 +568,8 @@ func (r *ReconcileBOSHDeployment) createDataGatheringJob(ctx context.Context, in
 		if !ok {
 			return fmt.Errorf("object is not an ExtendedJob")
 		}
+
+		exstEJob.Labels = dataGatheringEJob.Labels
 		exstEJob.Spec = dataGatheringEJob.Spec
 		return nil
 	})
@@ -629,12 +633,37 @@ func (r *ReconcileBOSHDeployment) deployInstanceGroups(ctx context.Context, inst
 			if !ok {
 				return fmt.Errorf("object is not an ExtendedJob")
 			}
+
+			exstEJob.Labels = eJob.Labels
 			exstEJob.Spec = eJob.Spec
 			return nil
 		})
 		if err != nil {
 			log.WarningEvent(ctx, instance, "CreateExtendedJobForDeploymentError", err.Error())
 			return errors.Wrapf(err, "creating or updating ExtendedJob '%s'", eJob.Name)
+		}
+	}
+
+	for _, svc := range kubeConfigs.Services {
+		// Set BOSHDeployment instance as the owner and controller
+		if err := r.setReference(instance, &svc, r.scheme); err != nil {
+			log.WarningEvent(ctx, instance, "NewServiceForDeploymentError", err.Error())
+			return errors.Wrap(err, "couldn't set reference for a Service for a BOSH Deployment")
+		}
+
+		_, err := controllerutil.CreateOrUpdate(ctx, r.client, svc.DeepCopy(), func(obj runtime.Object) error {
+			exstSvc, ok := obj.(*corev1.Service)
+			if !ok {
+				return fmt.Errorf("object is not a Service")
+			}
+
+			exstSvc.Labels = svc.Labels
+			exstSvc.Spec = svc.Spec
+			return nil
+		})
+		if err != nil {
+			log.WarningEvent(ctx, instance, "CreateServiceForDeploymentError", err.Error())
+			return errors.Wrapf(err, "creating or updating Service '%s'", svc.Name)
 		}
 	}
 
@@ -651,6 +680,7 @@ func (r *ReconcileBOSHDeployment) deployInstanceGroups(ctx context.Context, inst
 				return fmt.Errorf("object is not an ExtendStatefulSet")
 			}
 
+			exstSts.Labels = eSts.Labels
 			exstSts.Spec = eSts.Spec
 			return nil
 		})

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -78,6 +78,15 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 								Properties: map[string]interface{}{
 									"password": "((foo_password))",
 								},
+								BOSHContainerization: bdm.BOSHContainerization{
+									Ports: []bdm.Port{
+										{
+											Name:     "foo",
+											Protocol: "TCP",
+											Internal: 8080,
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pkg/kube/controllers/extendedstatefulset/pod_mutator.go
+++ b/pkg/kube/controllers/extendedstatefulset/pod_mutator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 
+	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
 )
@@ -130,6 +132,19 @@ func (m *PodMutator) mutatePodsFn(ctx context.Context, pod *corev1.Pod) error {
 			}
 		}
 	}
+
+	// Add pod ordinal label for service selectors
+	podLabels := pod.GetLabels()
+	if podLabels == nil {
+		podLabels = map[string]string{}
+	}
+
+	podOrdinal := names.OrdinalFromPodName(pod.GetName())
+	if podOrdinal != -1 {
+		podLabels[essv1.LabelPodOrdinal] = strconv.Itoa(podOrdinal)
+		pod.SetLabels(podLabels)
+	}
+
 	return nil
 }
 

--- a/pkg/kube/controllers/extendedstatefulset/reconciler.go
+++ b/pkg/kube/controllers/extendedstatefulset/reconciler.go
@@ -424,7 +424,7 @@ func (r *ReconcileExtendedStatefulSet) listStatefulSetVersions(ctx context.Conte
 // isStatefulSetReady returns true if one owned Pod is running
 func (r *ReconcileExtendedStatefulSet) isStatefulSetReady(ctx context.Context, statefulSet *v1beta2.StatefulSet) (bool, error) {
 	labelsSelector := labels.Set{
-		"controller-revision-hash": statefulSet.Status.CurrentRevision,
+		v1beta2.StatefulSetRevisionLabel: statefulSet.Status.CurrentRevision,
 	}
 
 	podList := &corev1.PodList{}

--- a/pkg/kube/controllers/extendedstatefulset/reconciler.go
+++ b/pkg/kube/controllers/extendedstatefulset/reconciler.go
@@ -244,7 +244,7 @@ func (r *ReconcileExtendedStatefulSet) calculateDesiredStatefulSets(exStatefulSe
 		}
 
 	} else {
-		statefulSet, err := r.generateSingleStatefulSet(exStatefulSet, &template, -1, "", desiredVersion, templateSHA1)
+		statefulSet, err := r.generateSingleStatefulSet(exStatefulSet, &template, 0, "", desiredVersion, templateSHA1)
 		if err != nil {
 			return desiredStatefulSets, desiredVersion, errors.Wrap(err, "Could not generate StatefulSet template for single zone")
 		}
@@ -635,7 +635,7 @@ func (r *ReconcileExtendedStatefulSet) handleDelete(ctx context.Context, exState
 }
 
 // generateSingleStatefulSet creates a StatefulSet from one zone
-func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *essv1a1.ExtendedStatefulSet, template *v1beta2.StatefulSet, zoneIndex int, zone string, version int, templateSha1 string) (*v1beta2.StatefulSet, error) {
+func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *essv1a1.ExtendedStatefulSet, template *v1beta2.StatefulSet, zoneIndex int, zoneName string, version int, templateSha1 string) (*v1beta2.StatefulSet, error) {
 	statefulSet := template.DeepCopy()
 
 	// Get the labels and annotations
@@ -651,13 +651,23 @@ func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *
 
 	statefulSetNamePrefix := exStatefulSet.GetName()
 
+	// Get the pod labels and annotations
+	podLabels := statefulSet.Spec.Template.GetLabels()
+	if podLabels == nil {
+		podLabels = make(map[string]string)
+	}
+	podAnnotations := statefulSet.Spec.Template.GetAnnotations()
+	if podAnnotations == nil {
+		podAnnotations = make(map[string]string)
+	}
+
 	// Update available-zone specified properties
-	if zoneIndex >= 0 && len(zone) != 0 {
+	if zoneName != "" {
 		// Reset name prefix with zoneIndex
 		statefulSetNamePrefix = fmt.Sprintf("%s-z%d", exStatefulSet.GetName(), zoneIndex)
 
 		labels[essv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
-		labels[essv1a1.LabelAZName] = zone
+		labels[essv1a1.LabelAZName] = zoneName
 
 		zonesBytes, err := json.Marshal(exStatefulSet.Spec.Zones)
 		if err != nil {
@@ -665,27 +675,21 @@ func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *
 		}
 		annotations[essv1a1.AnnotationZones] = string(zonesBytes)
 
-		// Get the pod labels and annotations
-		podLabels := statefulSet.Spec.Template.GetLabels()
-		if podLabels == nil {
-			podLabels = make(map[string]string)
-		}
 		podLabels[essv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
-		podLabels[essv1a1.LabelAZName] = zone
+		podLabels[essv1a1.LabelAZName] = zoneName
 
-		podAnnotations := statefulSet.Spec.Template.GetAnnotations()
-		if podAnnotations == nil {
-			podAnnotations = make(map[string]string)
-		}
 		podAnnotations[essv1a1.AnnotationZones] = string(zonesBytes)
 
-		statefulSet.Spec.Template.SetLabels(podLabels)
-		statefulSet.Spec.Template.SetAnnotations(podAnnotations)
-
-		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneIndex, zone)
+		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneIndex, zoneName)
 	}
 
-	r.injectContainerEnv(&statefulSet.Spec.Template.Spec, zoneIndex, zone, exStatefulSet.Spec.Template.Spec.Replicas)
+	// Set az-index as 0 for single zoneName
+	podLabels[essv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
+
+	statefulSet.Spec.Template.SetLabels(podLabels)
+	statefulSet.Spec.Template.SetAnnotations(podAnnotations)
+
+	r.injectContainerEnv(&statefulSet.Spec.Template.Spec, zoneIndex, zoneName, exStatefulSet.Spec.Template.Spec.Replicas)
 
 	annotations[essv1a1.AnnotationStatefulSetSHA1] = templateSha1
 	annotations[essv1a1.AnnotationVersion] = fmt.Sprintf("%d", version)

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -145,6 +145,21 @@ func JobName(eJobName, podName string) (string, error) {
 	return fmt.Sprintf("%s-%s", namePrefix, hashID), nil
 }
 
+// ServiceName returns a unique, short name for a given instance
+func ServiceName(deploymentName, instanceName string) string {
+	serviceName := fmt.Sprintf("%s-%s-headless", deploymentName, instanceName)
+
+	if len(serviceName) > 63 {
+		// names are limited to 63 characters so we recalculate the name as
+		// <name trimmed to 31 characters>-<md5 hash of name>-headless
+		sumHex := md5.Sum([]byte(serviceName))
+		sum := hex.EncodeToString(sumHex[:])
+		serviceName = fmt.Sprintf("%s-%s-headless", serviceName[:31], sum)
+	}
+
+	return serviceName
+}
+
 func randSuffix(str string) (string, error) {
 	randBytes := make([]byte, 16)
 	_, err := rand.Read(randBytes)

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -146,18 +146,38 @@ func JobName(eJobName, podName string) (string, error) {
 }
 
 // ServiceName returns a unique, short name for a given instance
-func ServiceName(deploymentName, instanceName string) string {
-	serviceName := fmt.Sprintf("%s-%s-headless", deploymentName, instanceName)
+func ServiceName(deploymentName, instanceName string, index int) string {
+	var serviceName string
+	if index == -1 {
+		serviceName = fmt.Sprintf("%s-%s", deploymentName, instanceName)
+	} else {
+		serviceName = fmt.Sprintf("%s-%s-%d", deploymentName, instanceName, index)
+	}
 
 	if len(serviceName) > 63 {
 		// names are limited to 63 characters so we recalculate the name as
 		// <name trimmed to 31 characters>-<md5 hash of name>-headless
 		sumHex := md5.Sum([]byte(serviceName))
 		sum := hex.EncodeToString(sumHex[:])
-		serviceName = fmt.Sprintf("%s-%s-headless", serviceName[:31], sum)
+		serviceName = fmt.Sprintf("%s-%s", serviceName[:31], sum)
 	}
 
 	return serviceName
+}
+
+// OrdinalFromPodName returns ordinal from pod name
+func OrdinalFromPodName(name string) int {
+	podOrdinal := -1
+	r := regexp.MustCompile(`(.*)-([0-9]+)$`)
+
+	match := r.FindStringSubmatch(name)
+	if len(match) < 3 {
+		return podOrdinal
+	}
+	if i, err := strconv.ParseInt(match[2], 10, 32); err == nil {
+		podOrdinal = int(i)
+	}
+	return podOrdinal
 }
 
 func randSuffix(str string) (string, error) {

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -73,6 +73,11 @@ instance_groups:
   properties:
     foo:
       app_domain: "((app_domain))"
+    bosh_containerization:
+      ports:
+      - name: "redis"
+        protocol: "TCP"
+        internal: 6379
 - name: diego-cell
   azs:
   - z1
@@ -91,6 +96,11 @@ instance_groups:
     properties:
       foo:
         domain: "((system_domain))"
+      bosh_containerization:
+        ports:
+        - name: "rep-server"
+          protocol: "TCP"
+          internal: 1801
 variables:
 - name: "adminpass"
   type: "password"
@@ -293,6 +303,11 @@ instance_groups:
       nats:
         user: admin
         password: changeme
+      bosh_containerization:
+        ports:
+        - name: "nats"
+          protocol: "TCP"
+          internal: 4222
 `,
 		},
 	}


### PR DESCRIPTION
As same as [example](https://github.com/cloudfoundry-incubator/cf-operator/blob/master/docs/from_bosh_to_kube.md#example-deployment-manifest-conversion-details), deployment manifest should contain `bosh_containerization.ports` field to specify what ports the instance want to be exposed.

```
    instance_groups:
    - name: nats
      instances: 1
      jobs:
      - name: nats
        release: nats
        properties:
          nats:
            user: admin
            password: ((nats_password))
          bosh_containerization:
            ports:
            - name: "nats"
              protocol: "TCP"
              internal: 4222
```

And cf-operator will convert this block and create headless services for instance groups:
```
$ k get svc -o yaml nats-deployment-nats-headless
apiVersion: v1
kind: Service
metadata:
  name: nats-deployment-nats-headless
...
spec:
  clusterIP: None
  ports:
Create services for instance groups
  - name: nats
    port: 4222
    protocol: TCP
    targetPort: 4222
  selector:
    instance-group: nats
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```
