### PR TITLE
Enabled separate namespace for deployment and operation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 export OPERATOR_DOCKER_ORGANIZATION=${OPERATOR_DOCKER_ORGANIZATION:-'cfcontainerization'}
+export CF_OPERATOR_NAMESPACE=${CF_OPERATOR_NAMESPACE:-'cf-operator'}
 
 [ -f .envrc.local ] && . ./.envrc.local

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -24,9 +24,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:
             - name: CF_OPERATOR_NAMESPACE
+              {{ if .Values.env.CF_OPERATOR_NAMESPACE -}}
+              value: {{ .Values.env.CF_OPERATOR_NAMESPACE }}
+              {{- else -}}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+              {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -27,3 +27,6 @@ serviceAccount:
   cfOperatorServiceAccount:
     create: true
     name:
+
+env:
+  CF_OPERATOR_NAMESPACE: ~

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,8 +4,9 @@ build:
   artifacts:
   - image: cfcontainerization/cf-operator
     context: .
-    docker:
-      dockerfile: Dockerfile
+    custom:
+      buildCommand: bin/build-image
+      dependencies: {}
   local:
     push: false
   tagPolicy:
@@ -15,7 +16,7 @@ deploy:
     releases:
     - name: cf-operator
       chartPath: deploy/helm/cf-operator
-      namespace: scf
       setValueTemplates:
         image.tag: "{{ .DIGEST }}"
+        env.CF_OPERATOR_NAMESPACE: "{{ .CF_OPERATOR_NAMESPACE }}"
       wait: true


### PR DESCRIPTION
The namespace that cf-operator is deployed can be separate from the one that it operates on. This commit enables it if `env.CF_OPERATOR_NAMESPACE` is specified in the Helm installation.