### PR TITLE
Add phony to build make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ check-scripts:
 
 ############ BUILD TARGETS ############
 
+.PHONY: build
 build:
 	bin/build
 


### PR DESCRIPTION
`make` won't build if the `build` directory already exists.