### PR TITLE
Qu1queee/165310307

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -48,13 +48,12 @@ var rootCmd = &cobra.Command{
 		log.Infof("Starting cf-operator %s with namespace %s", version.Version, cfOperatorNamespace)
 		log.Infof("cf-operator docker image: %s", manifest.GetOperatorDockerImage())
 
-		operatorWebhookHost := viper.GetString("operator-webhook-host")
+		operatorWebhookHost := viper.GetString("operator-webhook-service-host")
 		operatorWebhookPort := viper.GetInt32("operator-webhook-port")
 
-		// TODO: comment out this, while we do not want to break
-		// if operatorWebhookHost == "" {
-		// 	log.Fatal("required flag 'operator-webhook-host' not set (env variable: CF_OPERATOR_WEBHOOK_HOST)")
-		// }
+		if operatorWebhookHost == "" {
+			log.Fatal("required flag 'operator-webhook-service-host' not set (env variable: CF_OPERATOR_WEBHOOK_SERVICE_HOST)")
+		}
 
 		config := &config.Config{
 			CtxTimeOut:        10 * time.Second,
@@ -95,25 +94,25 @@ func init() {
 	pf.StringP("cf-operator-namespace", "n", "default", "Namespace to watch for BOSH deployments")
 	pf.StringP("docker-image-org", "o", "cfcontainerization", "Dockerhub organization that provides the operator docker image")
 	pf.StringP("docker-image-repository", "r", "cf-operator", "Dockerhub repository that provides the operator docker image")
-	pf.StringP("operator-webhook-host", "w", "", "Hostname/IP under which the webhook server can be reached from the cluster")
+	pf.StringP("operator-webhook-service-host", "w", "", "Hostname/IP under which the webhook server can be reached from the cluster")
 	pf.StringP("operator-webhook-port", "p", "2999", "Port the webhook server listens on")
 	pf.StringP("docker-image-tag", "t", version.Version, "Tag of the operator docker image")
 	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
 	viper.BindPFlag("cf-operator-namespace", pf.Lookup("cf-operator-namespace"))
 	viper.BindPFlag("docker-image-org", pf.Lookup("docker-image-org"))
 	viper.BindPFlag("docker-image-repository", pf.Lookup("docker-image-repository"))
-	viper.BindPFlag("operator-webhook-host", pf.Lookup("operator-webhook-host"))
+	viper.BindPFlag("operator-webhook-service-host", pf.Lookup("operator-webhook-service-host"))
 	viper.BindPFlag("operator-webhook-port", pf.Lookup("operator-webhook-port"))
 	viper.BindPFlag("docker-image-tag", rootCmd.PersistentFlags().Lookup("docker-image-tag"))
 
 	argToEnv := map[string]string{
-		"kubeconfig":              "KUBECONFIG",
-		"cf-operator-namespace":   "CF_OPERATOR_NAMESPACE",
-		"docker-image-org":        "DOCKER_IMAGE_ORG",
-		"docker-image-repository": "DOCKER_IMAGE_REPOSITORY",
-		"operator-webhook-host":   "CF_OPERATOR_WEBHOOK_SERVICE_HOST",
-		"operator-webhook-port":   "CF_OPERATOR_WEBHOOK_PORT",
-		"docker-image-tag":        "DOCKER_IMAGE_TAG",
+		"kubeconfig":                    "KUBECONFIG",
+		"cf-operator-namespace":         "CF_OPERATOR_NAMESPACE",
+		"docker-image-org":              "DOCKER_IMAGE_ORG",
+		"docker-image-repository":       "DOCKER_IMAGE_REPOSITORY",
+		"operator-webhook-service-host": "CF_OPERATOR_WEBHOOK_SERVICE_HOST",
+		"operator-webhook-port":         "CF_OPERATOR_WEBHOOK_PORT",
+		"docker-image-tag":              "DOCKER_IMAGE_TAG",
 	}
 
 	// Add env variables to help

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -12,7 +12,6 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 	"code.cloudfoundry.org/cf-operator/version"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,9 +51,10 @@ var rootCmd = &cobra.Command{
 		operatorWebhookHost := viper.GetString("operator-webhook-host")
 		operatorWebhookPort := viper.GetInt32("operator-webhook-port")
 
-		if operatorWebhookHost == "" {
-			log.Fatal("required flag 'operator-webhook-host' not set (env variable: CF_OPERATOR_WEBHOOK_HOST)")
-		}
+		// TODO: comment out this, while we do not want to break
+		// if operatorWebhookHost == "" {
+		// 	log.Fatal("required flag 'operator-webhook-host' not set (env variable: CF_OPERATOR_WEBHOOK_HOST)")
+		// }
 
 		config := &config.Config{
 			CtxTimeOut:        10 * time.Second,
@@ -107,15 +107,15 @@ func init() {
 	viper.BindPFlag("docker-image-tag", rootCmd.PersistentFlags().Lookup("docker-image-tag"))
 
 	argToEnv := map[string]string{
-	"kubeconfig": "KUBECONFIG",
-	"cf-operator-namespace": "CF_OPERATOR_NAMESPACE",
-	"docker-image-org": "DOCKER_IMAGE_ORG",
-	"docker-image-repository": "DOCKER_IMAGE_REPOSITORY",
-	"operator-webhook-host": "CF_OPERATOR_WEBHOOK_HOST",
-	"operator-webhook-port": "CF_OPERATOR_WEBHOOK_PORT",
-	"docker-image-tag": "DOCKER_IMAGE_TAG",
+		"kubeconfig":              "KUBECONFIG",
+		"cf-operator-namespace":   "CF_OPERATOR_NAMESPACE",
+		"docker-image-org":        "DOCKER_IMAGE_ORG",
+		"docker-image-repository": "DOCKER_IMAGE_REPOSITORY",
+		"operator-webhook-host":   "CF_OPERATOR_WEBHOOK_SERVICE_HOST",
+		"operator-webhook-port":   "CF_OPERATOR_WEBHOOK_PORT",
+		"docker-image-tag":        "DOCKER_IMAGE_TAG",
 	}
-	
+
 	// Add env variables to help
 	AddEnvToUsage(rootCmd, argToEnv)
 }

--- a/deploy/helm/cf-operator/templates/cluster_role.yaml
+++ b/deploy/helm/cf-operator/templates/cluster_role.yaml
@@ -8,9 +8,13 @@ items:
       name: cf-operator:cluster
     rules:
     - apiGroups:
-      - admissionregistration.k8s.io
+      - '*'
       resources:
-      - mutatingwebhookconfigurations
+      - '*'
+      verbs:
+      - '*'
+    - nonResourceURLs:
+      - '*'
       verbs:
       - '*'
   - kind: ClusterRoleBinding

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -33,7 +33,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "cf-operator"
-            - name: CF_OPERATOR_WEBHOOK_HOST
-              value: {{ .Release.Name }}-webhook
             - name: CF_OPERATOR_WEBHOOK_PORT
               value: "{{ .Values.operator.webhook.port }}"

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -33,5 +33,11 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "cf-operator"
+            - name: DOCKER_IMAGE_ORG
+              value: "cfcontainerization"
+            - name: DOCKER_IMAGE_REPOSITORY
+              value: "cf-operator"
+            - name: DOCKER_IMAGE_TAG
+              value: "latest"
             - name: CF_OPERATOR_WEBHOOK_PORT
               value: "{{ .Values.operator.webhook.port }}"

--- a/deploy/helm/cf-operator/templates/service.yaml
+++ b/deploy/helm/cf-operator/templates/service.yaml
@@ -1,11 +1,11 @@
-apiVersio: v1
+apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-webhook
+  name: cf-operator-webhook
 spec:
-  type: NodePort
   selector:
     name: cf-operator
   ports:
-    - port: {{ .Values.operator.webhook.port }}
-      TargetPort: {{ .Values.operator.webhook.port }}
+  - port: 2999
+    targetPort: 2999
+    name: cf-operator-webhook

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for cf-operator.
 image:
-  repository: cfcontainerization/cf-operator
-  tag: latest
+  repository: havener/cf-operator
+  tag: test-encalada
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for cf-operator.
 image:
-  repository: havener/cf-operator
-  tag: test-encalada
+  repository: cfcontainerization/cf-operator
+  tag: latest
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/docs/commands/cf-operator.md
+++ b/docs/commands/cf-operator.md
@@ -13,14 +13,14 @@ cf-operator [flags]
 ### Options
 
 ```
-  -n, --cf-operator-namespace string     (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
-  -o, --docker-image-org string          (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
-  -r, --docker-image-repository string   (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
-  -t, --docker-image-tag string          (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
-  -h, --help                             help for cf-operator
-  -c, --kubeconfig string                (KUBECONFIG) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     (CF_OPERATOR_WEBHOOK_HOST) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
+  -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
+  -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
+  -t, --docker-image-tag string                (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
+  -h, --help                                   help for cf-operator
+  -c, --kubeconfig string                      (KUBECONFIG) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -w, --operator-webhook-service-host string   (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
 ```
 
 ### SEE ALSO

--- a/docs/commands/cf-operator_util_data-gather.md
+++ b/docs/commands/cf-operator_util_data-gather.md
@@ -26,15 +26,15 @@ cf-operator util data-gather [flags]
 ### Options inherited from parent commands
 
 ```
-  -m, --bosh-manifest-path string        (BOSH_MANIFEST_PATH) path to the bosh manifest file
-  -n, --cf-operator-namespace string     (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
-  -o, --docker-image-org string          (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
-  -r, --docker-image-repository string   (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
-  -t, --docker-image-tag string          (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
-  -g, --instance-group-name string       (INSTANCE_GROUP_NAME) name of the instance group for data gathering
-  -c, --kubeconfig string                (KUBECONFIG) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     (CF_OPERATOR_WEBHOOK_HOST) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
+  -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
+  -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
+  -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
+  -t, --docker-image-tag string                (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
+  -g, --instance-group-name string             (INSTANCE_GROUP_NAME) name of the instance group for data gathering
+  -c, --kubeconfig string                      (KUBECONFIG) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -w, --operator-webhook-service-host string   (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
 ```
 
 ### SEE ALSO

--- a/docs/commands/cf-operator_util_template-render.md
+++ b/docs/commands/cf-operator_util_template-render.md
@@ -27,15 +27,15 @@ cf-operator util template-render [flags]
 ### Options inherited from parent commands
 
 ```
-  -m, --bosh-manifest-path string        (BOSH_MANIFEST_PATH) path to the bosh manifest file
-  -n, --cf-operator-namespace string     (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
-  -o, --docker-image-org string          (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
-  -r, --docker-image-repository string   (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
-  -t, --docker-image-tag string          (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
-  -g, --instance-group-name string       (INSTANCE_GROUP_NAME) name of the instance group for data gathering
-  -c, --kubeconfig string                (KUBECONFIG) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     (CF_OPERATOR_WEBHOOK_HOST) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
+  -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
+  -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
+  -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
+  -t, --docker-image-tag string                (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
+  -g, --instance-group-name string             (INSTANCE_GROUP_NAME) name of the instance group for data gathering
+  -c, --kubeconfig string                      (KUBECONFIG) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -w, --operator-webhook-service-host string   (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
 ```
 
 ### SEE ALSO

--- a/docs/commands/cf-operator_util_variable-interpolation.md
+++ b/docs/commands/cf-operator_util_variable-interpolation.md
@@ -24,15 +24,15 @@ cf-operator util variable-interpolation [flags]
 ### Options inherited from parent commands
 
 ```
-  -m, --bosh-manifest-path string        (BOSH_MANIFEST_PATH) path to the bosh manifest file
-  -n, --cf-operator-namespace string     (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
-  -o, --docker-image-org string          (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
-  -r, --docker-image-repository string   (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
-  -t, --docker-image-tag string          (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
-  -g, --instance-group-name string       (INSTANCE_GROUP_NAME) name of the instance group for data gathering
-  -c, --kubeconfig string                (KUBECONFIG) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     (CF_OPERATOR_WEBHOOK_HOST) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
+  -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
+  -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
+  -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
+  -t, --docker-image-tag string                (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
+  -g, --instance-group-name string             (INSTANCE_GROUP_NAME) name of the instance group for data gathering
+  -c, --kubeconfig string                      (KUBECONFIG) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -w, --operator-webhook-service-host string   (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
 ```
 
 ### SEE ALSO

--- a/docs/commands/cf-operator_version.md
+++ b/docs/commands/cf-operator_version.md
@@ -19,13 +19,13 @@ cf-operator version [flags]
 ### Options inherited from parent commands
 
 ```
-  -n, --cf-operator-namespace string     (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
-  -o, --docker-image-org string          (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
-  -r, --docker-image-repository string   (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
-  -t, --docker-image-tag string          (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
-  -c, --kubeconfig string                (KUBECONFIG) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     (CF_OPERATOR_WEBHOOK_HOST) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
+  -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
+  -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")
+  -t, --docker-image-tag string                (DOCKER_IMAGE_TAG) Tag of the operator docker image (default "0.0.1")
+  -c, --kubeconfig string                      (KUBECONFIG) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           (CF_OPERATOR_WEBHOOK_PORT) Port the webhook server listens on (default "2999")
+  -w, --operator-webhook-service-host string   (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
 ```
 
 ### SEE ALSO

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -179,7 +179,7 @@ var _ = Describe("CLI", func() {
 
 	Describe("data-gather", func() {
 		It("lists its flags incl. ENV binding", func() {
-			session, err := act("util", "data-gather",  "-h")
+			session, err := act("util", "data-gather", "-h")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out).Should(Say(`Flags:
   -b, --base-dir string               \(BASE_DIR\) a path to the base directory

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -29,14 +29,14 @@ var _ = Describe("CLI", func() {
 			session, err := act("help")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out).Should(Say(`Flags:
-  -n, --cf-operator-namespace string     \(CF_OPERATOR_NAMESPACE\) Namespace to watch for BOSH deployments \(default "default"\)
-  -o, --docker-image-org string          \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
-  -r, --docker-image-repository string   \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)
-  -t, --docker-image-tag string          \(DOCKER_IMAGE_TAG\) Tag of the operator docker image \(default "\d+.\d+.\d+"\)
-  -h, --help                             help for cf-operator
-  -c, --kubeconfig string                \(KUBECONFIG\) Path to a kubeconfig, not required in-cluster
-  -w, --operator-webhook-host string     \(CF_OPERATOR_WEBHOOK_HOST\) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-port string     \(CF_OPERATOR_WEBHOOK_PORT\) Port the webhook server listens on \(default "2999"\)`))
+  -n, --cf-operator-namespace string           \(CF_OPERATOR_NAMESPACE\) Namespace to watch for BOSH deployments \(default "default"\)
+  -o, --docker-image-org string                \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
+  -r, --docker-image-repository string         \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)
+  -t, --docker-image-tag string                \(DOCKER_IMAGE_TAG\) Tag of the operator docker image \(default "\d+.\d+.\d+"\)
+  -h, --help                                   help for cf-operator
+  -c, --kubeconfig string                      \(KUBECONFIG\) Path to a kubeconfig, not required in-cluster
+  -p, --operator-webhook-port string           \(CF_OPERATOR_WEBHOOK_PORT\) Port the webhook server listens on \(default "2999"\)
+  -w, --operator-webhook-service-host string   \(CF_OPERATOR_WEBHOOK_SERVICE_HOST\) Hostname/IP under which the webhook server can be reached from the cluster`))
 		})
 
 		It("shows all available commands", func() {

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -15,11 +15,9 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
 	"code.cloudfoundry.org/cf-operator/testing"
-
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
 	"k8s.io/client-go/rest"
@@ -104,9 +102,9 @@ func (e *Environment) AllLogMessages() (msgs []string) {
 }
 
 func (e *Environment) setupCFOperator() (err error) {
-	whh, found := os.LookupEnv("CF_OPERATOR_WEBHOOK_HOST")
+	whh, found := os.LookupEnv("CF_OPERATOR_WEBHOOK_SERVICE_HOST")
 	if !found {
-		return fmt.Errorf("no webhook host set. Please set CF_OPERATOR_WEBHOOK_HOST to the host/ip the operator runs on and try again")
+		return fmt.Errorf("no webhook host set. Please set CF_OPERATOR_WEBHOOK_SERVICE_HOST to the host/ip the operator runs on and try again")
 	}
 	e.Config.WebhookServerHost = whh
 


### PR DESCRIPTION

- Ensure we use the `CF_OPERATOR_WEBHOOK_SERVICE_HOST` instead of `CF_OPERATOR_WEBHOOK_HOST,` so that the kube api server can resolve the correct service(cf-operator-webhook) cluster IP. This relies on the environment variables available in the container, of the form `<SVC>_SERVICE_HOST`, where the service name is `cf-operator-webhook` and the `CF_OPERATOR_WEBHOOK_SERVICE_HOST` env variable will contain the ClusterIP of that service. (see https://kubernetes.io/docs/concepts/containers/container-environment-variables/#cluster-information)

- Modify viper flag from `operator-webhook-host` to `operator-webhook-service-host`, to be more adhoc regarding the above  env var change.

- Add cluster-admin permissions to the cf-operator clusterRole template, in order for the operator to see other pods in the `default` namespace.

- Redefine the service template, so that we can get a ClusterIP, and the proper names.

- Specify cf-operator docker image,org,tag.

- Modify documentation to use correct viper flags and env vars.