### PR TITLE
Generate files for initContainers when dumping logs

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -155,7 +155,8 @@ var _ = Describe("Deploy", func() {
 			Expect(len(pods.Items)).To(Equal(2))
 			pod := pods.Items[1]
 			Expect(pod.Spec.InitContainers).To(HaveLen(5))
-			Expect(pod.Spec.InitContainers[4].Command[0]).To(Equal("/var/vcap/jobs/garden/bin/bpm-pre-start"))
+			Expect(pod.Spec.InitContainers[4].Args).To(ContainElement("/var/vcap/jobs/garden/bin/bpm-pre-start"))
+			Expect(pod.Spec.InitContainers[4].Command[0]).To(Equal("/bin/sh"))
 		})
 	})
 

--- a/pkg/bosh/manifest/container_factory.go
+++ b/pkg/bosh/manifest/container_factory.go
@@ -212,9 +212,11 @@ func jobSpecCopierContainer(releaseName string, jobImage string, volumeMountName
 			},
 		},
 		Command: []string{
-			"bash",
-			"-c",
-			fmt.Sprintf(`mkdir -p "%s" && cp -ar %s/* "%s"`, inContainerReleasePath, VolumeJobsSrcDirMountPath, inContainerReleasePath),
+			"/bin/sh",
+		},
+		Args: []string{
+			"-xc",
+			fmt.Sprintf("mkdir -p %s && cp -ar %s/* %s", inContainerReleasePath, VolumeJobsSrcDirMountPath, inContainerReleasePath),
 		},
 	}
 }
@@ -252,7 +254,13 @@ func templateRenderingContainer(instanceGroupName string, secretName string) cor
 				Value: VolumeRenderingDataMountPath,
 			},
 		},
-		Args: []string{"util", "template-render"},
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-xc",
+			"cf-operator util template-render",
+		},
 	}
 }
 
@@ -276,9 +284,14 @@ func createDirContainer(name string, jobs []Job) corev1.Container {
 				MountPath: VolumeSysDirMountPath,
 			},
 		},
-		Env:     []corev1.EnvVar{},
-		Command: []string{"/bin/sh", "-c"},
-		Args:    []string{fmt.Sprintf("mkdir -p %s", strings.Join(dirs, " "))},
+		Env: []corev1.EnvVar{},
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-xc",
+			fmt.Sprintf("mkdir -p %s", strings.Join(dirs, " ")),
+		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &vcapUserID,
 		},
@@ -295,8 +308,13 @@ func boshPreStartInitContainer(
 		Name:         names.Sanitize(fmt.Sprintf("bosh-pre-start-%s", jobName)),
 		Image:        jobImage,
 		VolumeMounts: volumeMounts,
-		Command:      []string{"/bin/sh", "-c"},
-		Args:         []string{fmt.Sprintf(`if [ -x "%[1]s" ]; then "%[1]s"; fi`, boshPreStart)},
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-xc",
+			fmt.Sprintf(`if [ -x "%[1]s" ]; then "%[1]s"; fi`, boshPreStart),
+		},
 	}
 }
 
@@ -309,7 +327,13 @@ func bpmPreStartInitContainer(
 		Name:         names.Sanitize(fmt.Sprintf("bpm-pre-start-%s", process.Name)),
 		Image:        jobImage,
 		VolumeMounts: volumeMounts,
-		Command:      []string{process.Hooks.PreStart},
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-xc",
+			process.Hooks.PreStart,
+		},
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &process.Unsafe.Privileged,
 		},

--- a/pkg/bosh/manifest/container_factory_test.go
+++ b/pkg/bosh/manifest/container_factory_test.go
@@ -461,7 +461,7 @@ var _ = Describe("ContainerFactory", func() {
 				containers, err := act()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(containers).To(HaveLen(6))
-				Expect(containers[5].Command).To(ContainElement("fake-cmd"))
+				Expect(containers[5].Args).To(ContainElement("fake-cmd"))
 			})
 
 			It("generates hook init containers with bpm volumes for ephemeral disk", func() {

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -84,7 +84,7 @@ var _ = Describe("kube converter", func() {
 					// Test init containers in the extended job
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-redis"))
 					Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
-					Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
+					Expect(specCopierInitContainer.Command[0]).To(Equal("/bin/sh"))
 					Expect(rendererInitContainer.Image).To(Equal("/:"))
 					Expect(rendererInitContainer.Name).To(Equal("renderer-redis-slave"))
 
@@ -130,7 +130,7 @@ var _ = Describe("kube converter", func() {
 					// Test init containers in the extended statefulSet
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 					Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/cflinuxfs3:opensuse-15.0-28.g837c5b3-30.263-7.0.0_233.gde0accd0-0.62.0"))
-					Expect(specCopierInitContainer.Command[0]).To(Equal("bash"))
+					Expect(specCopierInitContainer.Command[0]).To(Equal("/bin/sh"))
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 					Expect(rendererInitContainer.Image).To(Equal("/:"))
 					Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))

--- a/testing/dump_env.sh
+++ b/testing/dump_env.sh
@@ -26,10 +26,19 @@ function get_containers_of_pod() {
   kubectl get pods "${POD}" --namespace "${NS}" --output=jsonpath='{.spec.containers[*].name}'
 }
 
+function get_init_containers_of_pod() {
+  kubectl get pods "${POD}" --namespace "${NS}" --output=jsonpath='{.spec.initContainers[*].name}'
+}
+
 function retrieve_container_kube_logs() {
   printf " Kube logs"
   kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}"            > "${CONTAINER_DIR}/kube.log"
   kubectl logs "${POD}" --namespace "${NS}" --container "${CONTAINER}" --previous > "${CONTAINER_DIR}/kube-previous.log"
+}
+
+function retrieve_init_container_kube_logs() {
+  printf " Kube logs"
+  kubectl logs "${POD}" --namespace "${NS}" --container "${INITCONTAINER}"            > "${INIT_CONTAINER_DIR}/kube.log"
 }
 
 function get_all_resources() {
@@ -95,11 +104,23 @@ for POD in "${PODS[@]}"; do
   # Iterate over containers and dump logs.
   CONTAINERS=($(get_containers_of_pod))
   for CONTAINER in "${CONTAINERS[@]}"; do
-    printf "  - \e[0;32m${CONTAINER}\e[0m logs:"
+    printf "  container - \e[0;32m${CONTAINER}\e[0m logs:"
 
     CONTAINER_DIR="${POD_DIR}/${CONTAINER}"
     mkdir -p ${CONTAINER_DIR}
     retrieve_container_kube_logs 2> /dev/null || true
+
+    printf "\n"
+  done
+
+  # Iterate over initContainers and dump logs.
+  INITCONTAINERS=($(get_init_containers_of_pod))
+  for INITCONTAINER in "${INITCONTAINERS[@]}"; do
+    printf "  initContainer - \e[0;32m${INITCONTAINER}\e[0m logs:"
+
+    INIT_CONTAINER_DIR="${POD_DIR}/init-containers/${INITCONTAINER}"
+    mkdir -p ${INIT_CONTAINER_DIR}
+    retrieve_init_container_kube_logs 2> /dev/null || true
 
     printf "\n"
   done


### PR DESCRIPTION
[#166661635](https://www.pivotaltracker.com/story/show/166661635)

Generate files for initContainers when dumping logs
- For every pod, add an initcontainer dir, with a kube.log file

Modify initContainer cmd and args, to have a common struct
- Use Command and Args fields, when defining the corev1.Container
- Use '-x'  to dump an stack of the executed cmd into the pod logs