### PR TITLE
Move the bootstrap logic to the operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.2.1
 	github.com/stretchr/objx v0.2.0 // indirect
-	github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f
+	github.com/viovanov/bosh-template-go v0.0.0-20190711164142-409a5c63db67
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,12 @@ github.com/viovanov/bosh-template-go v0.0.0-20190711024214-c61109f4c16b h1:yGRMC
 github.com/viovanov/bosh-template-go v0.0.0-20190711024214-c61109f4c16b/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
 github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f h1:tNNj7ovHmXtrNN13NlUEhiP1noCAb6iTPqEfZJPm2dY=
 github.com/viovanov/bosh-template-go v0.0.0-20190711031255-6b635706165f/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
+github.com/viovanov/bosh-template-go v0.0.0-20190711155008-5e9115cdfccb h1:UMjP/S1vO1twriI280NaWdBYhFlLLckSwGgbAK220/M=
+github.com/viovanov/bosh-template-go v0.0.0-20190711155008-5e9115cdfccb/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
+github.com/viovanov/bosh-template-go v0.0.0-20190711161810-4888a47ca2b7 h1:QEs93O+xyHUBlutCb2+6oXPzVWSjVB4/sKubAyHDTUo=
+github.com/viovanov/bosh-template-go v0.0.0-20190711161810-4888a47ca2b7/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
+github.com/viovanov/bosh-template-go v0.0.0-20190711164142-409a5c63db67 h1:xCouh2jRznXWqzyt6QsHVg/1wjcKmdgMQ1ga7qnebwQ=
+github.com/viovanov/bosh-template-go v0.0.0-20190711164142-409a5c63db67/go.mod h1:c6vU7jEbBrrJjP52K6N/Lfk4tHlL2+ev7H6LJ82pq/I=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=

--- a/pkg/bosh/manifest/data_gatherer.go
+++ b/pkg/bosh/manifest/data_gatherer.go
@@ -315,6 +315,7 @@ func (dg *DataGatherer) renderJobBPM(currentJob *Job, baseDir string) error {
 				&btg.InstanceInfo{
 					Address:    jobInstance.Address,
 					AZ:         jobInstance.AZ,
+					Bootstrap:  jobInstance.Index == 0,
 					ID:         jobInstance.ID,
 					Index:      jobInstance.Index,
 					Deployment: dg.manifest.Name,

--- a/pkg/bosh/manifest/render_job_tmpls.go
+++ b/pkg/bosh/manifest/render_job_tmpls.go
@@ -78,11 +78,12 @@ func RenderJobTemplates(boshManifestPath string, jobsDir string, jobsOutputDir s
 					},
 
 					&btg.InstanceInfo{
-						Address: currentJobInstance.Address,
-						AZ:      currentJobInstance.AZ,
-						ID:      currentJobInstance.ID,
-						Index:   currentJobInstance.Index,
-						Name:    currentJobInstance.Name,
+						Address:   currentJobInstance.Address,
+						AZ:        currentJobInstance.AZ,
+						Bootstrap: currentJobInstance.Index == 0,
+						ID:        currentJobInstance.ID,
+						Index:     currentJobInstance.Index,
+						Name:      currentJobInstance.Name,
 					},
 
 					filepath.Join(jobSrcDir, JobSpecFilename),


### PR DESCRIPTION
According to https://bosh.io/docs/jobs/#properties-spec, `there is no guarantee that instances will be numbered consecutively`. This change moves the logic from the `bosh-template-go` library to the operator.