### PR TITLE
Compress cf-operator helm chart with tar

### DIFF
--- a/bin/build-helm
+++ b/bin/build-helm
@@ -7,7 +7,7 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . "${GIT_ROOT}/.envrc"
 
 output_dir=${GIT_ROOT}/helm
-filename="${output_dir}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}.zip"
+filename="${output_dir}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}.tgz"
 
 [ -d "${output_dir}" ] && rm -r "${output_dir}"
 cp -r "${GIT_ROOT}/deploy/helm" "${output_dir}"
@@ -15,6 +15,6 @@ cp -r "${GIT_ROOT}/deploy/helm" "${output_dir}"
 perl -pi -e "s|repository: .*|repository: ${OPERATOR_DOCKER_ORGANIZATION}/cf-operator|g" "${output_dir}/cf-operator/values.yaml"
 perl -pi -e "s|tag: .*|tag: ${VERSION_TAG}|g" "${output_dir}/cf-operator/values.yaml"
 
-zip -r "${filename}" helm
+tar -C "${output_dir}" -czvf "${filename}" cf-operator
 
 echo "The helm chart is now available from ${filename}"


### PR DESCRIPTION
In the future, this will allow stored *.tgz files in the s3 bucket, to be installed from a full URL.

e.g.
```
helm install <URL>
```