### PR TITLE
Removed Kubernetes module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/go-logr/zapr v0.1.0 // indirect
@@ -36,12 +35,10 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/ginkgo v1.6.0
 	github.com/onsi/gomega v1.4.2
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.2 // indirect
-	github.com/rohitsakala/goveralls v0.0.4 // indirect
 	github.com/spf13/afero v1.1.2
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
@@ -56,19 +53,15 @@ require (
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	golang.org/x/tools v0.0.0-20190410211219-2538eef75904 // indirect
 	google.golang.org/appengine v1.2.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/square/go-jose.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.1
-	k8s.io/api v0.0.0-20181213150558-05914d821849
-	k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476 // indirect
-	k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
-	k8s.io/client-go v2.0.0-alpha.0.0.20181213151034-8d9ed539ba31+incompatible
+	k8s.io/api v0.0.0-20190222213804-5cb15d344471
+	k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5 // indirect
+	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
+	k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible
 	k8s.io/klog v0.1.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20181024003938-96e8bb74ecdd // indirect
-	k8s.io/kubernetes v1.13.1
-	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
 	bdcv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
@@ -28,6 +27,7 @@ import (
 	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util"
+	podutil "code.cloudfoundry.org/cf-operator/pkg/kube/util/pod"
 )
 
 // Machine produces and destroys resources for tests

--- a/pkg/kube/controllers/extendedjob/pod_state.go
+++ b/pkg/kube/controllers/extendedjob/pod_state.go
@@ -1,12 +1,10 @@
 package extendedjob
 
 import (
-	"fmt"
+	corev1 "k8s.io/api/core/v1"
 
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	podutil "code.cloudfoundry.org/cf-operator/pkg/kube/util/pod"
 )
 
 // InferPodState determines our pod state
@@ -40,13 +38,4 @@ func InferPodState(pod corev1.Pod) ejv1.PodState {
 	}
 
 	return ejv1.PodStateUnknown
-}
-
-// PodStatusString gives a summary of the pods state
-func PodStatusString(pod corev1.Pod) string {
-	conditions := []string{}
-	for _, c := range pod.Status.Conditions {
-		conditions = append(conditions, fmt.Sprintf("%s", c.Type))
-	}
-	return fmt.Sprintf("phase=%s conditions=%s)", pod.Status.Phase, conditions)
 }

--- a/pkg/kube/controllers/extendedjob/trigger_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/trigger_reconciler.go
@@ -19,6 +19,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
+	podutil "code.cloudfoundry.org/cf-operator/pkg/kube/util/pod"
 )
 
 var _ reconcile.Reconciler = &TriggerReconciler{}
@@ -82,7 +83,7 @@ func (r *TriggerReconciler) Reconcile(request reconcile.Request) (result reconci
 	if podState == ejv1.PodStateUnknown {
 		ctxlog.Debugf(ctx,
 			"Failed to determine state %s: %#v",
-			PodStatusString(*pod),
+			podutil.GetPodStatusString(*pod),
 			pod.Status,
 		)
 		return

--- a/pkg/kube/controllers/extendedstatefulset/reconciler.go
+++ b/pkg/kube/controllers/extendedstatefulset/reconciler.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	podUtils "k8s.io/kubernetes/pkg/api/v1/pod"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -30,6 +29,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/finalizer"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/owner"
+	podutil "code.cloudfoundry.org/cf-operator/pkg/kube/util/pod"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/versionedsecretstore"
 )
 
@@ -462,7 +462,7 @@ func (r *ReconcileExtendedStatefulSet) isStatefulSetReady(ctx context.Context, s
 
 	for _, pod := range podList.Items {
 		if metav1.IsControlledBy(&pod, statefulSet) {
-			if podUtils.IsPodReady(&pod) {
+			if podutil.IsPodReady(&pod) {
 				ctxlog.Debug(ctx, "Pod '", statefulSet.Name, "' owned by StatefulSet '", statefulSet.Name, "' is running.")
 				return true, nil
 			}

--- a/pkg/kube/controllers/extendedstatefulset/volumes.go
+++ b/pkg/kube/controllers/extendedstatefulset/volumes.go
@@ -7,15 +7,16 @@ import (
 	"strconv"
 	"strings"
 
-	essv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 	"github.com/pkg/errors"
 	"k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	podUtils "k8s.io/kubernetes/pkg/api/v1/pod"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	essv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
+	podutil "code.cloudfoundry.org/cf-operator/pkg/kube/util/pod"
 )
 
 // alterVolumeManagementStatefulSet creates the volumemanagement statefulset for persistent volume claim creation
@@ -169,7 +170,7 @@ func (r *ReconcileExtendedStatefulSet) isVolumeManagementStatefulSetReady(ctx co
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to query for pod by name: %v", podName)
 		}
-		if !podUtils.IsPodReady(pod) {
+		if !podutil.IsPodReady(pod) {
 			return false, nil
 		}
 	}

--- a/pkg/kube/util/pod/util.go
+++ b/pkg/kube/util/pod/util.go
@@ -1,0 +1,40 @@
+package pod
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetPodStatusString gives a summary of the pods state.
+func GetPodStatusString(pod corev1.Pod) string {
+	conditions := []string{}
+	for _, c := range pod.Status.Conditions {
+		conditions = append(conditions, fmt.Sprintf("%s", c.Type))
+	}
+	return fmt.Sprintf("phase=%s conditions=%s)", pod.Status.Phase, conditions)
+}
+
+// IsPodReady returns whether the pod status is ready or not.
+func IsPodReady(pod *corev1.Pod) bool {
+	_, condition := GetPodCondition(&pod.Status, corev1.PodReady)
+	return condition != nil && condition.Status == corev1.ConditionTrue
+}
+
+// GetPodCondition returns:
+//   1. The index of the condition, or -1 if not present.
+//   2. The PodCondition.
+func GetPodCondition(
+	status *corev1.PodStatus,
+	conditionType corev1.PodConditionType,
+) (int, *corev1.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return i, &status.Conditions[i]
+		}
+	}
+	return -1, nil
+}


### PR DESCRIPTION
Removed Kubernetes as a Go Module since we were using only 2 functions.
The Kubernetes repository is not supposed to be depended on, we should rather depend on the individual packages that the github.com/kubernetes org provides.