### PR TITLE
Improvements in the helm chart definition

### DIFF
--- a/bin/build-helm
+++ b/bin/build-helm
@@ -12,7 +12,8 @@ filename="${output_dir}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}.tgz"
 [ -d "${output_dir}" ] && rm -r "${output_dir}"
 cp -r "${GIT_ROOT}/deploy/helm" "${output_dir}"
 
-perl -pi -e "s|repository: .*|repository: ${OPERATOR_DOCKER_ORGANIZATION}/cf-operator|g" "${output_dir}/cf-operator/values.yaml"
+perl -pi -e "s|repository: .*|repository: cf-operator|g" "${output_dir}/cf-operator/values.yaml"
+perl -pi -e "s|org: .*|org: ${OPERATOR_DOCKER_ORGANIZATION}|g" "${output_dir}/cf-operator/values.yaml"
 perl -pi -e "s|tag: .*|tag: ${VERSION_TAG}|g" "${output_dir}/cf-operator/values.yaml"
 
 tar -C "${output_dir}" -czvf "${filename}" cf-operator

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: cf-operator
       containers:
         - name: cf-operator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.org }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
           - containerPort: 60000
             name: metrics
@@ -34,8 +34,8 @@ spec:
             - name: OPERATOR_NAME
               value: "cf-operator"
             - name: DOCKER_IMAGE_ORG
-              value: "cfcontainerization"
+              value: "{{ .Values.image.org }}"
             - name: DOCKER_IMAGE_REPOSITORY
-              value: "cf-operator"
+              value: "{{ .Values.image.repository }}"
             - name: DOCKER_IMAGE_TAG
-              value: "latest"
+              value: "{{ .Values.image.tag }}"

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -1,7 +1,8 @@
 # Default values for cf-operator.
 image:
-  repository: cfcontainerization/cf-operator
-  tag: latest
+  repository: cf-operator
+  org: cfcontainerization
+  tag: foobar
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Make usage of the `values.yaml` in different chart templates
Do not use latest for the cf-operator img
Fix script, that overrides the chart.