### PR TITLE
Fix when spec.index equals 0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.2.1
 	github.com/stretchr/objx v0.2.0 // indirect
-	github.com/viovanov/bosh-template-go v0.0.0-20190531194715-753a0fd8d6cb
+	github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/cloudfoundry/bosh-utils v0.0.0-20190206192830-9a0affed2bf1 h1:TxcGamw
 github.com/cloudfoundry/bosh-utils v0.0.0-20190206192830-9a0affed2bf1/go.mod h1:JCrKwetZGjxbfq1U139TZuXDBfdGLtjOEAfxMWKV/QM=
 github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c h1:L6Qwcfk/qeD05lCaMxjhn8fCKNAVEWOBn1vqU7KJHtk=
 github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c/go.mod h1:67a7aIi94FHDZdoeGSJRRFDp66l9MhaAG1yGxpUoFD8=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
@@ -93,6 +94,7 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -151,6 +153,7 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rohitsakala/goveralls v0.0.4/go.mod h1:LfkwLgYbHd6eJ1ER4uEdcKJW6pLbYZ8nMPp7h0rQyoo=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -181,6 +184,10 @@ github.com/viovanov/bosh-template-go v0.0.0-20190531002828-39f4ed6564ad h1:gCPQr
 github.com/viovanov/bosh-template-go v0.0.0-20190531002828-39f4ed6564ad/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
 github.com/viovanov/bosh-template-go v0.0.0-20190531194715-753a0fd8d6cb h1:jIlx6A8c7fh6fKBUHr9nWXgbBiQxrvHSWrWJWQihA/k=
 github.com/viovanov/bosh-template-go v0.0.0-20190531194715-753a0fd8d6cb/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
+github.com/viovanov/bosh-template-go v0.0.0-20190711024214-c61109f4c16b h1:yGRMCudc306dZbbbMXuidIA7/4na536pbgAcmXO2MvA=
+github.com/viovanov/bosh-template-go v0.0.0-20190711024214-c61109f4c16b/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
+github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f h1:tNNj7ovHmXtrNN13NlUEhiP1noCAb6iTPqEfZJPm2dY=
+github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
@@ -223,6 +230,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190410211219-2538eef75904/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190520220859-26647e34d3c0 h1:lvPfJvgU8ph6AjkvFjGFZaot/UyeyrJZA0jr2T3x6oI=
 golang.org/x/tools v0.0.0-20190520220859-26647e34d3c0/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+google.golang.org/appengine v1.2.0 h1:S0iUepdCWODXRvtE+gcRDd15L+k+k1AiHlMiMjefH24=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/bosh/manifest/data_gatherer.go
+++ b/pkg/bosh/manifest/data_gatherer.go
@@ -316,7 +316,7 @@ func (dg *DataGatherer) renderJobBPM(currentJob *Job, baseDir string) error {
 					Address:    jobInstance.Address,
 					AZ:         jobInstance.AZ,
 					ID:         jobInstance.ID,
-					Index:      string(jobInstance.Index),
+					Index:      jobInstance.Index,
 					Deployment: dg.manifest.Name,
 					Name:       jobInstance.Name,
 				},

--- a/pkg/bosh/manifest/render_job_tmpls.go
+++ b/pkg/bosh/manifest/render_job_tmpls.go
@@ -81,7 +81,7 @@ func RenderJobTemplates(boshManifestPath string, jobsDir string, jobsOutputDir s
 						Address: currentJobInstance.Address,
 						AZ:      currentJobInstance.AZ,
 						ID:      currentJobInstance.ID,
-						Index:   string(currentJobInstance.Index),
+						Index:   currentJobInstance.Index,
 						Name:    currentJobInstance.Name,
 					},
 


### PR DESCRIPTION
Whenever the index as `string` was "0", the template rendering rendered it as `\u0000`. As `int`, it renders correctly to 0.