### PR TITLE
Support for BPM volumes

### DIFF
--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -340,16 +340,17 @@ The following subsections describe the mapping of BPM configuration into contain
 
 ### Resources
 
-| Bosh                   | Kube Pod Container                                             |
-| ---------------------- | -------------------------------------------------------------- |
-| `workdir`              | `workingDir`. Not implemented yet.                             |
-| `hooks`                | `initContainers` and container hooks. Not implemented yet.     |
-| `process.capabilities` | `container.SecurityContext.Capabilities`.                      |
-| `limits`               | `container.Resources.Limits`. Not implemented yet.             |
-| `ephemeral_disk`       | `emptyDir` volumes.                                            |
-| `persistent_disk`      | `PersistentVolumeClaims`.                                      |
-| `additional_volumes`   | `PersistentVolumeClaims`. Not yet implemented.                 |
-| `unsafe`               | `container.SecurityContext.Capabilities`. Not yet implemented. |
+| Bosh                          | Kube Pod Container                                              |
+| ----------------------------- | --------------------------------------------------------------- |
+| `workdir`                     | `workingDir`. Not implemented yet.                              |
+| `hooks`                       | `initContainers`. and container hooks. Not implemented yet.     |
+| `process.capabilities`        | `container.SecurityContext.Capabilities`.                       |
+| `limits`                      | `container.Resources.Limits`. Not implemented yet.              |
+| `ephemeral_disk`              | `emptyDir`. volumes.                                            |
+| `persistent_disk`             | `PersistentVolumeClaims`. Not yet implemented.                  |
+| `additional_volumes`          | `emptyDir`. Paths under /var/vcap/store are currently ignored.  |
+| `unsafe.unrestricted_volumes` | `emptyDir`. Paths under /var/vcap/store are currently ignored.  |
+| `unsafe`                      | `container.SecurityContext.Capabilities`. Not yet implemented.  |
 
 ### Health checks
 

--- a/pkg/bosh/manifest/container_factory.go
+++ b/pkg/bosh/manifest/container_factory.go
@@ -209,13 +209,10 @@ func generateBPMVolumes(bpmProcess bpm.Process, jobName string) ([]corev1.Volume
 		bpmVolumes = append(bpmVolumes, bpmEphemeralDisk)
 	}
 
-	if bpmProcess.PersistentDisk {
-		bpmPersistentDisk := corev1.VolumeMount{
-			Name:      fmt.Sprintf("%s-%s", VolumePersistentDirName, jobName),
-			MountPath: fmt.Sprintf("%s%s", VolumePersistentDirMountPath, jobName),
-		}
-		bpmVolumes = append(bpmVolumes, bpmPersistentDisk)
-	}
+	// TODO: skip this, while we need to figure it out a better way
+	// to define persistenVolumeClaims for jobs
+	// if bpmProcess.PersistentDisk {
+	// }
 
 	for i, additionalVolume := range bpmProcess.AdditionalVolumes {
 		match, _ := regexp.MatchString(AdditionalVolumesRegexValidation, additionalVolume.Path)

--- a/pkg/bosh/manifest/container_factory.go
+++ b/pkg/bosh/manifest/container_factory.go
@@ -215,11 +215,20 @@ func generateBPMVolumes(bpmProcess bpm.Process, jobName string) ([]corev1.Volume
 	// }
 
 	for i, additionalVolume := range bpmProcess.AdditionalVolumes {
-		match, _ := regexp.MatchString(AdditionalVolumesRegexValidation, additionalVolume.Path)
+		match, _ := regexp.MatchString(AdditionalVolumesRegex, additionalVolume.Path)
 		if !match {
 			return []corev1.VolumeMount{}, errors.Errorf("The %s path, must be a path inside"+
 				" /var/vcap/data, /var/vcap/store or /var/vcap/sys/run, for a path outside these,"+
 				" you must use the unrestricted_volumes key", additionalVolume.Path)
+		}
+
+		matchVcapStore, _ := regexp.MatchString(AdditionalVolumesVcapStoreRegex, additionalVolume.Path)
+
+		// TODO: skip additional volumes under /var/vcap/store
+		// while we need to figure it out a better way to define
+		// persistenVolumeClaims for jobs
+		if matchVcapStore {
+			continue
 		}
 		// TODO: How to map the following bpm volume schema fields
 		// - allow_executions

--- a/pkg/bosh/manifest/container_factory_test.go
+++ b/pkg/bosh/manifest/container_factory_test.go
@@ -108,28 +108,6 @@ var _ = Describe("ContainerFactory", func() {
 				}))
 		})
 
-		It("adds the persistent_disk volume", func() {
-			containers, err := act()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(containers[0].VolumeMounts).ToNot(ContainElement(
-				corev1.VolumeMount{
-					Name:             "bpm-persistent-disk-fake-job",
-					ReadOnly:         false,
-					MountPath:        fmt.Sprintf("%s%s", VolumePersistentDirMountPath, "fake-job"),
-					SubPath:          "",
-					MountPropagation: nil,
-				}))
-			Expect(containers[1].VolumeMounts).To(ContainElement(
-				corev1.VolumeMount{
-					Name:             "bpm-persistent-disk-other-job",
-					ReadOnly:         false,
-					MountPath:        fmt.Sprintf("%s%s", VolumePersistentDirMountPath, "other-job"),
-					SubPath:          "",
-					MountPropagation: nil,
-				}))
-
-		})
-
 		It("adds the additional volumes", func() {
 			containers, err := act()
 			Expect(err).ToNot(HaveOccurred())
@@ -269,21 +247,7 @@ var _ = Describe("ContainerFactory", func() {
 			It("generates hook init containers with bpm volumes for ephemeral disk", func() {
 				containers, err := act(false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(containers[5].VolumeMounts).To(HaveLen(8))
-				Expect(containers[5].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:             "bpm-persistent-disk-fake-job",
-						ReadOnly:         false,
-						MountPath:        fmt.Sprintf("%s%s", VolumePersistentDirMountPath, "fake-job"),
-						SubPath:          "",
-						MountPropagation: nil,
-					}))
-			})
-
-			It("generates hook init containers with bpm volumes for persistent disk", func() {
-				containers, err := act(false)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(containers[5].VolumeMounts).To(HaveLen(8))
+				Expect(containers[5].VolumeMounts).To(HaveLen(7))
 				Expect(containers[5].VolumeMounts).To(ContainElement(
 					corev1.VolumeMount{
 						Name:             "bpm-ephemeral-disk-fake-job",
@@ -297,7 +261,7 @@ var _ = Describe("ContainerFactory", func() {
 			It("generates hook init containers with bpm additional volumes", func() {
 				containers, err := act(false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(containers[5].VolumeMounts).To(HaveLen(8))
+				Expect(containers[5].VolumeMounts).To(HaveLen(7))
 				Expect(containers[5].VolumeMounts).To(ContainElement(
 					corev1.VolumeMount{
 						Name:             "bpm-additional-volume-fake-job-0",

--- a/pkg/bosh/manifest/container_factory_test.go
+++ b/pkg/bosh/manifest/container_factory_test.go
@@ -119,7 +119,7 @@ var _ = Describe("ContainerFactory", func() {
 					SubPath:          "",
 					MountPropagation: nil,
 				}))
-			Expect(containers[0].VolumeMounts).To(ContainElement(
+			Expect(containers[0].VolumeMounts).ToNot(ContainElement(
 				corev1.VolumeMount{
 					Name:             "bpm-additional-volume-fake-job-1",
 					ReadOnly:         true,
@@ -247,7 +247,7 @@ var _ = Describe("ContainerFactory", func() {
 			It("generates hook init containers with bpm volumes for ephemeral disk", func() {
 				containers, err := act(false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(containers[5].VolumeMounts).To(HaveLen(7))
+				Expect(containers[5].VolumeMounts).To(HaveLen(6))
 				Expect(containers[5].VolumeMounts).To(ContainElement(
 					corev1.VolumeMount{
 						Name:             "bpm-ephemeral-disk-fake-job",
@@ -261,7 +261,7 @@ var _ = Describe("ContainerFactory", func() {
 			It("generates hook init containers with bpm additional volumes", func() {
 				containers, err := act(false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(containers[5].VolumeMounts).To(HaveLen(7))
+				Expect(containers[5].VolumeMounts).To(HaveLen(6))
 				Expect(containers[5].VolumeMounts).To(ContainElement(
 					corev1.VolumeMount{
 						Name:             "bpm-additional-volume-fake-job-0",
@@ -270,7 +270,7 @@ var _ = Describe("ContainerFactory", func() {
 						SubPath:          "",
 						MountPropagation: nil,
 					}))
-				Expect(containers[5].VolumeMounts).To(ContainElement(
+				Expect(containers[5].VolumeMounts).ToNot(ContainElement(
 					corev1.VolumeMount{
 						Name:             "bpm-additional-volume-fake-job-1",
 						ReadOnly:         true,

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -369,15 +369,12 @@ func bpmVolumes(cfac *ContainerFactory, ig *InstanceGroup, manifestName string) 
 				}
 				bpmVolumes = append(bpmVolumes, eD)
 			}
-			if process.PersistentDisk {
-				pD := corev1.Volume{
-					Name: fmt.Sprintf("%s-%s", VolumePersistentDirName, job.Name),
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-%s-%s", manifestName, ig.Name, "pvc"),
-					}},
-				}
-				bpmVolumes = append(bpmVolumes, pD)
-			}
+
+			// TODO: skip this, while we need to figure it out a better way
+			// to define persistenVolumeClaims for jobs
+			// if process.PersistentDisk {
+			// }
+
 			for i := range process.AdditionalVolumes {
 				aV := corev1.Volume{
 					Name: fmt.Sprintf("%s-%s-%b", AdditionalVolume, job.Name, i),

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -375,16 +376,17 @@ func bpmVolumes(cfac *ContainerFactory, ig *InstanceGroup, manifestName string) 
 			// if process.PersistentDisk {
 			// }
 
-			for i := range process.AdditionalVolumes {
+			for i, additionalVolume := range process.AdditionalVolumes {
+				matchVcapStore, _ := regexp.MatchString(AdditionalVolumesVcapStoreRegex, additionalVolume.Path)
+				if matchVcapStore {
+					continue
+				}
 				aV := corev1.Volume{
-					Name: fmt.Sprintf("%s-%s-%b", AdditionalVolume, job.Name, i),
-					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: fmt.Sprintf("%s-%s-%s", manifestName, ig.Name, "pvc"),
-					}},
+					Name:         fmt.Sprintf("%s-%s-%b", AdditionalVolume, job.Name, i),
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 				}
 				bpmVolumes = append(bpmVolumes, aV)
 			}
-
 		}
 	}
 	return bpmVolumes

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -134,7 +134,7 @@ var _ = Describe("kube converter", func() {
 					Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))
 
 					// Test shared volume setup
-					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(7))
+					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(8))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
@@ -142,15 +142,17 @@ var _ = Describe("kube converter", func() {
 					Expect(stS.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/var/vcap/data/shared"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[5].ReadOnly).To(Equal(false))
-					Expect(stS.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/var/vcap/store"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("bpm-unrestricted-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/log"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[7].Name).To(Equal("store-dir"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[7].MountPath).To(Equal("/var/vcap/store"))
 					Expect(specCopierInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 					Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 
 					// Test share pod spec volumes
-					Expect(len(stS.Spec.Volumes)).To(Equal(9))
+					Expect(len(stS.Spec.Volumes)).To(Equal(10))
 
 					Expect(stS.Spec.Volumes[6].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
 					Expect(stS.Spec.Volumes[6].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
@@ -158,8 +160,11 @@ var _ = Describe("kube converter", func() {
 					Expect(stS.Spec.Volumes[7].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
 					Expect(stS.Spec.Volumes[7].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
 
-					Expect(stS.Spec.Volumes[8].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Volumes[8].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
+					Expect(stS.Spec.Volumes[8].Name).To(Equal("bpm-unrestricted-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Volumes[8].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
+
+					Expect(stS.Spec.Volumes[9].Name).To(Equal("store-dir"))
+					Expect(stS.Spec.Volumes[9].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
 
 					// Test the renderer container setup
 					Expect(rendererInitContainer.Env[0].Name).To(Equal("INSTANCE_GROUP_NAME"))

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -77,8 +77,7 @@ var _ = Describe("kube converter", func() {
 					Expect(eJob.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
 					Expect(eJob.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"/var/vcap/packages/test-server/bin/test-server"}))
 					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("bpm-ephemeral-disk-redis-server"))
-					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-persistent-disk-redis-server"))
-					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("bpm-additional-volume-redis-server-0"))
+					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-additional-volume-redis-server-0"))
 
 					// Test init containers in the extended job
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis"))
@@ -135,37 +134,32 @@ var _ = Describe("kube converter", func() {
 					Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))
 
 					// Test shared volume setup
-					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(8))
+					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(7))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/var/vcap/data/cflinuxfs3-rootfs-setup"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-persistent-disk-cflinuxfs3-rootfs-setup"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/var/vcap/store/cflinuxfs3-rootfs-setup"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/var/vcap/data/shared"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[6].ReadOnly).To(Equal(false))
-					Expect(stS.Spec.Containers[0].VolumeMounts[7].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[7].MountPath).To(Equal("/var/vcap/store"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/var/vcap/data/shared"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[5].ReadOnly).To(Equal(false))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("store-dir"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/var/vcap/store"))
 					Expect(specCopierInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 					Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 
 					// Test share pod spec volumes
-					Expect(len(stS.Spec.Volumes)).To(Equal(10))
+					Expect(len(stS.Spec.Volumes)).To(Equal(9))
 
 					Expect(stS.Spec.Volumes[6].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
 					Expect(stS.Spec.Volumes[6].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
 
-					Expect(stS.Spec.Volumes[7].Name).To(Equal("bpm-persistent-disk-cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Volumes[7].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
 					Expect(stS.Spec.Volumes[7].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
 
-					Expect(stS.Spec.Volumes[8].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Volumes[8].Name).To(Equal("store-dir"))
 					Expect(stS.Spec.Volumes[8].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
-
-					Expect(stS.Spec.Volumes[9].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Volumes[9].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
 
 					// Test the renderer container setup
 					Expect(rendererInitContainer.Env[0].Name).To(Equal("INSTANCE_GROUP_NAME"))

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -156,7 +156,7 @@ var _ = Describe("kube converter", func() {
 					Expect(stS.Spec.Volumes[6].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
 
 					Expect(stS.Spec.Volumes[7].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
-					Expect(stS.Spec.Volumes[7].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
+					Expect(stS.Spec.Volumes[7].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
 
 					Expect(stS.Spec.Volumes[8].Name).To(Equal("store-dir"))
 					Expect(stS.Spec.Volumes[8].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -76,6 +76,9 @@ var _ = Describe("kube converter", func() {
 					Expect(eJob.Spec.Template.Spec.Containers[0].Name).To(Equal("redis-server-test-server"))
 					Expect(eJob.Spec.Template.Spec.Containers[0].Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
 					Expect(eJob.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"/var/vcap/packages/test-server/bin/test-server"}))
+					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("bpm-ephemeral-disk-redis-server"))
+					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-persistent-disk-redis-server"))
+					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("bpm-additional-volume-redis-server-0"))
 
 					// Test init containers in the extended job
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis"))
@@ -132,18 +135,37 @@ var _ = Describe("kube converter", func() {
 					Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))
 
 					// Test shared volume setup
+					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(8))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(stS.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/var/vcap/store"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/var/vcap/data/cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[5].Name).To(Equal("bpm-persistent-disk-cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/var/vcap/store/cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/var/vcap/data/shared"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[6].ReadOnly).To(Equal(false))
+					Expect(stS.Spec.Containers[0].VolumeMounts[7].Name).To(Equal("store-dir"))
+					Expect(stS.Spec.Containers[0].VolumeMounts[7].MountPath).To(Equal("/var/vcap/store"))
 					Expect(specCopierInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(specCopierInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 					Expect(rendererInitContainer.VolumeMounts[0].Name).To(Equal("rendering-data"))
 					Expect(rendererInitContainer.VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))
 
 					// Test share pod spec volumes
-					Expect(stS.Spec.Volumes[6].Name).To(Equal("store-dir"))
-					Expect(stS.Spec.Volumes[6].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
+					Expect(len(stS.Spec.Volumes)).To(Equal(10))
+
+					Expect(stS.Spec.Volumes[6].Name).To(Equal("bpm-ephemeral-disk-cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Volumes[6].EmptyDir).To(Equal(&corev1.EmptyDirVolumeSource{}))
+
+					Expect(stS.Spec.Volumes[7].Name).To(Equal("bpm-persistent-disk-cflinuxfs3-rootfs-setup"))
+					Expect(stS.Spec.Volumes[7].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
+
+					Expect(stS.Spec.Volumes[8].Name).To(Equal("bpm-additional-volume-cflinuxfs3-rootfs-setup-0"))
+					Expect(stS.Spec.Volumes[8].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
+
+					Expect(stS.Spec.Volumes[9].Name).To(Equal("store-dir"))
+					Expect(stS.Spec.Volumes[9].PersistentVolumeClaim.ClaimName).To(Equal("foo-deployment-diego-cell-pvc"))
 
 					// Test the renderer container setup
 					Expect(rendererInitContainer.Env[0].Name).To(Equal("INSTANCE_GROUP_NAME"))

--- a/pkg/bosh/manifest/volume.go
+++ b/pkg/bosh/manifest/volume.go
@@ -28,4 +28,22 @@ const (
 	VolumeStoreDirName = "store-dir"
 	// VolumeStoreDirMountPath is the mount path for the store directory.
 	VolumeStoreDirMountPath = "/var/vcap/store"
+
+	// VolumeEphemeralDirName is the volume name for the ephemeral disk directory.
+	VolumeEphemeralDirName = "bpm-ephemeral-disk"
+	// VolumeEphemeralDirMountPath is the mount path for the ephemeral directory.
+	VolumeEphemeralDirMountPath = "/var/vcap/data/"
+
+	// VolumePersistentDirName is the volume name for the persistent disk directory.
+	VolumePersistentDirName = "bpm-persistent-disk"
+	// VolumePersistentDirMountPath is the mount path for the persistent directory.
+	VolumePersistentDirMountPath = "/var/vcap/store/"
+
+	// AdditionalVolume helps in building an additional volume name together with
+	// the index under the additional_volumes bpm list inside the bpm process schema
+	AdditionalVolume = "bpm-additional-volume"
+
+	// AdditionalVolumesRegexValidation ensures only a valid path is defined
+	// under the additional_volumes bpm list inside the bpm process schema
+	AdditionalVolumesRegexValidation = "((/var/vcap/data/.+)|(/var/vcap/store/.+)|(/var/vcap/sys/run/.+))"
 )

--- a/pkg/bosh/manifest/volume.go
+++ b/pkg/bosh/manifest/volume.go
@@ -45,4 +45,7 @@ const (
 	// AdditionalVolumesVcapStoreRegex ensures that the path is of the form
 	// /var/vcap/store
 	AdditionalVolumesVcapStoreRegex = "(/var/vcap/store/.+)"
+
+	// UnrestrictedVolume is the volume name for the unrestricted ones
+	UnrestrictedVolume = "bpm-unrestricted-volume"
 )

--- a/pkg/bosh/manifest/volume.go
+++ b/pkg/bosh/manifest/volume.go
@@ -34,11 +34,6 @@ const (
 	// VolumeEphemeralDirMountPath is the mount path for the ephemeral directory.
 	VolumeEphemeralDirMountPath = "/var/vcap/data/"
 
-	// VolumePersistentDirName is the volume name for the persistent disk directory.
-	VolumePersistentDirName = "bpm-persistent-disk"
-	// VolumePersistentDirMountPath is the mount path for the persistent directory.
-	VolumePersistentDirMountPath = "/var/vcap/store/"
-
 	// AdditionalVolume helps in building an additional volume name together with
 	// the index under the additional_volumes bpm list inside the bpm process schema
 	AdditionalVolume = "bpm-additional-volume"

--- a/pkg/bosh/manifest/volume.go
+++ b/pkg/bosh/manifest/volume.go
@@ -38,7 +38,11 @@ const (
 	// the index under the additional_volumes bpm list inside the bpm process schema
 	AdditionalVolume = "bpm-additional-volume"
 
-	// AdditionalVolumesRegexValidation ensures only a valid path is defined
+	// AdditionalVolumesRegex ensures only a valid path is defined
 	// under the additional_volumes bpm list inside the bpm process schema
-	AdditionalVolumesRegexValidation = "((/var/vcap/data/.+)|(/var/vcap/store/.+)|(/var/vcap/sys/run/.+))"
+	AdditionalVolumesRegex = "((/var/vcap/data/.+)|(/var/vcap/store/.+)|(/var/vcap/sys/run/.+))"
+
+	// AdditionalVolumesVcapStoreRegex ensures that the path is of the form
+	// /var/vcap/store
+	AdditionalVolumesVcapStoreRegex = "(/var/vcap/store/.+)"
 )

--- a/testing/boshreleases/releases.go
+++ b/testing/boshreleases/releases.go
@@ -43,6 +43,9 @@ processes:
     open_files: 1024
   ephemeral_disk: true
   persistent_disk: true
+  additional_volumes:
+  - path: /var/vcap/data/shared
+    writable: true
   unsafe:
     unrestricted_volumes:
     - path: /dev/log

--- a/testing/boshreleases/releases.go
+++ b/testing/boshreleases/releases.go
@@ -46,6 +46,8 @@ processes:
   additional_volumes:
   - path: /var/vcap/data/shared
     writable: true
+  - path: /var/vcap/store/foo
+    writable: true
   unsafe:
     unrestricted_volumes:
     - path: /dev/log


### PR DESCRIPTION
[#166404375](https://www.pivotaltracker.com/story/show/166404375)

This includes:
- bpm ephemeral disk support (uses a emptyDir volume)
- bpm persistent disk support (ignored for the moment)
- bpm additional volumes support (uses a emptyDir volume)
- bpm unrestricted volumes support (uses a emptyDir volume)

For both `additional_volumes` and ` unrestricted_volumes` , paths under `/var/vcap/store/` are not
supported, until we find a better way to handle persistentVolumesClaim.


This PR generates the volumeMounts for the above types, for the
containers(corev1.PodSpec)  and initContainers(only bpm hooks), and also a matching Volume for the pod definition.
