### PR TITLE
Versioned cf-operator-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /go/src/code.cloudfoundry.org/cf-operator && \
     make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 
-FROM cfcontainerization/cf-operator-base
+FROM cfcontainerization/cf-operator-base@sha256:2bb233fea55317729ebba6636976459e56d3c6605eaf3c54774449e9507341a5
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 USER vcap


### PR DESCRIPTION
Use the sha256 sum of the image to version the cf-operator-base.