### PR TITLE
Affinity and updates

### DIFF
--- a/pkg/bosh/manifest/interpolator_test.go
+++ b/pkg/bosh/manifest/interpolator_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Resolver", func() {
+var _ = Describe("Interpolator", func() {
 	var (
 		baseManifest     []byte
 		ops              []byte

--- a/pkg/bosh/manifest/kube_resources.go
+++ b/pkg/bosh/manifest/kube_resources.go
@@ -356,8 +356,7 @@ func (kc *KubeConverter) errandToExtendedJob(
 	}
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
-		affinity := corev1.Affinity(*instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity)
-		eJob.Spec.Template.Spec.Affinity = &affinity
+		eJob.Spec.Template.Spec.Affinity = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity
 	}
 	return eJob, nil
 }


### PR DESCRIPTION
Make sure manifest.Marshal and LoadYAML retain affinity structs

`manifest.Marshal` is used to create the 'WithOps' secret and for calculating the SHA label.
Marshalling lowercases all the k8s-only struct keys, but `ghodss/yaml` seems to ignore the case anyhow.
So loading a manifest with lower case keys also works.


[#167128619](https://www.pivotaltracker.com/story/show/167128619)