### PR TITLE
Add a machine readable event logs for predicates/reconciles

### DIFF
--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -2,6 +2,7 @@ package boshdeployment
 
 import (
 	"context"
+	"fmt"
 
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
@@ -42,11 +43,19 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 			o := e.Object.(*corev1.Secret)
 			shouldProcessEvent := isBPMInfoSecret(o)
 			if shouldProcessEvent {
-				ctxlog.WithEvent(o, "Predicates").Debugf(ctx,
-					"Secret %s creation allowed. Contains desired label %s, with value %s",
-					o.Name,
-					bdv1.LabelDeploymentSecretType,
-					o.GetLabels()[bdv1.LabelDeploymentSecretType])
+				ctxlog.WithEvent(o, "Predicates").DebugJSON(ctx,
+					"Filter for create events",
+					ctxlog.ReconcileEventsFromSource{
+						ReconciliationObjectName: e.Meta.GetName(),
+						ReconciliationObjectKind: bdv1.SecretType,
+						PredicateObjectName:      e.Meta.GetName(),
+						PredicateObjectKind:      bdv1.SecretType,
+						Namespace:                e.Meta.GetNamespace(),
+						Type:                     "predicate",
+						Message: fmt.Sprintf("Filter passed for %s, existing secret with label %s, value %s",
+							e.Meta.GetName(), bdv1.LabelDeploymentSecretType, o.GetLabels()[bdv1.LabelDeploymentSecretType]),
+					},
+				)
 			}
 
 			return shouldProcessEvent
@@ -57,11 +66,19 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 			o := e.ObjectNew.(*corev1.Secret)
 			shouldProcessEvent := isBPMInfoSecret(o)
 			if shouldProcessEvent {
-				ctxlog.WithEvent(o, "Predicates").Debugf(ctx,
-					"Secret %s update allowed. Contains desired label %s, with value %s",
-					o.Name,
-					bdv1.LabelDeploymentSecretType,
-					o.GetLabels()[bdv1.LabelDeploymentSecretType])
+				ctxlog.WithEvent(o, "Predicates").DebugJSON(ctx,
+					"Filter for update events",
+					ctxlog.ReconcileEventsFromSource{
+						ReconciliationObjectName: e.MetaNew.GetName(),
+						ReconciliationObjectKind: bdv1.SecretType,
+						PredicateObjectName:      e.MetaNew.GetName(),
+						PredicateObjectKind:      bdv1.SecretType,
+						Namespace:                e.MetaNew.GetNamespace(),
+						Type:                     "predicate",
+						Message: fmt.Sprintf("Filter passed for %s, new secret with label %s, value %s",
+							e.MetaNew.GetName(), bdv1.LabelDeploymentSecretType, o.GetLabels()[bdv1.LabelDeploymentSecretType]),
+					},
+				)
 			}
 
 			return shouldProcessEvent

--- a/pkg/kube/util/ctxlog/events.go
+++ b/pkg/kube/util/ctxlog/events.go
@@ -3,6 +3,7 @@ package ctxlog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -15,10 +16,24 @@ type event struct {
 	reason string
 }
 
+// ReconcileEventsFromSource for defining useful logs when defining
+// a mapping between a watched object and a
+// reconcile one
+type ReconcileEventsFromSource struct {
+	ReconciliationObjectName string `json:"reconciliationObjectName"`
+	ReconciliationObjectKind string `json:"reconciliationObjectKind"`
+	PredicateObjectName      string `json:"predicateObjectName"`
+	PredicateObjectKind      string `json:"predicateObjectKind"`
+	Namespace                string `json:"namespace"`
+	Message                  string `json:"message"`
+	Type                     string `json:"type"`
+}
+
 // EventLogger adds events and writes logs
 type EventLogger interface {
 	Infof(context.Context, string, ...interface{})
 	Debugf(context.Context, string, ...interface{})
+	DebugJSON(context.Context, string, interface{})
 	Errorf(context.Context, string, ...interface{}) error
 	Error(context.Context, ...interface{}) error
 }
@@ -28,6 +43,17 @@ func WithEvent(object runtime.Object, reason string) EventLogger {
 	return event{object: object, reason: reason}
 }
 
+// DebugJSON logs and adds an info event in json format
+func (ev event) DebugJSON(ctx context.Context, format string, objectInfo interface{}) {
+	log := ExtractLogger(ctx)
+
+	prettyJSON, _ := json.MarshalIndent(objectInfo, "", " ")
+	log.Debug(format, string(prettyJSON))
+
+	recorder := ExtractRecorder(ctx)
+	recorder.Event(ev.object, corev1.EventTypeNormal, ev.reason, fmt.Sprintf("%s \n%s", format, string(prettyJSON)))
+}
+
 // Debugf logs and adds an info event
 func (ev event) Debugf(ctx context.Context, format string, v ...interface{}) {
 	log := ExtractLogger(ctx)
@@ -35,6 +61,11 @@ func (ev event) Debugf(ctx context.Context, format string, v ...interface{}) {
 
 	recorder := ExtractRecorder(ctx)
 	recorder.Eventf(ev.object, corev1.EventTypeNormal, ev.reason, format, v...)
+}
+
+// GenReconcilePredicatesObject ...
+func GenReconcilePredicatesObject(ns string, t string, msg string, rKind string, pKind string) ReconcileEventsFromSource {
+	return ReconcileEventsFromSource{}
 }
 
 // Infof logs and adds an info event


### PR DESCRIPTION
[#166436624](https://www.pivotaltracker.com/story/show/166436624)

This event logs have two types:
- "Predicate" type, mainly for Create or Update events.
  Where the reconcile.Requests are coming from a source event
  of the same object type as the reconciled one.

- "Mapping" type, where the reconcile events, reconcile
  updates from one object into a different object type.

This will print the logs in a pretty.Json format.