### PR TITLE
Add git submodule for vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Temporary Build Files
 /cf-operator
 binaries
-/vendor
 # Temp dir for generated kube files
 /_tmp
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor"]
+	path = vendor
+	url = https://github.com/cloudfoundry-incubator/cf-operator-vendor


### PR DESCRIPTION
The git submodule contains all vendored dependencies for CI.

[#166206612](https://www.pivotaltracker.com/story/show/166206612)