### PR TITLE
165909121 load affinity struct

### DIFF
--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -182,10 +182,9 @@ instance_groups:
           healthcheck:
             some_process_name:
               readiness:
-                handler:
-                  exec:
-                    command:
-                    - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
+                exec:
+                  command:
+                  - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
         # List of ports to be opened up for this job.
         ports:
         - name: "health-port"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/directxman12/zapr v0.1.1
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
@@ -57,12 +57,10 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
-	k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5 // indirect
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible
 	k8s.io/klog v0.1.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20181024003938-96e8bb74ecdd // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
-	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/pkg/bosh/manifest/container_factory.go
+++ b/pkg/bosh/manifest/container_factory.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
 )
 
@@ -346,7 +347,7 @@ func bpmProcessContainer(
 	jobImage string,
 	process bpm.Process,
 	volumeMounts []corev1.VolumeMount,
-	healthchecks map[string]HealthCheck,
+	healthchecks map[string]bc.HealthCheck,
 ) corev1.Container {
 	name := names.Sanitize(fmt.Sprintf("%s-%s", jobName, processName))
 	container := corev1.Container{

--- a/pkg/bosh/manifest/containerization/containerization.go
+++ b/pkg/bosh/manifest/containerization/containerization.go
@@ -45,8 +45,7 @@ type Settings struct {
 	Affinity Affinity
 }
 
-type Affinity struct {
-}
+type Affinity corev1.Affinity
 
 // BOSHContainerization represents the special 'bosh_containerization'
 // property key. It contains all kubernetes structures we need to add to the BOSH manifest.

--- a/pkg/bosh/manifest/containerization/containerization.go
+++ b/pkg/bosh/manifest/containerization/containerization.go
@@ -3,7 +3,7 @@
 package containerization
 
 import (
-	yaml "gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -12,88 +12,86 @@ import (
 
 // Manifest is a BOSH deployment manifest
 type Manifest struct {
-	InstanceGroups []*InstanceGroup `yaml:"instance_groups,omitempty"`
+	InstanceGroups []*InstanceGroup `json:"instance_groups,omitempty"`
 }
 
 type InstanceGroup struct {
-	Jobs []Job `yaml:"jobs"`
+	Jobs []Job `json:"jobs"`
 	// for env.bosh.agent.settings.affinity
-	Env Env `yaml:"env,omitempty"`
+	Env Env `json:"env,omitempty"`
 }
 
 type Job struct {
-	Properties JobProperties `yaml:"properties,omitempty"`
+	Properties JobProperties `json:"properties,omitempty"`
 }
 
 type JobProperties struct {
-	BOSHContainerization BOSHContainerization `yaml:"bosh_containerization"`
+	BOSHContainerization BOSHContainerization `json:"bosh_containerization"`
 }
 
 type Env struct {
-	BOSH BOSH `yaml:"bosh,omitempty"`
+	BOSH BOSH `json:"bosh,omitempty"`
 }
 
 type BOSH struct {
-	Agent Agent `yaml:"agent,omitempty"`
+	Agent Agent `json:"agent,omitempty"`
 }
 
 type Agent struct {
-	Settings Settings `yaml:"settings,omitempty"`
+	Settings Settings `json:"settings,omitempty"`
 }
 
 type Settings struct {
-	Affinity Affinity
+	Affinity *corev1.Affinity `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 }
-
-type Affinity corev1.Affinity
 
 // BOSHContainerization represents the special 'bosh_containerization'
 // property key. It contains all kubernetes structures we need to add to the BOSH manifest.
 type BOSHContainerization struct {
-	Consumes         map[string]JobLink `yaml:"consumes"`
-	Instances        []JobInstance      `yaml:"instances"`
-	Release          string             `yaml:"release"`
-	BPM              *bpm.Config        `yaml:"bpm,omitempty"`
-	Ports            []Port             `yaml:"ports"`
-	Run              RunConfig          `yaml:"run"`
-	PreRenderScripts []string           `yaml:"pre_render_scripts"`
+	Consumes         map[string]JobLink `json:"consumes"`
+	Instances        []JobInstance      `json:"instances"`
+	Release          string             `json:"release"`
+	BPM              *bpm.Config        `json:"bpm,omitempty" yaml:"bpm,omitempty"`
+	Ports            []Port             `json:"ports"`
+	Run              RunConfig          `json:"run"`
+	PreRenderScripts []string           `json:"pre_render_scripts" yaml:"pre_render_scripts"`
 }
 
 // Port represents the port to be opened up for this job
 type Port struct {
-	Name     string `yaml:"name"`
-	Protocol string `yaml:"protocol"`
-	Internal int    `yaml:"internal"`
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
+	Internal int    `json:"internal"`
 }
 
 // JobInstance for data gathering
 type JobInstance struct {
-	Address  string                 `yaml:"address"`
-	AZ       string                 `yaml:"az"`
-	ID       string                 `yaml:"id"`
-	Index    int                    `yaml:"index"`
-	Instance int                    `yaml:"instance"`
-	Name     string                 `yaml:"name"`
-	Network  map[string]interface{} `yaml:"networks"`
-	IP       string                 `yaml:"ip"`
+	Address  string                 `json:"address"`
+	AZ       string                 `json:"az"`
+	ID       string                 `json:"id"`
+	Index    int                    `json:"index"`
+	Instance int                    `json:"instance"`
+	Name     string                 `json:"name"`
+	Network  map[string]interface{} `json:"networks"`
+	IP       string                 `json:"ip"`
 }
 
 // JobLink describes links inside a job properties
 // bosh_containerization.
 type JobLink struct {
-	Instances  []JobInstance          `yaml:"instances"`
-	Properties map[string]interface{} `yaml:"properties"`
+	Instances  []JobInstance          `json:"instances"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 // HealthCheck defines liveness and readiness probes for a container
 type HealthCheck struct {
-	ReadinessProbe *corev1.Probe `yaml:"readiness"`
-	LivenessProbe  *corev1.Probe `yaml:"liveness"`
+	ReadinessProbe *corev1.Probe `json:"readiness"`
+	LivenessProbe  *corev1.Probe `json:"liveness"`
 }
 
 // RunConfig describes the runtime configuration for this job
 type RunConfig struct {
-	HealthChecks map[string]HealthCheck `yaml:"healthcheck"`
+	HealthChecks map[string]HealthCheck `json:"healthcheck"`
 }
 
 // LoadKubeYAML is a special loader, since the YAML is already compatible to

--- a/pkg/bosh/manifest/containerization/containerization.go
+++ b/pkg/bosh/manifest/containerization/containerization.go
@@ -14,15 +14,38 @@ import (
 type Manifest struct {
 	InstanceGroups []*InstanceGroup `yaml:"instance_groups,omitempty"`
 }
+
 type InstanceGroup struct {
 	Jobs []Job `yaml:"jobs"`
+	// for env.bosh.agent.settings.affinity
+	Env Env `yaml:"env,omitempty"`
 }
+
 type Job struct {
 	Properties JobProperties `yaml:"properties,omitempty"`
 }
 
 type JobProperties struct {
 	BOSHContainerization BOSHContainerization `yaml:"bosh_containerization"`
+}
+
+type Env struct {
+	BOSH BOSH `yaml:"bosh,omitempty"`
+}
+
+type BOSH struct {
+	Agent Agent `yaml:"agent,omitempty"`
+}
+
+type Agent struct {
+	Settings Settings `yaml:"settings,omitempty"`
+}
+
+type Settings struct {
+	Affinity Affinity
+}
+
+type Affinity struct {
 }
 
 // BOSHContainerization represents the special 'bosh_containerization'

--- a/pkg/bosh/manifest/containerization_test.go
+++ b/pkg/bosh/manifest/containerization_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	yaml "gopkg.in/yaml.v2"
 
 	//. "github.com/onsi/gomega/gstruct"
 
@@ -15,7 +14,7 @@ import (
 
 var _ = Describe("BOSHContainerization", func() {
 	var (
-		m Manifest
+		m *Manifest
 	)
 
 	BeforeEach(func() {
@@ -24,8 +23,7 @@ var _ = Describe("BOSHContainerization", func() {
 		boshManifestBytes, err := ioutil.ReadFile(manifest_path)
 		Expect(err).ToNot(HaveOccurred())
 
-		m = Manifest{}
-		err = yaml.Unmarshal(boshManifestBytes, &m)
+		m, err = LoadYAML(boshManifestBytes)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/bosh/manifest/data_gatherer.go
+++ b/pkg/bosh/manifest/data_gatherer.go
@@ -15,19 +15,20 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 )
 
 // JobProviderLinks provides links to other jobs, indexed by provider type and name
-type JobProviderLinks map[string]map[string]JobLink
+type JobProviderLinks map[string]map[string]bc.JobLink
 
 // Lookup returns a link for a type and name, used when links are consumed
-func (jpl JobProviderLinks) Lookup(provider *JobSpecProvider) (JobLink, bool) {
+func (jpl JobProviderLinks) Lookup(provider *JobSpecProvider) (bc.JobLink, bool) {
 	link, ok := jpl[provider.Type][provider.Name]
 	return link, ok
 }
 
 // Add another job to the lookup map
-func (jpl JobProviderLinks) Add(job Job, spec JobSpec, jobsInstances []JobInstance) error {
+func (jpl JobProviderLinks) Add(job Job, spec JobSpec, jobsInstances []bc.JobInstance) error {
 	var properties map[string]interface{}
 
 	for _, link := range spec.Provides {
@@ -76,12 +77,12 @@ func (jpl JobProviderLinks) Add(job Job, spec JobSpec, jobsInstances []JobInstan
 		}
 
 		if _, ok := jpl[linkType]; !ok {
-			jpl[linkType] = map[string]JobLink{}
+			jpl[linkType] = map[string]bc.JobLink{}
 		}
 
 		// construct the jobProviderLinks of the current job that provides
 		// a link
-		jpl[linkType][linkName] = JobLink{
+		jpl[linkType][linkName] = bc.JobLink{
 			Instances:  jobsInstances,
 			Properties: properties,
 		}
@@ -399,10 +400,10 @@ func generateJobConsumersData(currentJob *Job, jobReleaseSpecs map[string]map[st
 
 		// generate the job.properties.bosh_containerization.consumes struct with the links information from providers.
 		if currentJob.Properties.BOSHContainerization.Consumes == nil {
-			currentJob.Properties.BOSHContainerization.Consumes = map[string]JobLink{}
+			currentJob.Properties.BOSHContainerization.Consumes = map[string]bc.JobLink{}
 		}
 
-		currentJob.Properties.BOSHContainerization.Consumes[providerName] = JobLink{
+		currentJob.Properties.BOSHContainerization.Consumes[providerName] = bc.JobLink{
 			Instances:  link.Instances,
 			Properties: link.Properties,
 		}

--- a/pkg/bosh/manifest/data_gatherer_test.go
+++ b/pkg/bosh/manifest/data_gatherer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	. "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
 	"code.cloudfoundry.org/cf-operator/testing"
 )
@@ -143,7 +144,7 @@ var _ = Describe("DataGatherer", func() {
 				//Check JobInstance for the redis-server job
 				jobInstancesRedis := manifest.InstanceGroups[0].Jobs[0].Properties.BOSHContainerization.Instances
 
-				compareToFakeRedis := []JobInstance{
+				compareToFakeRedis := []bc.JobInstance{
 					{Address: "foo-deployment-redis-slave-0.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-0-redis-server", Index: 0, Instance: 0, Name: "redis-slave-redis-server"},
 					{Address: "foo-deployment-redis-slave-1.default.svc.cluster.local", AZ: "z2", ID: "redis-slave-1-redis-server", Index: 1, Instance: 0, Name: "redis-slave-redis-server"},
 					{Address: "foo-deployment-redis-slave-2.default.svc.cluster.local", AZ: "z1", ID: "redis-slave-2-redis-server", Index: 2, Instance: 1, Name: "redis-slave-redis-server"},
@@ -186,7 +187,7 @@ var _ = Describe("DataGatherer", func() {
 
 					// doppler instance_group, with doppler job, only provides doppler link
 					jobBoshContainerizationConsumes := manifest.InstanceGroups[0].Jobs[0].Properties.BOSHContainerization.Consumes
-					var emptyJobBoshContainerizationConsumes map[string]JobLink
+					var emptyJobBoshContainerizationConsumes map[string]bc.JobLink
 					Expect(jobBoshContainerizationConsumes).To(BeEquivalentTo(emptyJobBoshContainerizationConsumes))
 				})
 			})

--- a/pkg/bosh/manifest/desired_manifest.go
+++ b/pkg/bosh/manifest/desired_manifest.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/versionedsecretstore"
@@ -39,8 +38,7 @@ func (r *Resolver) ReadDesiredManifest(ctx context.Context, boshDeploymentName, 
 
 	manifestData := secret.Data["manifest.yaml"]
 
-	manifest := &Manifest{}
-	err = yaml.Unmarshal(manifestData, manifest)
+	manifest, err := LoadYAML(manifestData)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to unmarshal manifest from secret '%s'", secretName)
 	}

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -114,6 +114,7 @@ var (
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
+	Affinity    bc.Affinity       `yaml:"-"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -110,11 +110,13 @@ var (
 	LabelDeploymentVersion = fmt.Sprintf("%s/deployment-version", apis.GroupName)
 )
 
-// AgentSettings from BOSH deployment manifest. These annotations and labels are added to kube resources
+// AgentSettings from BOSH deployment manifest.
+// These annotations and labels are added to kube resources.
+// Affinity is added into the pod's definition.
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Affinity    bc.Affinity
+	Affinity    bc.Affinity       `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
 	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
 )
@@ -116,7 +118,7 @@ var (
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Affinity    *bc.Affinity      `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	Affinity    *corev1.Affinity  `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -114,7 +114,7 @@ var (
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Affinity    bc.Affinity       `yaml:"-"`
+	Affinity    bc.Affinity
 }
 
 // Set overrides labels and annotations with operator-owned metadata

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"fmt"
 
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
 )
 
@@ -26,8 +27,8 @@ type InstanceGroup struct {
 	Env                AgentEnv               `yaml:"env,omitempty"`
 }
 
-func (ig *InstanceGroup) jobInstances(namespace string, deploymentName string, jobName string, spec JobSpec) []JobInstance {
-	var jobsInstances []JobInstance
+func (ig *InstanceGroup) jobInstances(namespace string, deploymentName string, jobName string, spec JobSpec) []bc.JobInstance {
+	var jobsInstances []bc.JobInstance
 	for i := 0; i < ig.Instances; i++ {
 
 		// TODO: Understand whether there are negative side-effects to using this
@@ -46,7 +47,7 @@ func (ig *InstanceGroup) jobInstances(namespace string, deploymentName string, j
 			// TODO: not allowed to hardcode svc.cluster.local
 			address := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace)
 
-			jobsInstances = append(jobsInstances, JobInstance{
+			jobsInstances = append(jobsInstances, bc.JobInstance{
 				Address:  address,
 				AZ:       az,
 				ID:       id,

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -116,7 +116,7 @@ var (
 type AgentSettings struct {
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
-	Affinity    bc.Affinity       `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	Affinity    *bc.Affinity      `json:"affinity,omitempty" yaml:"affinity,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata

--- a/pkg/bosh/manifest/job.go
+++ b/pkg/bosh/manifest/job.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 )
 
 // JobSpecFilename is the name of the job spec manifest in an unpacked BOSH release
@@ -85,8 +87,8 @@ func (j *Job) sysDirs(name string) []string {
 
 // JobProperties represents the properties map of a Job
 type JobProperties struct {
-	BOSHContainerization `yaml:"bosh_containerization"`
-	Properties           map[string]interface{} `yaml:",inline"`
+	BOSHContainerization bc.BOSHContainerization `yaml:"-"`
+	Properties           map[string]interface{}  `yaml:",inline"`
 }
 
 // ToMap returns a complete map with all properties, including the

--- a/pkg/bosh/manifest/job.go
+++ b/pkg/bosh/manifest/job.go
@@ -87,7 +87,7 @@ func (j *Job) sysDirs(name string) []string {
 
 // JobProperties represents the properties map of a Job
 type JobProperties struct {
-	BOSHContainerization bc.BOSHContainerization `yaml:"-"`
+	BOSHContainerization bc.BOSHContainerization `yaml:"bosh_containerization"`
 	Properties           map[string]interface{}  `yaml:",inline"`
 }
 

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -195,17 +195,18 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},
-							Affinity: &corev1.Affinity{
-								NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
-								PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
-								PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
-							},
 						},
 					},
 				},
 			},
 		},
 	}
+
+	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
+		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
+		extSts.Spec.Template.Spec.Template.Spec.Affinity = &affinity
+	}
+
 	return extSts, nil
 }
 
@@ -350,14 +351,14 @@ func (kc *KubeConverter) errandToExtendedJob(
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &admGroupID,
 					},
-					Affinity: &corev1.Affinity{
-						NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
-						PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
-						PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
-					},
 				},
 			},
 		},
+	}
+
+	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
+		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
+		eJob.Spec.Template.Spec.Affinity = &affinity
 	}
 	return eJob, nil
 }

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -195,6 +195,11 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
+								PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
+								PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
+							},
 						},
 					},
 				},
@@ -344,6 +349,11 @@ func (kc *KubeConverter) errandToExtendedJob(
 					Volumes:        volumes,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &admGroupID,
+					},
+					Affinity: &corev1.Affinity{
+						NodeAffinity:    instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.NodeAffinity,
+						PodAffinity:     instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAffinity,
+						PodAntiAffinity: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity.PodAntiAffinity,
 					},
 				},
 			},

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -189,6 +189,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							Annotations: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations,
 						},
 						Spec: corev1.PodSpec{
+							Affinity:       instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity,
 							Volumes:        volumes,
 							InitContainers: initContainers,
 							Containers:     containers,
@@ -200,11 +201,6 @@ func (kc *KubeConverter) serviceToExtendedSts(
 				},
 			},
 		},
-	}
-
-	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
-		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
-		extSts.Spec.Template.Spec.Template.Spec.Affinity = &affinity
 	}
 
 	return extSts, nil

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -2,6 +2,7 @@ package manifest_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -137,6 +137,7 @@ func LoadYAML(data []byte) (*Manifest, error) {
 		for j, job := range ig.Jobs {
 			m.InstanceGroups[i].Jobs[j].Properties.BOSHContainerization = job.Properties.BOSHContainerization
 		}
+		m.InstanceGroups[i].Env.AgentEnvBoshConfig.Agent.Settings.Affinity = ig.Env.BOSH.Agent.Settings.Affinity
 	}
 
 	return m, nil

--- a/pkg/bosh/manifest/render_job_tmpls.go
+++ b/pkg/bosh/manifest/render_job_tmpls.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 	btg "github.com/viovanov/bosh-template-go"
+
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 )
 
 // RenderJobTemplates will render templates for all jobs of the instance group
@@ -52,7 +54,7 @@ func RenderJobTemplates(boshManifestPath string, jobsDir string, jobsOutputDir s
 			}
 
 			// Find job instance that's being rendered
-			var currentJobInstance *JobInstance
+			var currentJobInstance *bc.JobInstance
 			for _, instance := range job.Properties.BOSHContainerization.Instances {
 				if instance.Index == specIndex {
 					currentJobInstance = &instance

--- a/pkg/bosh/manifest/resolver.go
+++ b/pkg/bosh/manifest/resolver.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,7 +74,7 @@ func (r *Resolver) WithOpsManifest(instance *bdc.BOSHDeployment, namespace strin
 	// Interpolate manifest with ops if exist
 	ops := spec.Ops
 	if len(ops) == 0 {
-		err = yaml.Unmarshal([]byte(m), manifest)
+		manifest, err := LoadYAML([]byte(m))
 		return manifest, err
 	}
 

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/fakes"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
@@ -86,8 +87,8 @@ var _ = Describe("ReconcileBPM", func() {
 								Properties: map[string]interface{}{
 									"password": "((foo_password))",
 								},
-								BOSHContainerization: bdm.BOSHContainerization{
-									Ports: []bdm.Port{
+								BOSHContainerization: bc.BOSHContainerization{
+									Ports: []bc.Port{
 										{
 											Name:     "foo",
 											Protocol: "TCP",

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,7 +170,7 @@ func (r *ReconcileBOSHDeployment) createManifestWithOps(ctx context.Context, ins
 	log.Debug(ctx, "Creating manifest secret with ops")
 
 	// Create manifest with ops as variable interpolation job input.
-	manifestBytes, err := yaml.Marshal(manifest)
+	manifestBytes, err := manifest.Marshal()
 	if err != nil {
 		return nil, log.WithEvent(instance, "ManifestWithOpsUnmarshalError").Errorf(ctx, "Error unmarshaling the manifest %s: %s", instance.GetName(), err)
 	}

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/fakes"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
@@ -81,8 +82,8 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 								Properties: map[string]interface{}{
 									"password": "((foo_password))",
 								},
-								BOSHContainerization: bdm.BOSHContainerization{
-									Ports: []bdm.Port{
+								BOSHContainerization: bc.BOSHContainerization{
+									Ports: []bc.Port{
 										{
 											Name:     "foo",
 											Protocol: "TCP",

--- a/pkg/kube/controllers/boshdeployment/generated_variable_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/generated_variable_reconciler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,8 +77,7 @@ func (r *ReconcileGeneratedVariable) Reconcile(request reconcile.Request) (recon
 
 	// Unmarshal the manifest
 	log.Debug(ctx, "Unmarshaling BOSHDeployment manifest from manifest with ops secret")
-	manifest := &bdm.Manifest{}
-	err = yaml.Unmarshal([]byte(manifestContents), manifest)
+	manifest, err := bdm.LoadYAML([]byte(manifestContents))
 	if err != nil {
 		return reconcile.Result{},
 			log.WithEvent(manifestSecret, "BadManifestError").Errorf(ctx, "Failed to unmarshal manifest from secret '%s': %v", request.NamespacedName, err)

--- a/testing/assets/gatherManifest.yml
+++ b/testing/assets/gatherManifest.yml
@@ -19,10 +19,9 @@ instance_groups:
               healthcheck:
                 doppler:
                   readiness:
-                    handler:
-                      exec:
-                        command:
-                        - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
+                    exec:
+                      command:
+                      - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
             bpm:
               processes:
                 - name: doppler
@@ -283,10 +282,9 @@ instance_groups:
               healthcheck:
                 doppler:
                   liveness:
-                    handler:
-                      exec:
-                        command:
-                        - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
+                    exec:
+                      command:
+                      - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
             bpm:
               processes:
                 - name: loggregator_trafficcontroller

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -553,7 +553,7 @@ const GardenRunc = `
           timestamp: "rfc3339"
 `
 
-// BPMReleaseWithoutPersistentDisk doesn't container persistent disk declaration
+// BPMReleaseWithoutPersistentDisk doesn't contain persistent disk declaration
 const BPMReleaseWithoutPersistentDisk = `
 name: bpm
 
@@ -633,4 +633,105 @@ instance_groups:
   - name: fake-job-d
     release: fake-release
   persistent_disk: 1024
+`
+
+// BPMReleaseWithAffinity contains affinity information
+const BPMReleaseWithAffinity = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+
+instance_groups:
+- name: bpm1
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/unit-test-az-name
+                    operator: In
+                    values:
+                    - unit-test-az1
+                    - unit-test-az2
+- name: bpm2
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: security
+                    operator: In
+                    values:
+                    - S1
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+- name: bpm3
+  instances: 1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      bosh_containerization:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+  env:
+    bosh:
+      agent:
+        settings:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: security
+                        operator: In
+                        values:
+                        - S2
+                  topologyKey: failure-domain.beta.kubernetes.io/zone
 `

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -61,15 +61,13 @@ instance_groups:
           healthcheck:
             test-server:
               readiness:
-                handler:
-                  exec:
-                    command:
-                    - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
+                exec:
+                  command:
+                  - "curl --silent --fail --head http://${HOSTNAME}:8080/health"
               liveness:
-                handler:
-                  exec:
-                    command:
-                    - "curl --silent --fail --head http://${HOSTNAME}:8080"
+                exec:
+                  command:
+                  - "curl --silent --fail --head http://${HOSTNAME}:8080"
         ports:
         - name: "rep-server"
           protocol: "TCP"

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -138,6 +138,15 @@ func (c *Catalog) BOSHManifestWithoutPersistentDisk() *manifest.Manifest {
 	return m
 }
 
+// BPMReleaseWithAffinity returns a manifest with affinity
+func (c *Catalog) BPMReleaseWithAffinity() *manifest.Manifest {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithAffinity))
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
 // DefaultBOSHManifestConfigMap for tests
 func (c *Catalog) DefaultBOSHManifestConfigMap(name string) corev1.ConfigMap {
 	return corev1.ConfigMap{


### PR DESCRIPTION
Following up on the idea of split parsing to support native k8s structs in our YAML.

I'm unclear if marshalling back to YAML is good enough and preserves structure (https://github.com/cloudfoundry-incubator/cf-operator/pull/386/files#diff-d45fe924bb1fed75634bbc041b67f2cbR146).


This includes all changes from wip PR #378 

[#165909121](https://www.pivotaltracker.com/story/show/165909121)