### PR TITLE
Improve tail-logs subcmd implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/directxman12/zapr v0.1.1
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0 // indirect
 	github.com/go-logr/zapr v0.1.0
@@ -34,7 +35,6 @@ require (
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.0.2
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/integration/util/util_suite_test.go
+++ b/integration/util/util_suite_test.go
@@ -18,7 +18,6 @@ func TestUtil(t *testing.T) {
 var (
 	env              *environment.Environment
 	namespacesToNuke []string
-	kubeCtlCmd       = "kubectl"
 )
 
 var _ = BeforeEach(func() {


### PR DESCRIPTION
Use the fsnotify golang pkg to:
- Set watchers for monitoring dirs and its sub-directories
- Be notified about new files and directories created during runtime

This should cover scenarios where:
- No dirs/files existing on the specified path
- dirs/files exists on the specified path
- dirs/files are updated on the fly

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>