### PR TITLE
Doc fixes

### DIFF
--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -433,7 +433,7 @@ releases:
     version: 28.g837c5b3-30.263-7.0.0_233.gde0accd0
 ```
 
-The stemcell information (name, and stemcell and fissile version) are taken from the `stemcells` entry that matches the instance group's stemcell alias. The registry URL including the organization, the release name, and the version com from the `releases` entry that's referenced from the job.
+The stemcell information (name, and stemcell and fissile version) are taken from the `stemcells` entry that matches the instance group's stemcell alias. The registry URL including the organization, the release name, and the version come from the `releases` entry that's referenced from the job.
 
 > **Note:**
 >

--- a/docs/rendering_templates.md
+++ b/docs/rendering_templates.md
@@ -40,41 +40,41 @@ Each init container uses the release's docker image.
 
 The main purpose of the data gathering phase is to compile all information required for all templates to be rendered and for all instance groups to be run:
 
-- properties
-- link instances
-- bpm yaml
+  - properties
+  - link instances
+  - bpm yaml
 
 Two containers are run for each instance group in the deployment manifest, using the image of the CF Operator. These two containers write the following on stdout:
 
-- A `Secret` named `<deployment-name>.ig-resolved.<instance-group>-v<version>`
+  - A `Secret` named `<deployment-name>.ig-resolved.<instance-group>-v<version>`
 
-  This is the "Resolved Instance Group Properties" yaml file.
-  It contains a deployment manifest structure that only has information pertinent to an instance group.
-  It includes:
-  - all job properties for that instance group
-  - all properties for all jobs that are link providers to any of the jobs of that instance group
-  - the rendered contents of each `bpm.yml.erb`, for each job in the instance group
-  - link instance specs for all AZs and replicas; read more about instance keys available for links [here](https://bosh.io/docs/links/#templates)
+    This is the "Resolved Instance Group Properties" yaml file.
+    It contains a deployment manifest structure that only has information pertinent to an instance group.
+    It includes:
+      - all job properties for that instance group
+      - all properties for all jobs that are link providers to any of the jobs of that instance group
+      - the rendered contents of each `bpm.yml.erb`, for each job in the instance group
+      - link instance specs for all AZs and replicas; read more about instance keys available for links [here](https://bosh.io/docs/links/#templates)
 
-  > **Note:**
-  >
-  > Link instance specs are stored in the `bosh_containerization` property key for each job in the instance group.
+    > **Note:**
+    >
+    > Link instance specs are stored in the `bosh_containerization` property key for each job in the instance group.
 
-- a `Secret` named `<deployment-name>.bpm.<instance-group>-v<version>`
+  - a `Secret` named `<deployment-name>.bpm.<instance-group>-v<version>`
 
-  Once all properties and link instances are compiled, `bpm.yml.erb` can be rendered for each job and for each AZ and replica of the instance group.
+    Once all properties and link instances are compiled, `bpm.yml.erb` can be rendered for each job and for each AZ and replica of the instance group.
   
-  The output of this container is the "BPM Info" yaml file.
-  It contains a deployment manifest structure that only has information pertinent to an instance group.
-  It includes the rendered contents of each `bpm.yml.erb`, for each job in the instance group.
+    The output of this container is the "BPM Info" yaml file.
+    It contains a deployment manifest structure that only has information pertinent to an instance group.
+    It includes the rendered contents of each `bpm.yml.erb`, for each job in the instance group.
   
-  > **Note:**
-  >
-  > The BPM information is stored under the `bosh_containerization` property, for each BOSH Job.
-  >
-  > **Important:**
-  >
-  > Because container entrypoints in Kubernetes cannot be different among the replicas of a Pod, we don't support the usage of things like `spec.index` in the ERB template of `bpm.yaml`.
+    > **Note:**
+    >
+    > The BPM information is stored under the `bosh_containerization` property, for each BOSH Job.
+    >
+    > **Important:**
+    >
+    > Because container entrypoints in Kubernetes cannot be different among the replicas of a Pod, we don't support the usage of things like `spec.index` in the ERB template of `bpm.yaml`.
 
 ### Run
 
@@ -199,6 +199,7 @@ bootstrap: <index == 0>
   > - The use of `spec.ip` in `bpm.yml.erb`
   >
   >   Since `bpm.yml` is rendered before the actual instance group runs, in a different pod, `spec.ip` is invalid.
+  >
   > - The use of `spec.index` in `bpm.yml.erb`
   >
   >   Any BPM information that is different for each replica, cannot be supported by the CF Operator, because all `Pod` replicas are identical by definition.


### PR DESCRIPTION
- Typo
- Bad list indentation broke deeper nested list rendering.
- Missing empty quoted line broke list rendering in that block.