### PR TITLE
Ensure all labels are prepended by the fissile.cloudfoundry.org

### DIFF
--- a/docs/controllers/extendedjob.md
+++ b/docs/controllers/extendedjob.md
@@ -36,7 +36,7 @@ E.g. when a `Pod` is created, deleted, transitioned to **ready** or a
 The execution of `ExtendedJob` can be limited to pods with certain labels.
 
 A separate native k8s `Job` is started for every pod that changes. The `Job`
-has a label `triggering-pod: uid` to identify which pod it is running for.
+has a label `fissile.cloudfoundry.org/triggering-pod: uid` to identify which pod it is running for.
 
 `ExtendedJob` does not trigger for pods from other `Jobs`. This is done by checking if
 a pod has a label `job-name`. The `job-name` label is [assigned by Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) to `Job` `Pods`.

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -2,10 +2,12 @@ package kube_test
 
 import (
 	b64 "encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/testing"
 
 	. "github.com/onsi/ginkgo"
@@ -43,10 +45,10 @@ var _ = Describe("Examples", func() {
 				err = kubectlHelper.Wait(namespace, "ready", "pod/foo-pod-1")
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=ready-triggered-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=ready-triggered-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=ready-triggered-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=ready-triggered-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -72,7 +74,7 @@ var _ = Describe("Examples", func() {
 				err = kubectlHelper.DeleteResource(namespace, "pod", "foo-pod-1")
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=delete-triggered-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=delete-triggered-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -183,10 +185,10 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for pods")
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=deletes-pod-1")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=deletes-pod-1", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "terminate", "pod", "ejob-name=deletes-pod-1")
+				err = kubectlHelper.WaitLabelFilter(namespace, "terminate", "pod", fmt.Sprintf("%s=deletes-pod-1", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -199,10 +201,10 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for pods")
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=one-time-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=one-time-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=one-time-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=one-time-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -215,14 +217,14 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for pods")
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=auto-errand-sleep-again")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=auto-errand-sleep-again", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=auto-errand-sleep-again")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=auto-errand-sleep-again", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Delete the pod")
-				err = kubectlHelper.DeleteLabelFilter(namespace, "pod", "ejob-name=auto-errand-sleep-again")
+				err = kubectlHelper.DeleteLabelFilter(namespace, "pod", fmt.Sprintf("%s=auto-errand-sleep-again", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Update the config change")
@@ -231,10 +233,10 @@ var _ = Describe("Examples", func() {
 				err = kubectlHelper.Apply(namespace, yamlFilePath)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=auto-errand-sleep-again")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=auto-errand-sleep-again", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=auto-errand-sleep-again")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=auto-errand-sleep-again", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -254,10 +256,10 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for pods")
-				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", "ejob-name=manual-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "ready", "pod", fmt.Sprintf("%s=manual-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=manual-sleep")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=manual-sleep", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -270,7 +272,7 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for pods")
-				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", "ejob-name=myfoo")
+				err = kubectlHelper.WaitLabelFilter(namespace, "complete", "pod", fmt.Sprintf("%s=myfoo", ejv1.LabelEJobName))
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking for secret")

--- a/integration/extended_job_test.go
+++ b/integration/extended_job_test.go
@@ -53,7 +53,7 @@ var _ = Describe("ExtendedJob", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+			jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 			Expect(jobs).To(HaveLen(1))
 		})
@@ -64,7 +64,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-				jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+				jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 				Expect(jobs).To(HaveLen(1))
 
@@ -86,7 +86,7 @@ var _ = Describe("ExtendedJob", func() {
 						Expect(err).NotTo(HaveOccurred())
 						defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-						jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+						jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 						Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 						Expect(jobs).To(HaveLen(1))
 
@@ -107,7 +107,7 @@ var _ = Describe("ExtendedJob", func() {
 						Expect(err).NotTo(HaveOccurred())
 						defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-						jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+						jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 						Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 						Expect(jobs).To(HaveLen(1))
 
@@ -130,7 +130,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-				jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+				jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 				Expect(jobs).To(HaveLen(1))
 
@@ -169,7 +169,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 				tearDowns = append(tearDowns, tearDownEJ)
 
-				_, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+				_, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -188,7 +188,7 @@ var _ = Describe("ExtendedJob", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					By("checking if job is running")
-					jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+					jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(jobs).To(HaveLen(1))
 				})
@@ -221,7 +221,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 				tearDowns = append(tearDowns, tearDownEJ)
 
-				_, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+				_, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -263,7 +263,7 @@ var _ = Describe("ExtendedJob", func() {
 					defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 					By("waiting for the job to start")
-					_, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+					_, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -288,7 +288,7 @@ var _ = Describe("ExtendedJob", func() {
 					defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 					By("waiting for the job to start")
-					_, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+					_, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -313,7 +313,7 @@ var _ = Describe("ExtendedJob", func() {
 					defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 					By("waiting for the job to start")
-					_, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+					_, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -330,7 +330,7 @@ var _ = Describe("ExtendedJob", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			exists, err := env.WaitForJobExists(env.Namespace, "extendedjob=true")
+			exists, err := env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeFalse())
 
@@ -341,7 +341,7 @@ var _ = Describe("ExtendedJob", func() {
 			err = env.UpdateExtendedJob(env.Namespace, *latest)
 			Expect(err).NotTo(HaveOccurred())
 
-			exists, err = env.WaitForJobExists(env.Namespace, "extendedjob=true")
+			exists, err = env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeFalse())
 		})
@@ -352,7 +352,7 @@ var _ = Describe("ExtendedJob", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+			jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 			Expect(jobs).To(HaveLen(1))
 		})
@@ -372,7 +372,7 @@ var _ = Describe("ExtendedJob", func() {
 			err = env.UpdateExtendedJob(env.Namespace, *latest)
 			Expect(err).NotTo(HaveOccurred())
 
-			jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+			jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 			Expect(jobs).To(HaveLen(1))
 
@@ -397,7 +397,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred(), "error waiting for pods")
 
 				By("waiting for the job")
-				_, err = env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+				_, err = env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 			})
 		})
@@ -415,7 +415,7 @@ var _ = Describe("ExtendedJob", func() {
 				Expect(err).NotTo(HaveOccurred())
 				defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-				exists, err := env.WaitForJobExists(env.Namespace, "extendedjob=true")
+				exists, err := env.WaitForJobExists(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(exists).To(BeFalse())
 			})
@@ -442,12 +442,12 @@ var _ = Describe("ExtendedJob", func() {
 				defer func(tdf environment.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 				By("waiting for the job")
-				_, err = env.CollectJobs(env.Namespace, "extendedjob=true", 1)
+				_, err = env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 1)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 
-				_, err = env.DeleteJobs(env.Namespace, "extendedjob=true")
+				_, err = env.DeleteJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(env.WaitForJobsDeleted(env.Namespace, "extendedjob=true")).To(Succeed())
+				Expect(env.WaitForJobsDeleted(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob))).To(Succeed())
 			})
 
 			It("should start a job for a matched pod", func() {
@@ -481,7 +481,7 @@ var _ = Describe("ExtendedJob", func() {
 				}
 
 				By("waiting for the jobs")
-				jobs, err := env.CollectJobs(env.Namespace, "extendedjob=true", 4)
+				jobs, err := env.CollectJobs(env.Namespace, fmt.Sprintf("%s=true", ejv1.LabelExtendedJob), 4)
 				Expect(err).NotTo(HaveOccurred(), "error waiting for jobs from extendedjob")
 				Expect(jobs).To(HaveLen(4))
 				Expect(env.ContainJob(jobs, "extendedjob-foo")).To(Equal(true))

--- a/pkg/kube/apis/extendedjob/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedjob/v1alpha1/types.go
@@ -24,16 +24,14 @@ var (
 	// LabelInstanceGroup is a label for persisted secrets, identifying
 	// the instance group they belong to
 	LabelInstanceGroup = fmt.Sprintf("%s/instance-group", apis.GroupName)
-)
 
-const (
 	// LabelExtendedJob key for label used to identify extendedjob. Value
 	// is set to true if the batchv1.Job is from an ExtendedJob
-	LabelExtendedJob = "extendedjob"
+	LabelExtendedJob = fmt.Sprintf("%s/extendedjob", apis.GroupName)
 	// LabelEJobName key for label on a batchv1.Job's pod, which is set to the ExtendedJob's name
-	LabelEJobName = "ejob-name"
+	LabelEJobName = fmt.Sprintf("%s/ejob-name", apis.GroupName)
 	// LabelTriggeringPod key for label, which is set to the UID of the pod that triggered an ExtendedJob
-	LabelTriggeringPod = "triggering-pod"
+	LabelTriggeringPod = fmt.Sprintf("%s/triggering-pod", apis.GroupName)
 )
 
 // ExtendedJobSpec defines the desired state of ExtendedJob


### PR DESCRIPTION
[#166441759](https://www.pivotaltracker.com/n/projects/2192232/stories/166441759)
Update tests using hardcoded string for the labels.
Update code that uses the labels, to use the new definition.
Make sure labels in test are not using plain values, but rather
a pkg variable.