### PR TITLE
Run integration tests in parallel

### DIFF
--- a/bin/test-integration
+++ b/bin/test-integration
@@ -7,18 +7,11 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 
 export DOCKER_IMAGE_TAG=${VERSION_TAG}
 
-echo "Test logs are here: /tmp/cf-operator-tests.log"
+echo "Test logs are here: /tmp/cf-operator-tests-*.log"
 
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"
   export TEST_NAMESPACE
-
-  remove_namespace() {
-    kubectl delete namespace --wait=false --grace-period=60 "$TEST_NAMESPACE"
-  }
-  trap remove_namespace EXIT
-
-  kubectl create namespace "$TEST_NAMESPACE"
 fi
 
 bin/apply-crds
@@ -36,8 +29,10 @@ code.cloudfoundry.org/cf-operator/pkg/kube/util/...,\
 code.cloudfoundry.org/cf-operator/pkg/kube/config/..."
 
 # Run code coverage only in CI
-if [ -n "$COVERAGE" ]; then COV_ARG="-cover -outputdir=./code-coverage  -coverprofile=${GOVER_FILE} -coverpkg ${pkgs}"; fi
+if [ -n "$COVERAGE" ]; then
+  COV_ARG="-cover -outputdir=./code-coverage  -coverprofile=${GOVER_FILE} -coverpkg ${pkgs}"
+  mkdir -p code-coverage
+fi
 
-mkdir -p code-coverage
-ginkgo --slowSpecThreshold=50 $COV_ARG integration/
-
+NODES=${NODES:-5}
+ginkgo --randomizeAllSpecs --nodes="$NODES" --slowSpecThreshold=50 $COV_ARG integration/

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 
 	"code.cloudfoundry.org/cf-operator/integration/environment"
@@ -18,13 +19,14 @@ func TestIntegration(t *testing.T) {
 var (
 	env          *environment.Environment
 	stopOperator environment.StopFunc
+	nsTeardown   environment.TearDownFunc
 )
 
 var _ = BeforeSuite(func() {
 	env = environment.NewEnvironment()
 
 	var err error
-	stopOperator, err = env.Setup()
+	nsTeardown, stopOperator, err = env.Setup(int32(config.GinkgoConfig.ParallelNode))
 	Expect(err).NotTo(HaveOccurred())
 })
 
@@ -32,5 +34,8 @@ var _ = AfterSuite(func() {
 	if stopOperator != nil {
 		time.Sleep(3 * time.Second)
 		defer stopOperator()
+	}
+	if nsTeardown != nil {
+		nsTeardown()
 	}
 })

--- a/pkg/kube/controllers/controllers_test.go
+++ b/pkg/kube/controllers/controllers_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Controllers", func() {
 
 		Context("if there is no cert secret yet", func() {
 			It("generates and persists the certificates on disk and in a secret", func() {
-				Expect(afero.Exists(config.Fs, "/tmp/cf-operator-certs/key.pem")).To(BeFalse())
+				file := "/tmp/cf-operator-mutating-hook-" + config.Namespace + "/key.pem"
+				Expect(afero.Exists(config.Fs, file)).To(BeFalse())
 
 				client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
 					kind := object.GetObjectKind()
@@ -107,7 +108,7 @@ var _ = Describe("Controllers", func() {
 				err := controllers.AddHooks(ctx, config, manager, generator)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(afero.Exists(config.Fs, "/tmp/cf-operator-certs/key.pem")).To(BeTrue())
+				Expect(afero.Exists(config.Fs, file)).To(BeTrue())
 				Expect(generator.GenerateCertificateCallCount()).To(Equal(2)) // Generate CA and certificate
 				Expect(client.CreateCallCount()).To(Equal(2))                 // Persist secret and the webhook config
 			})

--- a/pkg/kube/controllers/webhook_configuration.go
+++ b/pkg/kube/controllers/webhook_configuration.go
@@ -44,7 +44,7 @@ type WebhookConfig struct {
 func NewWebhookConfig(c client.Client, config *config.Config, generator credsgen.Generator, configName string) *WebhookConfig {
 	return &WebhookConfig{
 		ConfigName: configName,
-		CertDir:    "/tmp/cf-operator-certs",
+		CertDir:    path.Join("/tmp", configName),
 		client:     c,
 		config:     config,
 		generator:  generator,

--- a/pkg/testhelper/logger.go
+++ b/pkg/testhelper/logger.go
@@ -12,13 +12,18 @@ import (
 // NewTestLogger returns a ZAP logger for assertions, which also logs to
 // /tmp/cf-operator-tests.log
 func NewTestLogger() (obs *observer.ObservedLogs, log *zap.SugaredLogger) {
+	return NewTestLoggerWithPath("/tmp/cf-operator-tests.log")
+}
+
+// NewTestLoggerWithPath returns a logger which logs to path
+func NewTestLoggerWithPath(path string) (obs *observer.ObservedLogs, log *zap.SugaredLogger) {
 	// An in-memory zap core that can be used for assertions
 	var memCore zapcore.Core
 	memCore, obs = observer.New(zapcore.DebugLevel)
 
 	// A zap core that writes to a temp file
 	consoleEncoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
-	f, err := os.Create("/tmp/cf-operator-tests.log")
+	f, err := os.Create(path)
 	if err != nil {
 		panic(fmt.Sprintf("can't create log file: %s\n", err.Error()))
 	}


### PR DESCRIPTION
* Ginkgo beforesuite/aftersuite are executed for each parallel test node
* each Ginkgo test node has a separate namespace and webhook server port
  * `TEST_NAMESPACE + node_index`
  * `CF_OPERATOR_WEBHOOK_SERVICE_PORT + node_index` (starting at 1)
* namespaces are created and deleted by integration test environment
* no error if namespace already exists
* script defaults to 5 nodes (=tests in  parallel)
* different log files for every node (`/tmp/cf-operator-tests-*.log`)

See http://onsi.github.io/ginkgo/#parallel-specs

Requires https://github.com/cloudfoundry-incubator/cf-operator-ci/pull/56
Brings runtime on integration tests down to about 6 minutes: https://ci.flintstone.cf.cloud.ibm.com/teams/containerization/pipelines/mm-test/jobs/test-integration/builds/16

[#166115702](https://www.pivotaltracker.com/story/show/166115702)