### PR TITLE
Refact the data gatherer

### DIFF
--- a/cmd/internal/bpm_configs.go
+++ b/cmd/internal/bpm_configs.go
@@ -75,7 +75,7 @@ instance group.
 			return err
 		}
 
-		dg, err := manifest.NewDataGatherer(log, baseDir, namespace, *m, instanceGroupName)
+		dg, err := manifest.NewInstanceGroupResolver(baseDir, namespace, *m, instanceGroupName)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/instance_group.go
+++ b/cmd/internal/instance_group.go
@@ -18,14 +18,14 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 )
 
-// dataGatherCmd represents the dataGather command
-var dataGatherCmd = &cobra.Command{
-	Use:   "data-gather [flags]",
-	Short: "Gathers data of a bosh manifest",
-	Long: `Gathers data of a manifest.
+// instanceGroupCmd command to create an instance group manifest where all
+// properties are resolved
+var instanceGroupCmd = &cobra.Command{
+	Use:   "instance-group [flags]",
+	Short: "Resolves instance group properties of a BOSH manifest",
+	Long: `Resolves instance group properties of a BOSH manifest.
 
-This will retrieve information of an instance-group
-inside a bosh manifest file.
+This will resolve the properties of an instance group and return a manifest for that instance group.
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -76,17 +76,17 @@ inside a bosh manifest file.
 			return err
 		}
 
-		dg, err := manifest.NewDataGatherer(log, baseDir, namespace, *m, instanceGroupName)
+		dg, err := manifest.NewInstanceGroupResolver(baseDir, namespace, *m, instanceGroupName)
 		if err != nil {
 			return err
 		}
 
-		resolvedProperties, err := dg.ResolvedProperties()
+		manifest, err := dg.Manifest()
 		if err != nil {
 			return err
 		}
 
-		propertiesBytes, err := yaml.Marshal(resolvedProperties)
+		propertiesBytes, err := yaml.Marshal(manifest)
 		if err != nil {
 			return err
 		}
@@ -106,7 +106,7 @@ inside a bosh manifest file.
 		io.Copy(&buf, r)
 
 		if buf.Len() > 0 {
-			return errors.Errorf("unexpected data sent to stdOut, during the data-gather cmd: %s", buf.String())
+			return errors.Errorf("unexpected data sent to stdOut, during the instance-group cmd: %s", buf.String())
 		}
 		// Write to an original stdOut
 		// without any undesired data
@@ -128,5 +128,5 @@ inside a bosh manifest file.
 }
 
 func init() {
-	utilCmd.AddCommand(dataGatherCmd)
+	utilCmd.AddCommand(instanceGroupCmd)
 }

--- a/docs/commands/cf-operator_util.md
+++ b/docs/commands/cf-operator_util.md
@@ -32,7 +32,7 @@ Calls a utility subcommand.
 
 * [cf-operator](cf-operator.md)	 - cf-operator manages BOSH deployments on Kubernetes
 * [cf-operator util bpm-configs](cf-operator_util_bpm-configs.md)	 - Prints the BPM configs for all BOSH jobs of an instance group
-* [cf-operator util data-gather](cf-operator_util_data-gather.md)	 - Gathers data of a bosh manifest
+* [cf-operator util instance-group](cf-operator_util_instance-group.md)	 - Gathers data of a bosh manifest
 * [cf-operator util template-render](cf-operator_util_template-render.md)	 - Renders a bosh manifest
 * [cf-operator util variable-interpolation](cf-operator_util_variable-interpolation.md)	 - Interpolate variables
 

--- a/docs/commands/cf-operator_util_instance-group.md
+++ b/docs/commands/cf-operator_util_instance-group.md
@@ -1,4 +1,4 @@
-## cf-operator util data-gather
+## cf-operator util instance-group
 
 Gathers data of a bosh manifest
 
@@ -12,13 +12,13 @@ inside a bosh manifest file.
 
 
 ```
-cf-operator util data-gather [flags]
+cf-operator util instance-group [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for data-gather
+  -h, --help   help for instance-group
 ```
 
 ### Options inherited from parent commands

--- a/docs/controllers/boshdeployment.md
+++ b/docs/controllers/boshdeployment.md
@@ -55,7 +55,7 @@ Here's a state diagram that tries to explain the process of reconciling a `BOSHD
 >
 > The output of the ["Variable Interpolation"](https://github.com/cloudfoundry-incubator/cf-operator/tree/master/docs/commands/cf-operator_util_variable-interpolation.md) `ExtendedJob` is the input for the "Data Gathering" `ExtendedJob`. This is the "Desired Manifest" `Secret`. (`desired-manifest-v1`)
 >
-> The ["Data Gathering"](https://github.com/cloudfoundry-incubator/cf-operator/tree/master/docs/commands/cf-operator_util_data-gather.md) step generates 2 [Versioned Secrets](extendedjob.md#versioned-secrets) for each Instance Group:
+> The ["Data Gathering"](https://github.com/cloudfoundry-incubator/cf-operator/tree/master/docs/commands/cf-operator_util_instance-group.md) step generates 2 [Versioned Secrets](extendedjob.md#versioned-secrets) for each Instance Group:
 >
 > - Instance Group Resolved Properties (referenced by the Instance Group `ExtendedStatefulSets` and `ExtendedJobs`) (i.e. `ig-resolved.nats-v1`)
 > - Instance Group BPM (watched for by the BPM Reconciler) (i.e. `bpm.nats-v1`)

--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -559,7 +559,7 @@ After creating a `BOSHDeployment` named `nats-deployment`, with one Instance Gro
 
   ```text
   bpm-configs-nats-deployment
-  data-gathering-nats-deployment
+  ig-nats-deployment
   var-interpolation-nats-deployment
   ```
 

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -137,16 +137,16 @@ var _ = Describe("CLI", func() {
 		})
 	})
 
-	Describe("data-gather", func() {
+	Describe("instance-group", func() {
 		It("lists its flags incl. ENV binding", func() {
-			session, err := act("util", "data-gather", "-h")
+			session, err := act("util", "instance-group", "-h")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out).Should(Say(`Flags:
-  -h, --help * help for data-gather`))
+  -h, --help * help for instance-group`))
 		})
 
 		It("accepts the bosh-manifest-path as a parameter", func() {
-			session, err := act("util", "data-gather", "--base-dir=.", "-m", "foo.txt", "-g", "log-api")
+			session, err := act("util", "instance-group", "--base-dir=.", "-m", "foo.txt", "-g", "log-api")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Err).Should(Say("open foo.txt: no such file or directory"))
 		})
@@ -161,7 +161,7 @@ var _ = Describe("CLI", func() {
 			})
 
 			It("accepts the bosh-manifest-path as an environment variable", func() {
-				session, err := act("util", "data-gather", "--base-dir=.", "-g", "log-api")
+				session, err := act("util", "instance-group", "--base-dir=.", "-g", "log-api")
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session.Err).Should(Say("open bar.txt: no such file or directory"))
 			})

--- a/e2e/cli/util_dgather_test.go
+++ b/e2e/cli/util_dgather_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("data-gather", func() {
+var _ = Describe("instance-group", func() {
 	var (
 		manifestPath string
 	)
 
 	act := func(manifestPath string) (session *gexec.Session, err error) {
-		args := []string{"util", "data-gather", "-m", manifestPath, "-b", assetPath, "-g", "log-api"}
+		args := []string{"util", "instance-group", "-m", manifestPath, "-b", assetPath, "-g", "log-api"}
 		cmd := exec.Command(cliPath, args...)
 		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		return

--- a/pkg/bosh/converter/job_factory_test.go
+++ b/pkg/bosh/converter/job_factory_test.go
@@ -23,12 +23,12 @@ var _ = Describe("JobFactory", func() {
 		factory = converter.NewJobFactory(m, "namespace")
 	})
 
-	Describe("DataGatheringJob", func() {
+	Describe("InstanceGroupManifestJob", func() {
 		It("creates init containers", func() {
-			job, err := factory.DataGatheringJob()
+			job, err := factory.InstanceGroupManifestJob()
 			Expect(err).ToNot(HaveOccurred())
 			jobDG := job.Spec.Template.Spec
-			// Test init containers in the datagathering job
+			// Test init containers in the ig manifest job
 			Expect(jobDG.InitContainers[0].Name).To(Equal("spec-copier-redis"))
 			Expect(jobDG.InitContainers[1].Name).To(Equal("spec-copier-cflinuxfs3"))
 			Expect(jobDG.InitContainers[0].VolumeMounts[0].MountPath).To(Equal("/var/vcap/all-releases"))

--- a/pkg/bosh/manifest/instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/instance_group_resolver_test.go
@@ -7,24 +7,21 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-test/deep"
-	"go.uber.org/zap"
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	. "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
-	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
 	"code.cloudfoundry.org/cf-operator/testing"
 )
 
 const assetPath = "../../../testing/assets"
 
-var _ = Describe("DataGatherer", func() {
+var _ = Describe("InstanceGroupResolver", func() {
 
 	var (
 		m   *Manifest
 		env testing.Catalog
-		log *zap.SugaredLogger
-		dg  *DataGatherer
+		dg  *InstanceGroupResolver
 		ig  string
 	)
 
@@ -64,14 +61,10 @@ var _ = Describe("DataGatherer", func() {
 		})
 	})
 
-	Context("DataGatherer", func() {
-		BeforeEach(func() {
-			_, log = helper.NewTestLogger()
-		})
-
+	Context("InstanceGroupResolver", func() {
 		JustBeforeEach(func() {
 			var err error
-			dg, err = manifest.NewDataGatherer(log, assetPath, "default", *m, ig)
+			dg, err = manifest.NewInstanceGroupResolver(assetPath, "default", *m, ig)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -131,14 +124,14 @@ var _ = Describe("DataGatherer", func() {
 			})
 		})
 
-		Describe("ResolvedProperties", func() {
+		Describe("Manifest", func() {
 			BeforeEach(func() {
 				m = env.ElaboratedBOSHManifest()
 				ig = "redis-slave"
 			})
 
 			It("should gather all data for each job spec file", func() {
-				manifest, err := dg.ResolvedProperties()
+				manifest, err := dg.Manifest()
 				Expect(err).ToNot(HaveOccurred())
 
 				//Check JobInstance for the redis-server job
@@ -160,7 +153,7 @@ var _ = Describe("DataGatherer", func() {
 				})
 
 				It("resolves all required data if the job consumes a link", func() {
-					manifest, err := dg.ResolvedProperties()
+					manifest, err := dg.Manifest()
 					Expect(err).ToNot(HaveOccurred())
 
 					// log-api instance_group, with loggregator_trafficcontroller job, consumes a link from doppler job
@@ -183,7 +176,7 @@ var _ = Describe("DataGatherer", func() {
 				})
 
 				It("has an empty consumes list if the job does not consume a link", func() {
-					manifest, err := dg.ResolvedProperties()
+					manifest, err := dg.Manifest()
 					Expect(err).ToNot(HaveOccurred())
 
 					// doppler instance_group, with doppler job, only provides doppler link

--- a/pkg/bosh/manifest/job_provider_links.go
+++ b/pkg/bosh/manifest/job_provider_links.go
@@ -1,0 +1,83 @@
+package manifest
+
+import (
+	"fmt"
+	"strings"
+
+	bc "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest/containerization"
+)
+
+// JobProviderLinks provides links to other jobs, indexed by provider type and name
+type JobProviderLinks map[string]map[string]bc.JobLink
+
+// Lookup returns a link for a type and name, used when links are consumed
+func (jpl JobProviderLinks) Lookup(provider *JobSpecProvider) (bc.JobLink, bool) {
+	link, ok := jpl[provider.Type][provider.Name]
+	return link, ok
+}
+
+// Add another job to the lookup map
+func (jpl JobProviderLinks) Add(job Job, spec JobSpec, jobsInstances []bc.JobInstance) error {
+	var properties map[string]interface{}
+
+	for _, link := range spec.Provides {
+		properties = map[string]interface{}{}
+		for _, property := range link.Properties {
+			// generate a nested struct of map[string]interface{} when
+			// a property is of the form foo.bar
+			if strings.Contains(property, ".") {
+				spec.RetrieveNestedProperty(properties, property)
+			} else {
+				properties[property] = spec.RetrievePropertyDefault(property)
+			}
+		}
+		// Override default spec values with explicit settings from the
+		// current bosh deployment manifest, this should be done under each
+		// job, inside a `properties` key.
+		for _, propertyName := range link.Properties {
+			mergeNestedExplicitProperty(properties, job, propertyName)
+		}
+		linkName := link.Name
+		linkType := link.Type
+
+		// instance_group.job can override the link name through the
+		// instance_group.job.provides, via the "as" key
+		if job.Provides != nil {
+			if value, ok := job.Provides[linkName]; ok {
+				switch value := value.(type) {
+				case map[interface{}]interface{}:
+					if overrideLinkName, ok := value["as"]; ok {
+						linkName = fmt.Sprintf("%v", overrideLinkName)
+					}
+				default:
+					return fmt.Errorf("unexpected type detected: %T, should have been a map", value)
+				}
+
+			}
+		}
+
+		if providers, ok := jpl[linkType]; ok {
+			if _, ok := providers[linkName]; ok {
+				// If this comes from an addon, it will inevitably cause
+				// conflicts. So in this case, we simply ignore the error
+				if job.Properties.BOSHContainerization.IsAddon {
+					continue
+				}
+
+				return fmt.Errorf("multiple providers for link: name=%s type=%s", linkName, linkType)
+			}
+		}
+
+		if _, ok := jpl[linkType]; !ok {
+			jpl[linkType] = map[string]bc.JobLink{}
+		}
+
+		// construct the jobProviderLinks of the current job that provides
+		// a link
+		jpl[linkType][linkName] = bc.JobLink{
+			Instances:  jobsInstances,
+			Properties: properties,
+		}
+	}
+	return nil
+}

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -105,16 +105,16 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	// Apply the "Data Gathering" ExtendedJob
-	eJob, err = jobFactory.DataGatheringJob()
+	eJob, err = jobFactory.InstanceGroupManifestJob()
 	if err != nil {
-		return reconcile.Result{}, log.WithEvent(instance, "DataGatheringError").Errorf(ctx, "Failed to build data gathering eJob: %v", err)
+		return reconcile.Result{}, log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "Failed to build data gathering eJob: %v", err)
 
 	}
 	log.Debug(ctx, "Creating data gathering ExtendedJob")
 	err = r.createEJob(ctx, instance, eJob)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "DataGatheringError").Errorf(ctx, "Failed to create data gathering ExtendedJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "Failed to create data gathering ExtendedJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Apply the "BPM Configs" ExtendedJob

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -300,7 +300,7 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 					switch object := object.(type) {
 					case *ejv1.ExtendedJob:
 						eJob := object
-						if strings.HasPrefix(eJob.Name, "dg-") {
+						if strings.HasPrefix(eJob.Name, "ig-") {
 							return errors.New("fake-error")
 						}
 					}


### PR DESCRIPTION
* rename DataGatherer struct to InstanceGroupResolver
* rename CLI command data-gather to instance-group
* rename ResolvedProperties to Manifest
  (`instance_group_resolver.Manifest()`)
* DataGatheringJob renamed to InstanceGroupManifestJob
* 'ig-resolved' is an 'instance group manifest'
* EJob now prefixed with 'ig-' instead of 'dg-'
* renamed `dataGather()` to `resolveManifest`