### PR TITLE
Allow BPM-less jobs

### DIFF
--- a/pkg/bosh/bpm/config.go
+++ b/pkg/bosh/bpm/config.go
@@ -1,6 +1,8 @@
 package bpm
 
-import yaml "gopkg.in/yaml.v2"
+import (
+	yaml "gopkg.in/yaml.v2"
+)
 
 // Hooks from a BPM config
 type Hooks struct {

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -12,7 +12,7 @@ type BOSHContainerization struct {
 	Consumes  map[string]JobLink `yaml:"consumes"`
 	Instances []JobInstance      `yaml:"instances"`
 	Release   string             `yaml:"release"`
-	BPM       bpm.Config         `yaml:"bpm"`
+	BPM       *bpm.Config        `yaml:"bpm,omitempty"`
 	Ports     []Port             `yaml:"ports"`
 	Run       RunConfig          `yaml:"run"`
 }


### PR DESCRIPTION
If the job doesn't have `bpm.yml` and doesn't have `bosh_containerization.bpm`, then fail. If it only has `bosh_containerization.bpm`, then skip the `bpm.yml` rendering.