### PR TITLE
Embed the ca which was used for generating the cert

### DIFF
--- a/pkg/kube/controllers/extendedsecret/reconciler.go
+++ b/pkg/kube/controllers/extendedsecret/reconciler.go
@@ -245,6 +245,10 @@ func (r *ReconcileExtendedSecret) createCertificateSecret(ctx context.Context, i
 		},
 	}
 
+	if len(request.CA.Certificate) > 0 {
+		secret.Data["ca"] = request.CA.Certificate
+	}
+
 	return r.createSecret(ctx, instance, secret)
 }
 

--- a/pkg/kube/controllers/extendedsecret/reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/reconciler_test.go
@@ -227,6 +227,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 				secret := object.(*corev1.Secret)
 				Expect(secret.Data["certificate"]).To(Equal([]byte("the_cert")))
 				Expect(secret.Data["private_key"]).To(Equal([]byte("private_key")))
+				Expect(secret.Data["ca"]).To(Equal([]byte("theca")))
 				Expect(secret.GetLabels()).To(HaveKeyWithValue(esv1.LabelKind, "generated"))
 				return nil
 			})


### PR DESCRIPTION
The ca needs to be part of the generated variable as defined at
https://bosh.io/docs/variable-types/#certificate