### PR TITLE
Add `triggering-pod` label on job pods

### DIFF
--- a/docs/controllers/extendedjob.md
+++ b/docs/controllers/extendedjob.md
@@ -31,9 +31,10 @@ E.g. when a `Pod` is created, deleted, transitioned to **ready** or a
 The execution of `ExtendedJob` can be limited to pods with certain labels.
 
 A separate native k8s job will be started for every pod that changed. The job
-has a label `affected-pod: pod1` to identify which pod it is running for.
+has a label `triggering-pod: uid` to identify which pod it is running for.
 
-`ExtendedJob` does not trigger for pods from jobs. If a pod has a label `job-name` it won't trigger more jobs.
+`ExtendedJob` does not trigger for pods from jobs. This is done by checking if
+a pod has a label `job-name`. The `job-name` label is [assigned by Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) to job pods.
 
 #### State
 

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -847,7 +847,7 @@ func (m *Machine) CreateExtendedJob(namespace string, job ejv1.ExtendedJob) (*ej
 	return d, func() error {
 		pods, err := m.Clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{
 			LabelSelector: labels.Set(map[string]string{
-				"ejob-name": job.Name,
+				ejv1.LabelEJobName: job.Name,
 			}).String(),
 		})
 		if err != nil {

--- a/pkg/kube/apis/extendedjob/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedjob/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -17,6 +18,16 @@ import (
 var (
 	// LabelReferencedJobName is the name key for dependent job
 	LabelReferencedJobName = fmt.Sprintf("%s/referenced-job-name", apis.GroupName)
+)
+
+const (
+	// LabelExtendedJob key for label used to identify extendedjob. Value
+	// is set to true if the batchv1.Job is from an ExtendedJob
+	LabelExtendedJob = "extendedjob"
+	// LabelEJobName key for label on a batchv1.Job's pod, which is set to the ExtendedJob's name
+	LabelEJobName = "ejob-name"
+	// LabelTriggeringPod key for label, which is set to the UID of the pod that triggered an ExtendedJob
+	LabelTriggeringPod = "triggering-pod"
 )
 
 // ExtendedJobSpec defines the desired state of ExtendedJob

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -156,7 +156,7 @@ func (r *ErrandReconciler) createJob(ctx context.Context, eJob ejv1.ExtendedJob)
 	if template.Labels == nil {
 		template.Labels = map[string]string{}
 	}
-	template.Labels["ejob-name"] = eJob.Name
+	template.Labels[ejv1.LabelEJobName] = eJob.Name
 
 	name, err := names.JobName(eJob.Name, "")
 	if err != nil {
@@ -166,7 +166,7 @@ func (r *ErrandReconciler) createJob(ctx context.Context, eJob ejv1.ExtendedJob)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: eJob.Namespace,
-			Labels:    map[string]string{"extendedjob": "true"},
+			Labels:    map[string]string{ejv1.LabelExtendedJob: "true"},
 		},
 		Spec: batchv1.JobSpec{Template: *template},
 	}

--- a/pkg/kube/controllers/extendedjob/job_controller.go
+++ b/pkg/kube/controllers/extendedjob/job_controller.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
@@ -51,7 +52,7 @@ func AddJob(ctx context.Context, config *config.Config, mgr manager.Manager) err
 
 // isEJobJob matches our jobs
 func isEJobJob(labels map[string]string) bool {
-	if _, exists := labels["extendedjob"]; exists {
+	if _, exists := labels[ejv1.LabelExtendedJob]; exists {
 		return true
 	}
 	return false

--- a/pkg/kube/controllers/extendedjob/trigger_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/trigger_reconciler.go
@@ -125,8 +125,8 @@ func (r *TriggerReconciler) createJob(ctx context.Context, eJob ejv1.ExtendedJob
 	if template.Labels == nil {
 		template.Labels = map[string]string{}
 	}
-	template.Labels["ejob-name"] = eJob.Name
-	template.Labels["triggering-pod"] = podUID
+	template.Labels[ejv1.LabelEJobName] = eJob.Name
+	template.Labels[ejv1.LabelTriggeringPod] = podUID
 
 	name, err := names.JobName(eJob.Name, podName)
 	if err != nil {
@@ -136,7 +136,7 @@ func (r *TriggerReconciler) createJob(ctx context.Context, eJob ejv1.ExtendedJob
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: eJob.Namespace,
-			Labels:    map[string]string{"extendedjob": "true"},
+			Labels:    map[string]string{ejv1.LabelExtendedJob: "true"},
 		},
 		Spec: batchv1.JobSpec{Template: *template},
 	}

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -127,7 +127,6 @@ func GetVersionFromVersionedSecretName(name string) (int, error) {
 
 // JobName returns a unique, short name for a given eJob, pod(if exists) combination
 // k8s allows 63 chars, but the pod will have -\d{6} appended
-// IDEA: maybe use pod.Uid instead of rand
 func JobName(eJobName, podName string) (string, error) {
 	suffix := ""
 	if podName == "" {


### PR DESCRIPTION
Feature was documented, but not implemented. Also explain where 'job-name' label comes from. 