### PR TITLE
e2e tests for cli

### DIFF
--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,6 +1,8 @@
 package e2e_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -9,6 +11,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
+	SetDefaultEventuallyTimeout(10 * time.Second)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2E Suite")
 }

--- a/e2e/util_dgather_test.go
+++ b/e2e/util_dgather_test.go
@@ -1,0 +1,44 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("data-gather", func() {
+	var (
+		manifestPath string
+	)
+
+	act := func(manifestPath string) (session *gexec.Session, err error) {
+		args := []string{"util", "data-gather", "-m", manifestPath, "-b", "../testing/assets", "-g", "log-api"}
+		cmd := exec.Command(cliPath, args...)
+		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		return
+	}
+
+	Context("when manifest exists", func() {
+		BeforeEach(func() {
+			manifestPath = "../testing/assets/gatherManifest.yml"
+		})
+
+		It("gathers data to stdout", func() {
+			session, err := act(manifestPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0))
+			output := session.Out.Contents()
+			Expect(output).Should(ContainSubstring(`"properties.yaml":"name: cf`))
+
+			var yml map[string]interface{}
+			err = json.Unmarshal(output, &yml)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(yml["properties.yaml"]).ToNot(BeEmpty())
+		})
+	})
+})

--- a/e2e/util_render_template_test.go
+++ b/e2e/util_render_template_test.go
@@ -1,0 +1,53 @@
+package e2e_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("render-template", func() {
+	var (
+		manifestPath string
+		tmpDir       string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = ioutil.TempDir("", "ginkgo-run")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.RemoveAll(tmpDir)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	act := func(manifestPath string) (session *gexec.Session, err error) {
+		args := []string{"util", "template-render", "-m", manifestPath, "-j", "../testing/assets", "-g", "log-api", "--spec-index", "0", "-d", tmpDir}
+		cmd := exec.Command(cliPath, args...)
+		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		return
+	}
+
+	Context("when manifest exists", func() {
+		BeforeEach(func() {
+			manifestPath = "../testing/assets/gatherManifest.yml"
+		})
+
+		It("rendert the instance group template to a file", func() {
+			session, err := act(manifestPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0))
+
+			absDestFile := filepath.Join(tmpDir, "loggregator_trafficcontroller", "config/bpm.yml")
+			Expect(absDestFile).Should(BeAnExistingFile())
+		})
+	})
+})

--- a/e2e/util_render_template_test.go
+++ b/e2e/util_render_template_test.go
@@ -40,7 +40,7 @@ var _ = Describe("render-template", func() {
 			manifestPath = "../testing/assets/gatherManifest.yml"
 		})
 
-		It("rendert the instance group template to a file", func() {
+		It("renders the instance group template to a file", func() {
 			session, err := act(manifestPath)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/bosh/manifest/data_gatherer.go
+++ b/pkg/bosh/manifest/data_gatherer.go
@@ -248,8 +248,7 @@ func (dg *DataGatherer) renderJobBPM(currentJob *Job, baseDir string) error {
 		return fmt.Errorf("can't find BPM template for job %s", currentJob.Name)
 	}
 
-	// ### Render bpm.yml.erb for each job instance
-
+	// Render bpm.yml.erb for each job instance
 	erbFilePath := filepath.Join(baseDir, "jobs-src", currentJob.Release, currentJob.Name, "templates", bpmSource)
 	if _, err := os.Stat(erbFilePath); err != nil {
 		return err

--- a/pkg/bosh/manifest/render_job_tmpls.go
+++ b/pkg/bosh/manifest/render_job_tmpls.go
@@ -54,29 +54,6 @@ func RenderJobTemplates(boshManifestPath string, jobsDir string, jobsOutputDir s
 				return fmt.Errorf("no instance found for spec index '%d'", specIndex)
 			}
 
-			// Loop over name and link
-			jobInstanceLinks := []Link{}
-			for name, jobConsumersLink := range job.Properties.BOSHContainerization.Consumes {
-				jobInstances := []JobInstance{}
-
-				// Loop over instances of link
-				for _, jobConsumerLinkInstance := range jobConsumersLink.Instances {
-					jobInstances = append(jobInstances, JobInstance{
-						Address: jobConsumerLinkInstance.Address,
-						AZ:      jobConsumerLinkInstance.AZ,
-						ID:      jobConsumerLinkInstance.ID,
-						Index:   jobConsumerLinkInstance.Index,
-						Name:    jobConsumerLinkInstance.Name,
-					})
-				}
-
-				jobInstanceLinks = append(jobInstanceLinks, Link{
-					Name:       name,
-					Instances:  jobInstances,
-					Properties: jobConsumersLink.Properties,
-				})
-			}
-
 			// Loop over templates for rendering files
 			jobSrcDir := job.specDir(jobsDir)
 			for source, destination := range jobSpec.Templates {

--- a/pkg/bosh/manifest/render_job_tmpls.go
+++ b/pkg/bosh/manifest/render_job_tmpls.go
@@ -13,6 +13,7 @@ import (
 
 // RenderJobTemplates will render templates for all jobs of the instance group
 // https://bosh.io/docs/create-release/#job-specs
+// boshManifest is a resolved manifest for a single instance group
 func RenderJobTemplates(boshManifestPath string, jobsDir string, jobsOutputDir string, instanceGroupName string, specIndex int) error {
 
 	// Loading deployment manifest file

--- a/pkg/bosh/manifest/render_job_tmpls_test.go
+++ b/pkg/bosh/manifest/render_job_tmpls_test.go
@@ -27,13 +27,17 @@ var _ = Describe("Trender", func() {
 			instanceGroupName = "log-api"
 		})
 
+		act := func() error {
+			return manifest.RenderJobTemplates(deploymentManifest, jobsDir, jobsDir, instanceGroupName, index)
+		}
+
 		Context("with an invalid instance index", func() {
 			BeforeEach(func() {
 				index = 1000
 			})
 
 			It("fails", func() {
-				err := manifest.RenderJobTemplates(deploymentManifest, jobsDir, jobsDir, instanceGroupName, index)
+				err := act()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("no instance found"))
 			})
@@ -45,13 +49,13 @@ var _ = Describe("Trender", func() {
 			})
 
 			It("renders the job erb files correctly", func() {
-				err := manifest.RenderJobTemplates(deploymentManifest, jobsDir, jobsDir, instanceGroupName, index)
+				err := act()
 				Expect(err).ToNot(HaveOccurred())
 
 				absDestFile := filepath.Join(jobsDir, "loggregator_trafficcontroller", "config/bpm.yml")
 				Expect(absDestFile).Should(BeAnExistingFile())
 
-				// Unmarshal the rendered file
+				By("Checking the content of the rendered file")
 				bpmYmlBytes, err := ioutil.ReadFile(absDestFile)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -60,12 +64,14 @@ var _ = Describe("Trender", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Check fields if they are rendered
-				Expect(bpmYml["processes"][0].(map[interface{}]interface{})["env"].(map[interface{}]interface{})["AGENT_UDP_ADDRESS"]).To(Equal("127.0.0.1:3457"))
-				Expect(bpmYml["processes"][0].(map[interface{}]interface{})["env"].(map[interface{}]interface{})["TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT"]).To(Equal("8081"))
-				Expect(bpmYml["processes"][0].(map[interface{}]interface{})["env"].(map[interface{}]interface{})["FOOBARWITHLINKINSTANCESAZ"]).To(Equal("z1"))
+				values := bpmYml["processes"][0].(map[interface{}]interface{})["env"].(map[interface{}]interface{})
+				Expect(values["AGENT_UDP_ADDRESS"]).To(Equal("127.0.0.1:3457"))
+				Expect(values["TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT"]).To(Equal("8081"))
+				Expect(values["FOOBARWITHLINKINSTANCESAZ"]).To(Equal("z1"))
+			})
 
-				// Delete  the file
-				err = os.RemoveAll(filepath.Join(jobsDir, "loggregator_trafficcontroller"))
+			AfterEach(func() {
+				err := os.RemoveAll(filepath.Join(jobsDir, "loggregator_trafficcontroller"))
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
This adds basic e2e tests for the bosh cli commands.
In the future we could use those, instead of the unit tests.

I think that would be beneficial as data gathering and template rendering also uses Ruby and might write to disk. 

[#165014860](https://www.pivotaltracker.com/story/show/165014860)