### PR TITLE
Remove namespace cleanup from e2e tests

### DIFF
--- a/bin/test-helm-e2e
+++ b/bin/test-helm-e2e
@@ -12,15 +12,6 @@ fi
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"
   export TEST_NAMESPACE
-
-  remove_namespaces() {
-    namespaces=$(kubectl get ns -o=jsonpath="{..name}" | tr '[[:space:]]' '\n' | grep "$TEST_NAMESPACE")
-    for ns in $namespaces; do
-      echo "Deleting namespace $ns..."
-      kubectl delete namespace --wait=false --grace-period=60 "$ns"
-    done
-  }
-  trap remove_namespaces EXIT
 fi
 
 # Add all required CRD´s

--- a/bin/test-helm-e2e-storage
+++ b/bin/test-helm-e2e-storage
@@ -12,15 +12,6 @@ fi
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test-storage$(date +%s)"
   export TEST_NAMESPACE
-
-  remove_namespaces() {
-    namespaces=$(kubectl get ns -o=jsonpath="{..name}" | tr '[[:space:]]' '\n' | grep "$TEST_NAMESPACE")
-    for ns in $namespaces; do
-      echo "Deleting namespace $ns..."
-      kubectl delete namespace --wait=false --grace-period=60 "$ns"
-    done
-  }
-  trap remove_namespaces EXIT
 fi
 
 # Add all required CRD´s

--- a/bin/test-integration-storage
+++ b/bin/test-integration-storage
@@ -44,9 +44,6 @@ if [ -n "$COVERAGE" ]; then
   mkdir -p code-coverage
 fi
 
-# Build the required helm charts to run the cf-operator
-./bin/build-helm
-
 NODES=${NODES:-3}
 FLAKE_ATTEMPTS=${FLAKE_ATTEMPTS:-3}
 ginkgo \


### PR DESCRIPTION
Integration tests also don't do this. 
AfterSuite deletes namespaces, too.

[#167232164](https://www.pivotaltracker.com/story/show/167232164)