### PR TITLE
Increase the timeout from 30s to 60s

### DIFF
--- a/testing/kubectl_helper.go
+++ b/testing/kubectl_helper.go
@@ -198,7 +198,7 @@ func (k *Kubectl) Wait(namespace string, requiredStatus string, resourceName str
 
 // CheckWait check's if the condition is satisfied
 func (k *Kubectl) CheckWait(namespace string, requiredStatus string, resourceName string) (bool, error) {
-	cmd := exec.Command("kubectl", "--namespace", namespace, "wait", "--for=condition="+requiredStatus, resourceName)
+	cmd := exec.Command("kubectl", "--namespace", namespace, "wait", "--for=condition="+requiredStatus, resourceName, "--timeout=60s")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "Error from server (NotFound)") {


### PR DESCRIPTION
This is used via the `kubectl wait` ,
when waiting for pods to be `Ready`, during
e2e tests.