### PR TITLE
Clean up mutatingwebhookconfiguration and helm releases

### DIFF
--- a/dev-env-havener.yaml
+++ b/dev-env-havener.yaml
@@ -1,7 +1,7 @@
 #
 #
-# The dev-env-havener.yaml packs a development flow 
-# for a running minikube into a single configuration file. 
+# The dev-env-havener.yaml packs a development flow
+# for a running minikube into a single configuration file.
 # This flow involves:
 # - compiling a binary
 # - building a Docker img using the above binary
@@ -34,7 +34,7 @@ releases:
   chart_location: deploy/helm/cf-operator/
   overrides:
     image:
-      tag: (( shell . bin/include/versioning && echo "${VERSION_TAG}" )) 
+      tag: (( shell . bin/include/versioning && echo "${VERSION_TAG}" ))
       repository: cf-operator
       org: cfcontainerization
     customResources:
@@ -65,7 +65,7 @@ before:
     ./bin/apply-crds
 
     export RELEASE_NAMESPACE="quarks"
-    kubectl -n "${RELEASE_NAMESPACE}" delete mutatingwebhookconfiguration cf-operator-mutating-hook-quarks --ignore-not-found=true
+    kubectl -n "${RELEASE_NAMESPACE}" delete mutatingwebhookconfiguration cf-operator-hook-quarks --ignore-not-found=true
     kubectl -n "${RELEASE_NAMESPACE}" delete secret cf-operator-webhook-server-cert --ignore-not-found=true
 
 after:

--- a/e2e/kube/e2ehelper/e2e_helper.go
+++ b/e2e/kube/e2ehelper/e2e_helper.go
@@ -61,17 +61,16 @@ func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error
 	}
 	fmt.Println("Setting up in test namespace '" + namespace + "'...")
 
-	if crdExist {
-		// TODO: find relative path here
-		_, err = environment.RunBinary(helmCmd, "install", chartPath,
-			"--name", fmt.Sprintf("%s-%s", cfOperatorRelease, namespace),
-			"--namespace", namespace,
-			"--timeout", installTimeOutInSecs,
-			"--set", "customResources.enableInstallation=false",
-			"--wait")
-		if err != nil {
-			return "", nil, err
-		}
+	// TODO: find relative path here
+	_, err = environment.RunBinary(helmCmd, "install", chartPath,
+		"--name", fmt.Sprintf("%s-%s", cfOperatorRelease, namespace),
+		"--namespace", namespace,
+		"--timeout", installTimeOutInSecs,
+
+		"--set", fmt.Sprintf("customResources.enableInstallation=%s", strconv.FormatBool(!crdExist)),
+		"--wait")
+	if err != nil {
+		return "", nil, err
 	}
 
 	teardownFunc := func() error {

--- a/e2e/kube/suite_test.go
+++ b/e2e/kube/suite_test.go
@@ -7,18 +7,17 @@ import (
 	"os/exec"
 	"testing"
 
-	"code.cloudfoundry.org/cf-operator/e2e/kube/e2ehelper"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"code.cloudfoundry.org/cf-operator/e2e/kube/e2ehelper"
 	"code.cloudfoundry.org/cf-operator/integration/environment"
 )
 
 var (
-	nsIndex    int
-	nsTeardown environment.TearDownFunc
-	namespace  string
+	nsIndex   int
+	teardown  environment.TearDownFunc
+	namespace string
 )
 
 func FailAndCollectDebugInfo(description string, callerSkip ...int) {
@@ -47,12 +46,12 @@ var _ = BeforeEach(func() {
 		log.Fatal(err)
 	}
 	chartPath := fmt.Sprintf("%s%s", dir, "/../../helm/cf-operator")
-	namespace, nsTeardown, err = e2ehelper.SetUpEnvironment(chartPath)
+	namespace, teardown, err = e2ehelper.SetUpEnvironment(chartPath)
 	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterEach(func() {
-	if nsTeardown != nil {
-		nsTeardown()
+	if teardown != nil {
+		teardown()
 	}
 })

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -283,7 +283,7 @@ func getWebhookServicePort(namespaceCounter int) (int32, error) {
 func DeleteNamespace(ns string, kubeCtlCmd string) error {
 	fmt.Printf("Cleaning up namespace %s \n", ns)
 
-	_, err := RunBinary(kubeCtlCmd, "delete", "--ignore-not-found", "namespace", ns)
+	_, err := RunBinary(kubeCtlCmd, "delete", "--wait=false", "--ignore-not-found", "namespace", ns)
 	if err != nil {
 		return err
 	}

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -291,6 +291,19 @@ func DeleteNamespace(ns string, kubeCtlCmd string) error {
 	return nil
 }
 
+// DeleteWebhook removes existing mutatingwebhookconfiguration
+func DeleteWebhook(ns string, kubeCtlCmd string) error {
+	webHookName := fmt.Sprintf("%s-%s", "cf-operator-hook", ns)
+	fmt.Printf("Cleaning up mutatingwebhookconfiguration %s \n", webHookName)
+
+	_, err := RunBinary(kubeCtlCmd, "delete", "--ignore-not-found", "mutatingwebhookconfiguration", webHookName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RunBinary executes a binary cmd and returns the stdOutput
 func RunBinary(binaryName string, args ...string) ([]byte, error) {
 	cmd := exec.Command(binaryName, args...)

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -36,5 +36,9 @@ var _ = AfterSuite(func() {
 		if err != nil {
 			fmt.Printf("WARNING: failed to delete namespace %s: %v\n", namespace, err)
 		}
+		err = environment.DeleteWebhook(namespace, kubeCtlCmd)
+		if err != nil {
+			fmt.Printf("WARNING: failed to delete mutatingwebhookconfiguration in %s: %v\n", namespace, err)
+		}
 	}
 })


### PR DESCRIPTION
Integration tests now delete the mutatingwebhookconfiguration after
deleting their namespace.

E2E helm tests now delete their namespace, mutatingwebhookconfiguration
and helm release.

[#167216165](https://www.pivotaltracker.com/story/show/167216165)