### PR TITLE
Support CF_OPERATOR_TESTING_TMP env var for storing the testing logs

### DIFF
--- a/bin/include/testing
+++ b/bin/include/testing
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+function setup_testing_tmp {
+  if [ -z "${CF_OPERATOR_TESTING_TMP}" ]
+  then
+    echo "\$CF_OPERATOR_TESTING_TMP not set. aborting."
+    exit 1
+  fi
+
+  if [ "$SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP" != "true" ]
+  then
+    echo "${CF_OPERATOR_TESTING_TMP} will be cleaned up after the tests. Set SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=true to skip cleanup."
+  fi
+
+  mkdir -p "${CF_OPERATOR_TESTING_TMP}"
+}
+
+function cleanup_testing_tmp {
+  if [ "$SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP" == "true" ]
+  then
+    echo "Skipping cleanup of ${CF_OPERATOR_TESTING_TMP}."
+    return
+  fi
+
+  echo "Cleaning up ${CF_OPERATOR_TESTING_TMP}. To skip cleanup set SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=true"
+  rm -rf "${CF_OPERATOR_TESTING_TMP}"/cf-operator-test*
+}

--- a/bin/test-cli-e2e
+++ b/bin/test-cli-e2e
@@ -3,13 +3,17 @@ set -eu
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
+. "${GIT_ROOT}/bin/include/testing"
 
 if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
   DOCKER_IMAGE_TAG=${VERSION_TAG}
   export DOCKER_IMAGE_TAG
 fi
 
-echo "Test logs are here: /tmp/cf-operator-tests.log"
+: "${CF_OPERATOR_TESTING_TMP:=/tmp}"
+echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests.log"
+setup_testing_tmp
+trap cleanup_testing_tmp EXIT
 
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -3,6 +3,7 @@ set -eu
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
+. "${GIT_ROOT}/bin/include/testing"
 . "${GIT_ROOT}/.envrc"
 
 if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
@@ -15,7 +16,10 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-echo "Test logs are here: /tmp/cf-operator-tests-*.log"
+: "${CF_OPERATOR_TESTING_TMP:=/tmp}"
+echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests.log"
+setup_testing_tmp
+trap cleanup_testing_tmp EXIT
 
 bin/apply-crds
 

--- a/bin/test-storage
+++ b/bin/test-storage
@@ -3,6 +3,7 @@ set -eu
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
+. "${GIT_ROOT}/bin/include/testing"
 . "${GIT_ROOT}/.envrc"
 
 if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
@@ -15,7 +16,10 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-echo "Test logs are here: /tmp/cf-operator-tests-*.log"
+: "${CF_OPERATOR_TESTING_TMP:=/tmp}"
+echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests-*.log"
+setup_testing_tmp
+trap cleanup_testing_tmp EXIT
 
 bin/apply-crds
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,11 +49,18 @@ The node index starts at 1 and is used as following to generate names:
 
 		namespace: $TEST_NAMESPACE + <node_index>
 		webhook port: $CF_OPERATOR_WEBHOOK_SERVICE_PORT + <node_index>
-		log file: /tmp/cf-operator-tests-<node_index>.log
+		log file: $CF_OPERATOR_TESTING_TMP/cf-operator-tests-<node_index>.log
 
 Integration tests use the `TEST_NAMESPACE` environment variable as a base to
 calculate the namespace name. Test namespaces are deleted automatically once
 the tests are completed.
+
+`CF_OPERATOR_TESTING_TMP` can be used to set a tmp directory for storing logs
+and other files generated during testing. If this variable is not set `/tmp`
+will be used instead.
+
+Generated files will be cleand up after the test run unless `SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP`
+is set to `true`.
 
 ### Setup Webhook Host
 

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -244,7 +244,8 @@ func (e *Environment) setupCFOperator(namespace string) (err error) {
 	manifest.DockerImageRepository = operatorDockerImageRepo
 	manifest.DockerImageTag = operatorDockerImageTag
 
-	e.ObservedLogs, e.Log = helper.NewTestLoggerWithPath(fmt.Sprintf("/tmp/cf-operator-tests-%d.log", e.ID))
+	loggerPath := helper.LogfilePath(fmt.Sprintf("cf-operator-tests-%d.log", e.ID))
+	e.ObservedLogs, e.Log = helper.NewTestLoggerWithPath(loggerPath)
 	ctx := ctxlog.NewParentContext(e.Log)
 	e.mgr, err = operator.NewManager(ctx, e.Config, e.kubeConfig, manager.Options{Namespace: e.Namespace})
 

--- a/pkg/testhelper/logger.go
+++ b/pkg/testhelper/logger.go
@@ -3,6 +3,7 @@ package testhelper
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -10,9 +11,9 @@ import (
 )
 
 // NewTestLogger returns a ZAP logger for assertions, which also logs to
-// /tmp/cf-operator-tests.log
+// <tmpdir>/cf-operator-tests.log
 func NewTestLogger() (obs *observer.ObservedLogs, log *zap.SugaredLogger) {
-	return NewTestLoggerWithPath("/tmp/cf-operator-tests.log")
+	return NewTestLoggerWithPath(LogfilePath("cf-operator-tests.log"))
 }
 
 // NewTestLoggerWithPath returns a logger which logs to path
@@ -36,4 +37,13 @@ func NewTestLoggerWithPath(path string) (obs *observer.ObservedLogs, log *zap.Su
 
 	log = zap.New(zapcore.NewTee(memCore, fileCore)).Sugar()
 	return
+}
+
+// LogfilePath returns the path for the given filename in the testing tmp directory
+func LogfilePath(filename string) string {
+	tmpDir := os.Getenv("CF_OPERATOR_TESTING_TMP")
+	if tmpDir == "" {
+		tmpDir = "/tmp"
+	}
+	return path.Join(tmpDir, filename)
 }

--- a/testing/dump_env.sh
+++ b/testing/dump_env.sh
@@ -51,19 +51,20 @@ function get_all_events() {
   kubectl get events --namespace "${NS}" --output=yaml > "${NAMESPACE_DIR}/events.yaml"
 }
 
-NAMESPACE_DIR="/tmp/env_dumps/${NS}"
+OUTPUT_BASE="${CF_OPERATOR_TESTING_TMP:-/tmp}"
+NAMESPACE_DIR="/${OUTPUT_BASE}/env_dumps/${NS}"
 if [ -e "$NAMESPACE_DIR" ]; then
   i=1
-  while [ -e "/tmp/env_dumps/${NS}-$i" ]; do
+  while [ -e "/${OUTPUT_BASE}/env_dumps/${NS}-$i" ]; do
     let i++
   done
-  NAMESPACE_DIR="/tmp/env_dumps/${NS}-$i"
+  NAMESPACE_DIR="/${OUTPUT_BASE}/env_dumps/${NS}-$i"
 fi
 
 printf "Output directory: $(basename $NAMESPACE_DIR)...\n"
 SECRETS_DIR="${NAMESPACE_DIR}/secrets"
 CONFIGMAPS_DIR="${NAMESPACE_DIR}/configmaps"
-mkdir -p /tmp/env_dumps
+mkdir -p ${OUTPUT_BASE}/env_dumps
 mkdir -p ${SECRETS_DIR}
 mkdir -p ${CONFIGMAPS_DIR}
 


### PR DESCRIPTION
Files generated while testing will be cleaned up unless
SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP is set to true.