### PR TITLE
Improved image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-go.sum
-tmp/
-build/
+/*
+!/binaries/cf-operator-linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,3 @@
-FROM golang:1.12.2 AS build
-COPY . /go/src/code.cloudfoundry.org/cf-operator
-ARG GO111MODULE="on"
-ENV GO111MODULE $GO111MODULE
-RUN cd /go/src/code.cloudfoundry.org/cf-operator && \
-    make build && \
-    cp -p binaries/cf-operator /usr/local/bin/cf-operator
-
 FROM cfcontainerization/cf-operator-base
-COPY --from=build /usr/local/bin/cf-operator /usr/local/bin/cf-operator
-ENTRYPOINT ["cf-operator"]
+COPY binaries/cf-operator-linux-amd64 /usr/local/bin/cf-operator
+ENTRYPOINT ["/usr/local/bin/cf-operator"]

--- a/bin/build
+++ b/bin/build
@@ -5,5 +5,7 @@ set -euo pipefail
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . "${GIT_ROOT}/bin/include/versioning"
 
+: "${BINARY_NAME:=cf-operator}"
+
 BASEDIR="$(cd "$(dirname "$0")/.." && pwd)"
-CGO_ENABLED=0 go build -o "${BASEDIR}/binaries/cf-operator" -ldflags="-X code.cloudfoundry.org/cf-operator/version.Version=${ARTIFACT_VERSION}" cmd/cf-operator/main.go
+CGO_ENABLED=0 go build -o "${BASEDIR}/binaries/${BINARY_NAME}" -ldflags="-X code.cloudfoundry.org/cf-operator/version.Version=${ARTIFACT_VERSION}" cmd/cf-operator/main.go

--- a/bin/build-image
+++ b/bin/build-image
@@ -9,16 +9,26 @@ if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
   export DOCKER_IMAGE_TAG
 fi
 
-set +e
+set -o errexit
+
+export GOOS=linux
+export GOARCH=amd64
+export BINARY_NAME=cf-operator-linux-amd64
+
+"${GIT_ROOT}/bin/build"
+
+docker build "${GIT_ROOT}" \
+  --file "${GIT_ROOT}/Dockerfile" \
+  --tag "${OPERATOR_DOCKER_ORGANIZATION}/cf-operator:${DOCKER_IMAGE_TAG}"
+
+docker save "${OPERATOR_DOCKER_ORGANIZATION}/cf-operator:${DOCKER_IMAGE_TAG}"\
+  --output "${GIT_ROOT}/binaries/cf-operator-image.tgz"
 
 if type -a minikube >/dev/null 2>/dev/null; then
   if ! dockerenv=$(minikube docker-env); then
-    echo "Error: Could not retrieve docker settings from minikube."
-    exit 1
+    echo "Minikube not running. Skipping loading image into Minikube's Docker daemon..."
+    exit 0
   fi
   eval "${dockerenv}"
+  docker load --input "${GIT_ROOT}/binaries/cf-operator-image.tgz"
 fi
-
-set -e
-
-docker build "${GIT_ROOT}" -f "${GIT_ROOT}/Dockerfile" --build-arg GO111MODULE="${GO111MODULE:-on}" -t "${OPERATOR_DOCKER_ORGANIZATION}/cf-operator:${DOCKER_IMAGE_TAG}"


### PR DESCRIPTION
It builds the image on the host, then copies the final binary to the
image. It is useful while leveraging the host cache during the build
process.