### PR TITLE
Support Kubernetes Affinity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/directxman12/zapr v0.1.1
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
@@ -57,12 +57,10 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
-	k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5 // indirect
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible
 	k8s.io/klog v0.1.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20181024003938-96e8bb74ecdd // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
-	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
+	goyaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
@@ -118,7 +119,7 @@ var (
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Affinity    Affinity          `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	Affinity    *Affinity         `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 }
 
 type Affinity corev1.Affinity
@@ -132,7 +133,7 @@ func (a *Affinity) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	yamlByte, err := yaml.Marshal(c)
+	yamlByte, err := goyaml.Marshal(c)
 	if err != nil {
 		return fmt.Errorf("error marshaling 'JobProperties' into JSON: %v", err)
 	}

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -195,17 +195,18 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},
-							Affinity: &corev1.Affinity{
-								NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
-								PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
-								PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
-							},
 						},
 					},
 				},
 			},
 		},
 	}
+
+	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
+		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
+		extSts.Spec.Template.Spec.Template.Spec.Affinity = &affinity
+	}
+
 	return extSts, nil
 }
 
@@ -350,14 +351,14 @@ func (kc *KubeConverter) errandToExtendedJob(
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &admGroupID,
 					},
-					Affinity: &corev1.Affinity{
-						NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
-						PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
-						PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
-					},
 				},
 			},
 		},
+	}
+
+	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
+		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
+		eJob.Spec.Template.Spec.Affinity = &affinity
 	}
 	return eJob, nil
 }

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -195,6 +195,11 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
+								PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
+								PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
+							},
 						},
 					},
 				},
@@ -344,6 +349,11 @@ func (kc *KubeConverter) errandToExtendedJob(
 					Volumes:        volumes,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &admGroupID,
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
+						PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
+						PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
 					},
 				},
 			},

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -553,7 +553,7 @@ const GardenRunc = `
           timestamp: "rfc3339"
 `
 
-// BPMReleaseWithoutPersistentDisk doesn't container persistent disk declaration
+// BPMReleaseWithoutPersistentDisk doesn't contain persistent disk declaration
 const BPMReleaseWithoutPersistentDisk = `
 name: bpm
 
@@ -633,4 +633,105 @@ instance_groups:
   - name: fake-job-d
     release: fake-release
   persistent_disk: 1024
+`
+
+// BPMReleaseWithAffinity contains affinity information
+const BPMReleaseWithAffinity = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+
+instance_groups:
+- name: bpm1
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/unit-test-az-name
+                    operator: In
+                    values:
+                    - unit-test-az1
+                    - unit-test-az2
+- name: bpm2
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: security
+                    operator: In
+                    values:
+                    - S1
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+- name: bpm3
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: security
+                        operator: In
+                        values:
+                        - S2
+                  topologyKey: failure-domain.beta.kubernetes.io/zone
 `

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -138,6 +138,15 @@ func (c *Catalog) BOSHManifestWithoutPersistentDisk() *manifest.Manifest {
 	return m
 }
 
+// BPMReleaseWithAffinity returns a manifest with affinity
+func (c *Catalog) BPMReleaseWithAffinity() *manifest.Manifest {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithAffinity))
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
 // DefaultBOSHManifestConfigMap for tests
 func (c *Catalog) DefaultBOSHManifestConfigMap(name string) corev1.ConfigMap {
 	return corev1.ConfigMap{


### PR DESCRIPTION
[#165909121](https://www.pivotaltracker.com/story/show/165909121)

This PR is working on:
- Converted manifest YAML to JSON and then unmarshaled to struct because kube API objects work with JSON primarily such as `Affinity`
- Added `json` tags to Manifest struct and supported JSON `inline` tags for `JobProperties`

After that, we can support `Affinity` concisely:
```
instance_groups:
- name: bpm
  instances: 1
  jobs:
  - name: test-server
    release: bpm
    properties: ...
  env:
    bosh:
      agent:
        settings:
          affinity:
            nodeAffinity:
              requiredDuringSchedulingIgnoredDuringExecution:
                nodeSelectorTerms:
                - matchExpressions:
                  - key: kubernetes.io/unit-test-az-name
                    operator: In
                    values:
                    - unit-test-az1
                    - unit-test-az2
```

**Notice**: If you want to decode/encode Manifest struct and substruct, you should use package `"github.com/ghodss/yaml"` as kubectl does.

References:
- https://github.com/kubernetes/client-go/issues/193
- https://github.com/golang/go/issues/6213
- http://devel.io/2013/08/19/go-handling-arbitrary-json/