### PR TITLE
Multiple BPM processes test

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -32,29 +32,27 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// check for pod
+			By("checking for pod")
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for pod from deployment")
 
-			// check for services
+			By("checking for services")
 			svc, err := env.GetService(env.Namespace, headlessSvcName)
 			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
-			Expect(svc.Spec.Ports)
-			Expect(svc.Spec.Selector).To(Equal(map[string]string{
-				bdm.LabelInstanceGroupName: "nats",
-			}))
+			Expect(svc.Spec.Selector).To(Equal(map[string]string{bdm.LabelInstanceGroupName: "nats"}))
+			Expect(svc.Spec.Ports).NotTo(BeEmpty())
 			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(4222)))
 
 			svc, err = env.GetService(env.Namespace, clusterIpSvcName)
 			Expect(err).NotTo(HaveOccurred(), "error getting service for instance group")
-			Expect(svc.Spec.Ports)
 			Expect(svc.Spec.Selector).To(Equal(map[string]string{
 				bdm.LabelInstanceGroupName: "nats",
 				essv1.LabelAZIndex:         "0",
 				essv1.LabelPodOrdinal:      "0",
 			}))
+			Expect(svc.Spec.Ports).NotTo(BeEmpty())
 			Expect(svc.Spec.Ports[0].Name).To(Equal("nats"))
 			Expect(svc.Spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(4222)))
@@ -93,15 +91,13 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// check for pod
+			By("checking for pod")
 			err = env.WaitForPod(env.Namespace, podName)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for pod from deployment")
 
 			sts, err := env.GetStatefulSet(env.Namespace, stsName)
 			Expect(err).NotTo(HaveOccurred(), "error getting statefulset for deployment")
-
 			Expect(*sts.Spec.Replicas).To(BeEquivalentTo(4))
-			Expect(err).NotTo(HaveOccurred(), "error verifying pod label")
 		})
 	})
 
@@ -123,9 +119,8 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// check for events
+			By("checking for events")
 			events, err := env.GetBOSHDeploymentEvents(env.Namespace, boshDeployment.ObjectMeta.Name, string(boshDeployment.ObjectMeta.UID))
-
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env.ContainExpectedEvent(events, "ResolveManifestError", "failed to interpolate")).To(BeTrue())
 		})

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -282,3 +282,31 @@ instance_groups:
   - name: fake-job-d
     release: fake-release
 `
+
+const BPMRelease = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+
+instance_groups:
+- name: bpm
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+`


### PR DESCRIPTION
The new integration tets uses the  BPM release, instead of nats, because that has a test-server with multiple BPM processes.

[#166115702](https://www.pivotaltracker.com/story/show/166115702)