### PR TITLE
Modify the webhook validator for BOSHDeployment type

### DIFF
--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
@@ -1,13 +1,5 @@
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  name: nats-manifest.var-customed-password
-type: Opaque
-stringData:
-  password: customed_password
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nats-manifest

--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: nats-manifest.var-customed-password
+type: Opaque
+stringData:
+  password: customed_password
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nats-manifest

--- a/integration/environment/machine.go
+++ b/integration/environment/machine.go
@@ -38,6 +38,12 @@ type Machine struct {
 // TearDownFunc tears down the resource
 type TearDownFunc func() error
 
+// ChanResult holds different fields that can be
+// sent through a channel
+type ChanResult struct {
+	Error error
+}
+
 // CreateNamespace creates a namespace, it doesn't return an error if the namespace exists
 func (m *Machine) CreateNamespace(namespace string) (TearDownFunc, error) {
 	client := m.Clientset.CoreV1().Namespaces()
@@ -577,6 +583,15 @@ func (m *Machine) DeleteSecrets(namespace string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// CreateBOSHDeploymentUsingChan creates a BOSHDeployment custom resource and returns an error via a channel
+func (m *Machine) CreateBOSHDeploymentUsingChan(outputChannel chan ChanResult, namespace string, deployment bdv1.BOSHDeployment) {
+	client := m.VersionedClientset.BoshdeploymentV1alpha1().BOSHDeployments(namespace)
+	_, err := client.Create(&deployment)
+	outputChannel <- ChanResult{
+		Error: err,
+	}
 }
 
 // CreateBOSHDeployment creates a BOSHDeployment custom resource and returns a function to delete it

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -196,7 +196,7 @@ func (c *Catalog) DefaultConfigMap(name string) corev1.ConfigMap {
 	}
 }
 
-// DefaultBOSHDeployment fissile deployment CR
+// DefaultBOSHDeployment a deployment CR
 func (c *Catalog) DefaultBOSHDeployment(name, manifestRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -794,7 +794,7 @@ func (c *Catalog) Sleep1hPodSpec() corev1.PodSpec {
 	}
 }
 
-// EmptyBOSHDeployment empty fissile deployment CR
+// EmptyBOSHDeployment empty deployment CR
 func (c *Catalog) EmptyBOSHDeployment(name, manifestRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -802,7 +802,7 @@ func (c *Catalog) EmptyBOSHDeployment(name, manifestRef string) bdv1.BOSHDeploym
 	}
 }
 
-// DefaultBOSHDeploymentWithOps fissile deployment CR with ops
+// DefaultBOSHDeploymentWithOps a deployment CR with ops
 func (c *Catalog) DefaultBOSHDeploymentWithOps(name, manifestRef string, opsRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -815,20 +815,7 @@ func (c *Catalog) DefaultBOSHDeploymentWithOps(name, manifestRef string, opsRef 
 	}
 }
 
-// DefaultBOSHDeploymentWithUnsupportedOps fissile deployment CR with ops
-func (c *Catalog) DefaultBOSHDeploymentWithUnsupportedOps(name, manifestRef string, opsRef string) bdv1.BOSHDeployment {
-	return bdv1.BOSHDeployment{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: bdv1.BOSHDeploymentSpec{
-			Manifest: bdv1.Manifest{Ref: manifestRef, Type: bdv1.ConfigMapType},
-			Ops: []bdv1.Ops{
-				{Ref: opsRef, Type: bdv1.SecretType},
-			},
-		},
-	}
-}
-
-// WrongTypeBOSHDeployment fissile deployment CR containing wrong type
+// WrongTypeBOSHDeployment a deployment CR containing wrong type
 func (c *Catalog) WrongTypeBOSHDeployment(name, manifestRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -838,7 +825,7 @@ func (c *Catalog) WrongTypeBOSHDeployment(name, manifestRef string) bdv1.BOSHDep
 	}
 }
 
-// BOSHDeploymentWithWrongTypeOps fissile deployment CR with wrong type ops
+// BOSHDeploymentWithWrongTypeOps a deployment CR with wrong type ops
 func (c *Catalog) BOSHDeploymentWithWrongTypeOps(name, manifestRef string, opsRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -851,7 +838,7 @@ func (c *Catalog) BOSHDeploymentWithWrongTypeOps(name, manifestRef string, opsRe
 	}
 }
 
-// InterpolateBOSHDeployment fissile deployment CR
+// InterpolateBOSHDeployment a deployment CR
 func (c *Catalog) InterpolateBOSHDeployment(name, manifestRef, opsRef string, secretRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: name},

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -815,6 +815,19 @@ func (c *Catalog) DefaultBOSHDeploymentWithOps(name, manifestRef string, opsRef 
 	}
 }
 
+// DefaultBOSHDeploymentWithUnsupportedOps fissile deployment CR with ops
+func (c *Catalog) DefaultBOSHDeploymentWithUnsupportedOps(name, manifestRef string, opsRef string) bdv1.BOSHDeployment {
+	return bdv1.BOSHDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: bdv1.BOSHDeploymentSpec{
+			Manifest: bdv1.Manifest{Ref: manifestRef, Type: bdv1.ConfigMapType},
+			Ops: []bdv1.Ops{
+				{Ref: opsRef, Type: bdv1.SecretType},
+			},
+		},
+	}
+}
+
 // WrongTypeBOSHDeployment fissile deployment CR containing wrong type
 func (c *Catalog) WrongTypeBOSHDeployment(name, manifestRef string) bdv1.BOSHDeployment {
 	return bdv1.BOSHDeployment{


### PR DESCRIPTION
[#167145276](https://www.pivotaltracker.com/n/projects/2192232/stories/167145276)

- Do not allow admissions if the referenced spec.ops resources are not in place.

- For the spec.ops resources availability
  - Allow to check during 5 secs, if the resource is there(timeout after)
  - Only supported for configmaps and secrets

- Added integration tests that cover
  - not existing spec.ops resource referenced in the BOSHDeployment
  - use case when the spec.ops resource takes time to come up, but still under
    the timeout limits
  - use case when the spec.ops resource takes time to come up, but hits the
    timeout