### PR TITLE
Simplify container names

### DIFF
--- a/pkg/bosh/manifest/container_factory.go
+++ b/pkg/bosh/manifest/container_factory.go
@@ -126,7 +126,7 @@ func (c *ContainerFactory) JobsToInitContainers(
 	initContainers := flattenContainers(
 		copyingSpecsInitContainers,
 		templateRenderingContainer(c.instanceGroupName, resolvedPropertiesSecretName),
-		createDirContainer(c.instanceGroupName, jobs),
+		createDirContainer(jobs),
 		boshPreStartInitContainers,
 		bpmPreStartInitContainers,
 	)
@@ -261,7 +261,7 @@ func jobSpecCopierContainer(releaseName string, jobImage string, volumeMountName
 
 func templateRenderingContainer(instanceGroupName string, secretName string) corev1.Container {
 	return corev1.Container{
-		Name:  names.Sanitize(fmt.Sprintf("renderer-%s", instanceGroupName)),
+		Name:  "template-render",
 		Image: GetOperatorDockerImage(),
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -302,7 +302,7 @@ func templateRenderingContainer(instanceGroupName string, secretName string) cor
 	}
 }
 
-func createDirContainer(name string, jobs []Job) corev1.Container {
+func createDirContainer(jobs []Job) corev1.Container {
 	dirs := []string{}
 	for _, job := range jobs {
 		jobDirs := append(job.dataDirs(job.Name), job.sysDirs(job.Name)...)
@@ -310,7 +310,7 @@ func createDirContainer(name string, jobs []Job) corev1.Container {
 	}
 
 	return corev1.Container{
-		Name:  names.Sanitize(fmt.Sprintf("create-dirs-%s", name)),
+		Name:  "create-dirs",
 		Image: GetOperatorDockerImage(),
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/pkg/bosh/manifest/container_factory_test.go
+++ b/pkg/bosh/manifest/container_factory_test.go
@@ -401,7 +401,7 @@ var _ = Describe("ContainerFactory", func() {
 				containers, err := act()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(containers).To(HaveLen(5))
-				Expect(containers[2].Name).To(Equal("create-dirs-fake-ig"))
+				Expect(containers[2].Name).To(Equal("create-dirs"))
 				Expect(containers[2].Args).To(ContainElement("mkdir -p /var/vcap/data/fake-job /var/vcap/data/sys/log/fake-job /var/vcap/data/sys/run/fake-job /var/vcap/sys/log/fake-job /var/vcap/sys/run/fake-job /var/vcap/data/other-job /var/vcap/data/sys/log/other-job /var/vcap/data/sys/run/other-job /var/vcap/sys/log/other-job /var/vcap/sys/run/other-job"))
 				Expect(containers[2].VolumeMounts).To(HaveLen(2))
 			})

--- a/pkg/bosh/manifest/kube_resources_test.go
+++ b/pkg/bosh/manifest/kube_resources_test.go
@@ -87,7 +87,7 @@ var _ = Describe("kube converter", func() {
 					Expect(specCopierInitContainer.Image).To(Equal("hub.docker.com/cfcontainerization/redis:opensuse-42.3-28.g837c5b3-30.263-7.0.0_234.gcd7d1132-36.15.0"))
 					Expect(specCopierInitContainer.Command[0]).To(Equal("/bin/sh"))
 					Expect(rendererInitContainer.Image).To(Equal("/:"))
-					Expect(rendererInitContainer.Name).To(Equal("renderer-redis-slave"))
+					Expect(rendererInitContainer.Name).To(Equal("template-render"))
 
 					// Test shared volume setup
 					Expect(eJob.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("rendering-data"))
@@ -137,7 +137,7 @@ var _ = Describe("kube converter", func() {
 					Expect(specCopierInitContainer.Command[0]).To(Equal("/bin/sh"))
 					Expect(specCopierInitContainer.Name).To(Equal("spec-copier-cflinuxfs3"))
 					Expect(rendererInitContainer.Image).To(Equal("/:"))
-					Expect(rendererInitContainer.Name).To(Equal("renderer-diego-cell"))
+					Expect(rendererInitContainer.Name).To(Equal("template-render"))
 
 					// Test shared volume setup
 					Expect(len(stS.Spec.Containers[0].VolumeMounts)).To(Equal(8))


### PR DESCRIPTION
We still have stuttering with 'job name + bpm process name':

https://github.com/cloudfoundry-incubator/cf-operator/blob/master/pkg/bosh/manifest/container_factory.go#L407

[#167098775](https://www.pivotaltracker.com/story/show/167098775)