### PR TITLE
Fixes to reconciler requeue

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -67,13 +67,7 @@ var rootCmd = &cobra.Command{
 			log.Fatal("%s operator-webhook-service-host flag is not set (env variable: CF_OPERATOR_WEBHOOK_SERVICE_HOST).", cfFailedMessage)
 		}
 
-		config := &config.Config{
-			CtxTimeOut:        10 * time.Second,
-			Namespace:         cfOperatorNamespace,
-			WebhookServerHost: host,
-			WebhookServerPort: port,
-			Fs:                afero.NewOsFs(),
-		}
+		config := config.NewConfig(cfOperatorNamespace, host, port, afero.NewOsFs())
 		ctx := ctxlog.NewParentContext(log)
 
 		mgr, err := operator.NewManager(ctx, config, restConfig, manager.Options{

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,8 +3,8 @@
 - [Development](#development)
   - [Requirements](#requirements)
   - [Dependencies](#dependencies)
-  - [Publishing](#publishing)
   - [Creating a new Resource and Controller](#creating-a-new-resource-and-controller)
+    - [Reconcile Results](#reconcile-results)
     - [Testing](#testing)
   - [Create-Or-Update pattern](#create-or-update-pattern)
   - [Logging and Events](#logging-and-events)
@@ -25,8 +25,6 @@ Run with libraries fetched via go modules:
 ```bash
 export GO111MODULE=on
 ```
-
-## Publishing
 
 ## Creating a new Resource and Controller
 
@@ -159,6 +157,17 @@ export GO111MODULE=on
 - create a custom resource definition in `deploy/helm/cf-operator/templates/`
 - add the custom resource definition to `bin/apply-crds`
 
+### Reconcile Results
+
+	// RequeueOnError will requeue if reconcile also returns an error
+	RequeueOnError = reconcile.Result{}
+	// Requeue will requeue the request, behaviour is different than returning an error
+	Requeue = reconcile.Result{Requeue: true}
+	// RequeueAfterDefault requeues after the default, unless reconcile also returns an error
+	RequeueAfterDefault = reconcile.Result{RequeueAfter: config.RequeueAfter}
+	// NoRequeue does not requeue, unless reconcile also returns an error
+	NoRequeue = reconcile.Result{Requeue: false}
+
 ### Testing
 
 - create functions in `env/machine`
@@ -174,8 +183,8 @@ obj := someSecret.DeepCopy()
 _, err = controllerutil.CreateOrUpdate(ctx, r.client, obj, func() error {
   if !reflect.DeepEqual(obj.Data, someSecret.Data) {
     obj.Data = someSecret.Data
-  } 
-  
+  }
+
   return nil
 })
 ```

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -77,11 +77,8 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 
 		// Error reading the object - requeue the request.
-		return reconcile.Result{
-				Requeue:      true,
-				RequeueAfter: time.Second * 5,
-			},
-			log.WithEvent(bpmSecret, "GetBPMSecret").Errorf(ctx, "Failed to get Instance Group BPM versioned secret '%s': %v", request.NamespacedName, err)
+		log.WithEvent(bpmSecret, "GetBPMSecret").Errorf(ctx, "Failed to get Instance Group BPM versioned secret '%s': %v", request.NamespacedName, err)
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	// Get the label from the BPM Secret and read the corresponding desired manifest

--- a/pkg/kube/controllers/controllers_test.go
+++ b/pkg/kube/controllers/controllers_test.go
@@ -162,9 +162,8 @@ var _ = Describe("Controllers", func() {
 					// We should be getting 2 Create calls - one for the
 					// Validation webhook, one for the Mutating Webhook
 
-					switch object.(type) {
+					switch config := object.(type) {
 					case *admissionregistrationv1beta1.MutatingWebhookConfiguration:
-						config := object.(*admissionregistrationv1beta1.MutatingWebhookConfiguration)
 						Expect(config.Name).To(Equal("cf-operator-hook-" + config.Namespace))
 						Expect(len(config.Webhooks)).To(Equal(1))
 
@@ -175,7 +174,6 @@ var _ = Describe("Controllers", func() {
 						Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1beta1.Fail))
 						return nil
 					case *admissionregistrationv1beta1.ValidatingWebhookConfiguration:
-						config := object.(*admissionregistrationv1beta1.ValidatingWebhookConfiguration)
 						Expect(config.Name).To(Equal("cf-operator-hook-" + config.Namespace))
 						Expect(len(config.Webhooks)).To(Equal(1))
 

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -86,8 +86,8 @@ func (r *ErrandReconciler) Reconcile(request reconcile.Request) (reconcile.Resul
 		return result, err
 	}
 	if retry {
-		result.Requeue = true
-		return result, nil
+		ctxlog.Infof(ctx, "Retrying to create job '%s'", eJob.Name)
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	ctxlog.WithEvent(eJob, "CreateJob").Infof(ctx, "Created errand job for '%s'", eJob.Name)

--- a/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
@@ -325,7 +325,7 @@ var _ = Describe("ErrandReconciler", func() {
 					result, err := act()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(result.Requeue).To(BeTrue())
-					Expect(logs.FilterMessageSnippet("Skip create job due to configMap 'config1' not found").Len()).To(Equal(1))
+					Expect(logs.FilterMessageSnippet("Skip create job 'fake-pod' due to configMap 'config1' not found").Len()).To(Equal(1))
 
 					client.GetCalls(func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
 						switch obj.(type) {
@@ -342,7 +342,7 @@ var _ = Describe("ErrandReconciler", func() {
 					result, err = act()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(result.Requeue).To(BeTrue())
-					Expect(logs.FilterMessageSnippet("Skip create job due to secret 'secret1' not found").Len()).To(Equal(1))
+					Expect(logs.FilterMessageSnippet("Skip create job 'fake-pod' due to secret 'secret1' not found").Len()).To(Equal(1))
 				})
 			})
 		})

--- a/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler_test.go
@@ -56,9 +56,9 @@ var _ = Describe("ErrandReconciler", func() {
 		}
 
 		ejobGetStub := func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *ejv1.ExtendedJob:
-				eJob.DeepCopyInto(obj.(*ejv1.ExtendedJob))
+				eJob.DeepCopyInto(obj)
 				return nil
 			}
 			return apierrors.NewNotFound(schema.GroupResource{}, nn.Name)
@@ -274,24 +274,24 @@ var _ = Describe("ErrandReconciler", func() {
 
 				It("should trigger the job", func() {
 					client.GetCalls(func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
-						switch obj.(type) {
+						switch obj := obj.(type) {
 						case *ejv1.ExtendedJob:
-							eJob.DeepCopyInto(obj.(*ejv1.ExtendedJob))
+							eJob.DeepCopyInto(obj)
 							return nil
 						case *corev1.ConfigMap:
-							configMap.DeepCopyInto(obj.(*corev1.ConfigMap))
+							configMap.DeepCopyInto(obj)
 							return nil
 						case *corev1.Secret:
-							secret.DeepCopyInto(obj.(*corev1.Secret))
+							secret.DeepCopyInto(obj)
 							return nil
 						}
 						return apierrors.NewNotFound(schema.GroupResource{}, nn.Name)
 					})
 
-					client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOptionFunc) error {
-						switch object.(type) {
+					client.CreateCalls(func(context context.Context, obj runtime.Object, _ ...crc.CreateOptionFunc) error {
+						switch obj := obj.(type) {
 						case *batchv1.Job:
-							job := object.(*batchv1.Job)
+							job := obj
 							Expect(reflect.DeepEqual(job.Spec.Template.Spec, eJob.Spec.Template.Spec)).To(BeTrue())
 							return nil
 						}
@@ -314,9 +314,9 @@ var _ = Describe("ErrandReconciler", func() {
 
 				It("should skip when references are missing", func() {
 					client.GetCalls(func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
-						switch obj.(type) {
+						switch obj := obj.(type) {
 						case *ejv1.ExtendedJob:
-							eJob.DeepCopyInto(obj.(*ejv1.ExtendedJob))
+							eJob.DeepCopyInto(obj)
 							return nil
 						}
 						return apierrors.NewNotFound(schema.GroupResource{}, nn.Name)
@@ -328,12 +328,12 @@ var _ = Describe("ErrandReconciler", func() {
 					Expect(logs.FilterMessageSnippet("Skip create job 'fake-pod' due to configMap 'config1' not found").Len()).To(Equal(1))
 
 					client.GetCalls(func(ctx context.Context, nn types.NamespacedName, obj runtime.Object) error {
-						switch obj.(type) {
+						switch obj := obj.(type) {
 						case *ejv1.ExtendedJob:
-							eJob.DeepCopyInto(obj.(*ejv1.ExtendedJob))
+							eJob.DeepCopyInto(obj)
 							return nil
 						case *corev1.ConfigMap:
-							configMap.DeepCopyInto(obj.(*corev1.ConfigMap))
+							configMap.DeepCopyInto(obj)
 							return nil
 						}
 						return apierrors.NewNotFound(schema.GroupResource{}, nn.Name)

--- a/pkg/kube/controllers/extendedjob/job_creator.go
+++ b/pkg/kube/controllers/extendedjob/job_creator.go
@@ -70,7 +70,7 @@ func (j jobCreatorImpl) createJob(ctx context.Context, eJob ejv1.ExtendedJob, po
 		err = j.client.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: eJob.Namespace}, configMap)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				ctxlog.Debugf(ctx, "Skip create job due to configMap '%s' not found", configMapName)
+				ctxlog.Debugf(ctx, "Skip create job '%s' due to configMap '%s' not found", eJob.Name, configMapName)
 				// we want to requeue the job without error
 				retry = true
 				err = nil
@@ -89,7 +89,7 @@ func (j jobCreatorImpl) createJob(ctx context.Context, eJob ejv1.ExtendedJob, po
 		err = j.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: eJob.Namespace}, secret)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				ctxlog.Debugf(ctx, "Skip create job due to secret '%s' not found", secretName)
+				ctxlog.Debugf(ctx, "Skip create job '%s' due to secret '%s' not found", eJob.Name, secretName)
 				// we want to requeue the job without error
 				retry = true
 				err = nil

--- a/pkg/kube/controllers/extendedjob/job_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/job_reconciler.go
@@ -103,9 +103,7 @@ func (r *ReconcileJob) Reconcile(request reconcile.Request) (reconcile.Result, e
 			err = r.persistOutput(ctx, instance, ej)
 			if err != nil {
 				ctxlog.WithEvent(instance, "PersistOutputError").Errorf(ctx, "Could not persist output: '%s'", err)
-				return reconcile.Result{
-					Requeue: false,
-				}, err
+				return reconcile.Result{Requeue: false}, nil
 			}
 		} else if instance.Status.Failed == 1 && !ej.Spec.Output.WriteOnFailure {
 			ctxlog.WithEvent(&ej, "FailedPersistingOutput").Infof(ctx, "Will not persist output of job '%s' because it failed", instance.Name)

--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -6,6 +6,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	// CtxTimeOut is the default context.Context timeout
+	CtxTimeOut = 10 * time.Second
+)
+
 // Config controls the behaviour of different controllers
 type Config struct {
 	CtxTimeOut        time.Duration
@@ -13,4 +18,14 @@ type Config struct {
 	WebhookServerHost string
 	WebhookServerPort int32
 	Fs                afero.Fs
+}
+
+func NewConfig(namespace string, host string, port int32, fs afero.Fs) *Config {
+	return &Config{
+		CtxTimeOut:        CtxTimeOut,
+		Namespace:         namespace,
+		WebhookServerHost: host,
+		WebhookServerPort: port,
+		Fs:                fs,
+	}
 }


### PR DESCRIPTION
* Add constructor for config and constants for defaults
* Skipping eJobs due to missing inputs  requeued them within micro seconds
* Code requeued job reconcniler if `persistOutput` failed, comment said it won't
* BPM reconcile wanted to requeue after a delay, but did so immediately
* shortend some switch type assertions

[#166767434](https://www.pivotaltracker.com/story/show/166767434)