### PR TITLE
[#166406309] Fix "strconv.Atoi: parsing" bug

### DIFF
--- a/pkg/kube/controllers/extendedstatefulset/reconciler.go
+++ b/pkg/kube/controllers/extendedstatefulset/reconciler.go
@@ -140,7 +140,7 @@ func (r *ReconcileExtendedStatefulSet) Reconcile(request reconcile.Request) (rec
 	// Get the actual StatefulSet
 	actualStatefulSet, actualVersion, err := r.getActualStatefulSet(ctx, exStatefulSet)
 	if err != nil {
-		ctxlog.WithEvent(exStatefulSet, "StatefulSetNotFound").Error(ctx, "Could not retrieve latest StatefulSet owned by ExtendedStatefulSet '", request.NamespacedName, "': ", err)
+		ctxlog.WithEvent(exStatefulSet, "StatefulSetNotFound").Error(ctx, "Could not retrieve latest StatefulSet owned by ExtendedStatefulSet '", exStatefulSet.Name, "' in namespace '", request.NamespacedName, "': ", err)
 		return reconcile.Result{}, err
 	}
 
@@ -396,6 +396,10 @@ func (r *ReconcileExtendedStatefulSet) getActualStatefulSet(ctx context.Context,
 
 	for _, ss := range statefulSets {
 		strVersion := ss.Annotations[essv1a1.AnnotationVersion]
+		if strVersion == "" {
+			return nil, 0, errors.New(fmt.Sprintf("The statefulset '%s' does not have the annotation('%s'), a version could not be retrieved.", ss.Name, essv1a1.AnnotationVersion))
+		}
+
 		version, err := strconv.Atoi(strVersion)
 		if err != nil {
 			return nil, 0, err


### PR DESCRIPTION
[#166406309](https://www.pivotaltracker.com/story/show/166406309)
The strconv.Atoi() was trying to parse a value that is retrieved
from an statefulset annotation. If the object does not have this
annotation, then the parsing will fail.

Fix this, by adding a check to see if the version is empty, before
trying to use the strconv.Atoi()