### PR TITLE
Enabled builds with cf-operator as submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM golang:1.12.2 AS build
 COPY . /go/src/code.cloudfoundry.org/cf-operator
 ARG GO111MODULE="on"
 ENV GO111MODULE $GO111MODULE
+ARG GIT_ROOT="/go/src/code.cloudfoundry.org/cf-operator"
+ENV GIT_ROOT $GIT_ROOT
+ARG ARTIFACT_VERSION
+ENV ARTIFACT_VERSION $ARTIFACT_VERSION
 RUN cd /go/src/code.cloudfoundry.org/cf-operator && \
     make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator

--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,10 @@
 set -euo pipefail
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-. "${GIT_ROOT}/bin/include/versioning"
+
+if [ -z "${ARTIFACT_VERSION:-}" ]; then
+  . "${GIT_ROOT}/bin/include/versioning"
+fi
 
 BASEDIR="$(cd "$(dirname "$0")/.." && pwd)"
 CGO_ENABLED=0 go build -o "${BASEDIR}/binaries/cf-operator" -ldflags="-X code.cloudfoundry.org/cf-operator/version.Version=${ARTIFACT_VERSION}" cmd/cf-operator/main.go


### PR DESCRIPTION
Part of [#166081131](https://www.pivotaltracker.com/story/show/166081131)

The git commands can get messy when cf-operator is used as a git submodule. This PR enables overriding ARTIFACT_VERSION, especially for development purposes.