### PR TITLE
Allow arbitrary environment variables to be set for a POD

### DIFF
--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -18,6 +18,7 @@ type Quarks struct {
 	PreRenderScripts []string           `json:"pre_render_scripts" yaml:"pre_render_scripts"`
 	Debug            bool               `json:"debug" yaml:"debug"`
 	IsAddon          bool               `json:"is_addon" yaml:"is_addon"`
+	Envs             []corev1.EnvVar    `json:"envs" yaml:"envs"`
 }
 
 // Port represents the port to be opened up for this job

--- a/testing/assets/gatherManifest.yml
+++ b/testing/assets/gatherManifest.yml
@@ -662,6 +662,12 @@ instance_groups:
                 networks: {}
                 ip: ""
             release: loggregator
+            envs:
+            - name: TRAFFIC_CONTROLLER_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
           cc:
             internal_service_hostname: cloud-controller-ng.service.cf.internal
             mutual_tls:


### PR DESCRIPTION
[#167316563](https://www.pivotaltracker.com/story/show/167316563)

- If we have same env key in `bpm.processes.env`, arbitrary env variables will override those.

```
IBMMasterMBP:~ bjxzi$ k exec -it -n scf scf-dev-log-api-v1-0 -c loggregator-trafficcontroller-loggregator-trafficcontroller -- bash
/:/# env | grep TRAFFIC_CONTROLLER_IP
TRAFFIC_CONTROLLER_IP=172.30.23.17
```