### PR TITLE
Make job names more readable

### DIFF
--- a/integration/extended_job_test.go
+++ b/integration/extended_job_test.go
@@ -485,10 +485,10 @@ var _ = Describe("ExtendedJob", func() {
 				jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 4)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 				Expect(jobs).To(HaveLen(4))
-				Expect(env.ContainJob(jobs, "job-extendedjob-foo")).To(Equal(true))
-				Expect(env.ContainJob(jobs, "job-slowjob-foo")).To(Equal(true))
-				Expect(env.ContainJob(jobs, "job-extendedjob-bar")).To(Equal(true))
-				Expect(env.ContainJob(jobs, "job-slowjob-bar")).To(Equal(true))
+				Expect(env.ContainJob(jobs, "extendedjob-foo")).To(Equal(true))
+				Expect(env.ContainJob(jobs, "slowjob-foo")).To(Equal(true))
+				Expect(env.ContainJob(jobs, "extendedjob-bar")).To(Equal(true))
+				Expect(env.ContainJob(jobs, "slowjob-bar")).To(Equal(true))
 
 				By("checking if owner ref is set")
 				eJob, err := env.GetExtendedJob(env.Namespace, "extendedjob")
@@ -497,10 +497,10 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, job := range jobs {
-					if strings.Contains(job.GetName(), "job-extendedjob-") {
+					if strings.Contains(job.GetName(), "extendedjob-") {
 						Expect(job.GetOwnerReferences()).Should(ContainElement(jobOwnerRef(*eJob)))
 					}
-					if strings.Contains(job.GetName(), "job-slowjob-") {
+					if strings.Contains(job.GetName(), "slowjob-") {
 						Expect(job.GetOwnerReferences()).Should(ContainElement(jobOwnerRef(*slowJob)))
 					}
 				}

--- a/pkg/bosh/manifest/job_factory.go
+++ b/pkg/bosh/manifest/job_factory.go
@@ -117,7 +117,7 @@ func (f *JobFactory) VariableInterpolationJob() (*ejv1.ExtendedJob, error) {
 		false,
 	)
 
-	eJobName := fmt.Sprintf("var-interpolation-%s", f.Manifest.Name)
+	eJobName := fmt.Sprintf("vi-%s", f.Manifest.Name)
 
 	// Construct the var interpolation job
 	job := &ejv1.ExtendedJob{
@@ -188,7 +188,7 @@ func (f *JobFactory) DataGatheringJob() (*ejv1.ExtendedJob, error) {
 		containers[idx] = f.gatheringContainer("data-gather", ig.Name)
 	}
 
-	eJobName := fmt.Sprintf("data-gathering-%s", f.Manifest.Name)
+	eJobName := fmt.Sprintf("dg-%s", f.Manifest.Name)
 	return f.gatheringJob(eJobName, names.DeploymentSecretTypeInstanceGroupResolvedProperties, containers)
 }
 
@@ -202,7 +202,7 @@ func (f *JobFactory) BPMConfigsJob() (*ejv1.ExtendedJob, error) {
 		containers[idx] = f.gatheringContainer("bpm-configs", ig.Name)
 	}
 
-	eJobName := fmt.Sprintf("bpm-configs-%s", f.Manifest.Name)
+	eJobName := fmt.Sprintf("bpm-%s", f.Manifest.Name)
 	return f.gatheringJob(eJobName, names.DeploymentSecretBpmInformation, containers)
 }
 

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -264,7 +264,7 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 					switch object := object.(type) {
 					case *ejv1.ExtendedJob:
 						eJob := object
-						if strings.HasPrefix(eJob.Name, "var-interpolation") {
+						if strings.HasPrefix(eJob.Name, "vi-") {
 							return errors.New("fake-error")
 						}
 					}
@@ -273,7 +273,7 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to apply ExtendedJob 'var-interpolation-foo' for variable interpolation: fake-error"))
+				Expect(err.Error()).To(ContainSubstring("failed to apply ExtendedJob 'vi-foo' for variable interpolation: fake-error"))
 			})
 
 			It("handles an errors when creating data gathering eJob", func() {
@@ -298,7 +298,7 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 					switch object := object.(type) {
 					case *ejv1.ExtendedJob:
 						eJob := object
-						if strings.HasPrefix(eJob.Name, "data-gathering") {
+						if strings.HasPrefix(eJob.Name, "dg-") {
 							return errors.New("fake-error")
 						}
 					}
@@ -307,7 +307,7 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to apply ExtendedJob 'data-gathering-foo' for data gathering: fake-error"))
+				Expect(err.Error()).To(ContainSubstring("failed to apply ExtendedJob 'dg-foo' for data gathering: fake-error"))
 			})
 		})
 	})

--- a/pkg/kube/controllers/extendedjob/trigger_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/trigger_reconciler_test.go
@@ -226,9 +226,9 @@ var _ = Describe("TriggerReconciler", func() {
 
 					jobs := obj.Items
 					Expect(jobs).To(HaveLen(2))
-					Expect(jobs[0].Name).To(ContainSubstring("job-foo-"))
+					Expect(jobs[0].Name).To(ContainSubstring("foo-fake-pod"))
 					Expect(jobs[0].Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"sleep", "1"}))
-					Expect(jobs[1].Name).To(ContainSubstring("job-bar-"))
+					Expect(jobs[1].Name).To(ContainSubstring("bar-fake-pod"))
 					Expect(jobs[1].Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"sleep", "15"}))
 					Expect(logs.FilterMessageSnippet("Created job for 'foo' via pod fake-pod/ready").Len()).To(Equal(1))
 					Expect(logs.FilterMessageSnippet("Created job for 'bar' via pod fake-pod/ready").Len()).To(Equal(1))

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -146,21 +146,20 @@ func GetVersionFromVersionedSecretName(name string) (int, error) {
 
 // JobName returns a unique, short name for a given eJob, pod(if exists) combination
 // k8s allows 63 chars, but the pod will have -\d{6} appended
+// So we return max 56 chars: name19(-podname19)-suffix16
 func JobName(eJobName, podName string) (string, error) {
-	suffix := ""
+	name := ""
 	if podName == "" {
-		suffix = truncate(eJobName, 15)
+		name = truncate(eJobName, 39)
 	} else {
-		suffix = fmt.Sprintf("%s-%s", truncate(eJobName, 15), truncate(podName, 15))
+		name = fmt.Sprintf("%s-%s", truncate(eJobName, 19), truncate(podName, 19))
 	}
 
-	namePrefix := fmt.Sprintf("job-%s", suffix)
-
-	hashID, err := randSuffix(suffix)
+	hashID, err := randSuffix(name)
 	if err != nil {
 		return "", errors.Wrap(err, "could not randomize job suffix")
 	}
-	return fmt.Sprintf("%s-%s", namePrefix, hashID), nil
+	return fmt.Sprintf("%s-%s", name, hashID), nil
 }
 
 // ServiceName returns a unique, short name for a given instance
@@ -215,7 +214,6 @@ func randSuffix(str string) (string, error) {
 }
 
 func truncate(name string, max int) string {
-	name = strings.Replace(name, "-", "", -1)
 	if len(name) > max {
 		return name[0:max]
 	}


### PR DESCRIPTION
Remove the 'job-' prefix. Allow more characters, test and add code comments on how name is derived.

Before `kubectl get jobs -A --watch`:

```
test  job-varinterpolatio-86520fcc3fed9262   0/1                      0s
test  job-datagatheringte-f64e014e830f657a   0/1                      0s
test  job-bpmconfigstestb-61881c107cd7c4e2   0/1                      0s
```
Now:

```
test   vi-test-b7de7af5a15c9acf               0/1                      0s
test   dg-test-551801e05edd5ef9               0/1                      0s
test   bpm-test-adc56ecb205b0bc5              0/1                      0s
```

[#166502851](https://www.pivotaltracker.com/story/show/166502851)