### PR TITLE
Handle multi-config files

### DIFF
--- a/pkg/kube/config/fake/fake_clientconfig.go
+++ b/pkg/kube/config/fake/fake_clientconfig.go
@@ -1,0 +1,32 @@
+package fake
+
+import (
+	"fmt"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type FakeClientConfig struct {
+	ExpectedClientConfigError bool
+}
+
+func (f *FakeClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return clientcmdapi.Config{}, nil
+}
+
+func (f *FakeClientConfig) ClientConfig() (*restclient.Config, error) {
+	if f.ExpectedClientConfigError {
+		return nil, fmt.Errorf("error from ClientConfig")
+	}
+	return &restclient.Config{Host: "another.cluster.config.com"}, nil
+}
+
+func (f *FakeClientConfig) Namespace() (string, bool, error) {
+	return "", false, nil
+}
+
+func (f *FakeClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return &clientcmd.ClientConfigLoadingRules{}
+}

--- a/pkg/kube/config/getter.go
+++ b/pkg/kube/config/getter.go
@@ -83,8 +83,16 @@ func (g *getter) Get(configPath string) (*rest.Config, error) {
 		configPath = homeFile
 	}
 
-	paths := filepath.SplitList(configPath)
-	c, err := g.restConfigFromKubeConfig(&clientcmd.ClientConfigLoadingRules{Precedence: paths}, &clientcmd.ConfigOverrides{}).ClientConfig()
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if len(configPath) > 0 {
+		paths := filepath.SplitList(configPath)
+		if len(paths) == 1 {
+			loadingRules.ExplicitPath = paths[0]
+		} else {
+			loadingRules.Precedence = paths
+		}
+	}
+	c, err := g.restConfigFromKubeConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		return nil, &getConfigError{err}
 	}

--- a/pkg/kube/config/getter.go
+++ b/pkg/kube/config/getter.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 // Getter is the interface that wraps the Get method that returns the Kubernetes configuration used
 // to communicate with it using its API.
 type Getter interface {
-	Get(customConfigPath string) (*rest.Config, error)
+	Get(configPath string) (*rest.Config, error)
 }
 
 // NewGetter constructs a default getter that satisfies the Getter interface.
@@ -23,29 +22,23 @@ func NewGetter(log *zap.SugaredLogger) Getter {
 	return &getter{
 		log: log,
 
-		inClusterConfig:          rest.InClusterConfig,
-		lookupEnv:                os.LookupEnv,
-		readFile:                 ioutil.ReadFile,
-		restConfigFromKubeConfig: clientcmd.RESTConfigFromKubeConfig,
-		currentUser:              user.Current,
-		defaultRESTConfig:        clientcmd.DefaultClientConfig.ClientConfig,
+		inClusterConfig:   rest.InClusterConfig,
+		lookupEnv:         os.LookupEnv,
+		currentUser:       user.Current,
+		defaultRESTConfig: clientcmd.DefaultClientConfig.ClientConfig,
 	}
 }
 
 type getter struct {
 	log *zap.SugaredLogger
 
-	inClusterConfig          func() (*rest.Config, error)
-	lookupEnv                func(key string) (string, bool)
-	readFile                 func(filename string) ([]byte, error)
-	restConfigFromKubeConfig func(configBytes []byte) (*rest.Config, error)
-	currentUser              func() (*user.User, error)
-	defaultRESTConfig        func() (*rest.Config, error)
+	inClusterConfig   func() (*rest.Config, error)
+	lookupEnv         func(key string) (string, bool)
+	currentUser       func() (*user.User, error)
+	defaultRESTConfig func() (*rest.Config, error)
 }
 
-func (g *getter) Get(customConfigPath string) (*rest.Config, error) {
-	configPath := customConfigPath
-
+func (g *getter) Get(configPath string) (*rest.Config, error) {
 	if configPath == "" {
 		// If no explicit location, try the in-cluster config.
 		_, okHost := g.lookupEnv("KUBERNETES_SERVICE_HOST")
@@ -65,30 +58,35 @@ func (g *getter) Get(customConfigPath string) (*rest.Config, error) {
 		if err != nil {
 			return nil, &getConfigError{err}
 		}
-		configPath = filepath.Join(usr.HomeDir, ".kube", "config")
-	}
 
-	b, err := g.readFile(configPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, &getConfigError{err}
-		}
-
-		// If neither the custom config path, nor the user's ~/.kube directory config path exist, use a
-		// default config.
-		c, err := g.defaultRESTConfig()
+		homeFile := filepath.Join(usr.HomeDir, ".kube", "config")
+		_, err = os.Stat(homeFile)
 		if err != nil {
-			return nil, &getConfigError{err}
+			if !os.IsNotExist(err) {
+				return nil, &getConfigError{err}
+			}
+
+			// If neither the custom config path, nor the user's ~/.kube directory config path exist, use a
+			// default config.
+			c, err := g.defaultRESTConfig()
+			if err != nil {
+				return nil, &getConfigError{err}
+			}
+			g.log.Infof("%s does not exist, using default kube config", configPath)
+			return c, nil
 		}
-		g.log.Infof("%s does not exist, using default kube config", configPath)
-		return c, nil
+
+		configPath = homeFile
 	}
 
-	c, err := g.restConfigFromKubeConfig(b)
+	paths := filepath.SplitList(configPath)
+	c, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{Precedence: paths}, &clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		return nil, &getConfigError{err}
 	}
-	g.log.Infof("Using kube config '%s'", configPath)
+
+	g.log.Infof("Using kube server '%s'", c.Host)
+
 	return c, nil
 }
 


### PR DESCRIPTION
This PR worked on:
- supported multi-config files cf-operator will use current-context such as:
```
$ kubectx
eirini
eirini-deploy
knative
knative-deploy
**minikube**
mycluster

$ go run cmd/cf-operator/main.go
2019-07-02T15:45:37.611+0800	INFO	internal/root.go:35	Using kube server 'https://192.168.99.100:8443'
2019-07-02T15:45:37.611+0800	INFO	internal/root.go:39	Checking kube config
2019-07-02T15:45:37.627+0800	INFO	cobra@v0.0.3/command.go:766	Starting cf-operator 0.0.1 with namespace default
```

- fixed relative SSL path in KUBECONFIG