### PR TITLE
Remove webhook dirs after integration tests

### DIFF
--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -4,25 +4,29 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"time"
 
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
-	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
-	"code.cloudfoundry.org/cf-operator/testing"
 	"github.com/spf13/afero"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/operator"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
+	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
+	"code.cloudfoundry.org/cf-operator/testing"
 )
 
 // StopFunc is used to clean up the environment
@@ -96,6 +100,10 @@ func (e *Environment) Setup(node int32) (TearDownFunc, StopFunc, error) {
 			close(e.stop)
 		}
 	}, nil
+}
+
+func (e *Environment) RemoveWebhookCache(node int32) {
+	os.RemoveAll(path.Join(controllers.WebhookConfigDir, controllers.WebhookConfigPrefix+getNamespace(node)))
 }
 
 // FlushLog flushes the zap log

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -48,6 +48,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	env.RemoveWebhookCache(int32(config.GinkgoConfig.ParallelNode))
 	if stopOperator != nil {
 		time.Sleep(3 * time.Second)
 		defer stopOperator()

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,6 +32,10 @@ import (
 const (
 	// HTTPReadyzEndpoint route
 	HTTPReadyzEndpoint = "/readyz"
+	// WebhookConfigPrefix is the prefix for the dir containing the webhook SSL certs
+	WebhookConfigPrefix = "cf-operator-mutating-hook-"
+	// WebhookConfigDir contains the dir with the webhook SSL certs
+	WebhookConfigDir = "/tmp"
 )
 
 var addToManagerFuncs = []func(context.Context, *config.Config, manager.Manager) error{
@@ -75,7 +80,7 @@ func AddToScheme(s *runtime.Scheme) error {
 func AddHooks(ctx context.Context, config *config.Config, m manager.Manager, generator credsgen.Generator) error {
 	ctxlog.Infof(ctx, "Setting up webhook server on %s:%d", config.WebhookServerHost, config.WebhookServerPort)
 
-	webhookConfig := NewWebhookConfig(m.GetClient(), config, generator, "cf-operator-mutating-hook-"+config.Namespace)
+	webhookConfig := NewWebhookConfig(m.GetClient(), config, generator, WebhookConfigPrefix+config.Namespace)
 
 	disableConfigInstaller := true
 	hookServer, err := webhook.NewServer("cf-operator", m, webhook.ServerOptions{

--- a/pkg/kube/controllers/webhook_configuration.go
+++ b/pkg/kube/controllers/webhook_configuration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
+
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,7 +29,8 @@ import (
 
 // WebhookConfig generates certificates and the configuration for the webhook server
 type WebhookConfig struct {
-	ConfigName    string
+	ConfigName string
+	// CertDir is not deleted automatically, so we can re-use the same SSL between operator restarts in production
 	CertDir       string
 	Certificate   []byte
 	Key           []byte
@@ -44,7 +46,7 @@ type WebhookConfig struct {
 func NewWebhookConfig(c client.Client, config *config.Config, generator credsgen.Generator, configName string) *WebhookConfig {
 	return &WebhookConfig{
 		ConfigName: configName,
-		CertDir:    path.Join("/tmp", configName),
+		CertDir:    path.Join(WebhookConfigDir, configName),
 		client:     c,
 		config:     config,
 		generator:  generator,


### PR DESCRIPTION
Running integration tests locally leaves a lot of those dirs in /tmp

[#166541753](https://www.pivotaltracker.com/story/show/166541753)