### PR TITLE
Add missing target into the main `test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-helm:
 
 ############ TEST TARGETS ############
 
-test: vet lint test-unit test-integration test-integration-storage test-helm-e2e test-helm-e2e-storage test-cli-e2e test-integration-subcmds
+test: vet lint staticcheck test-unit test-integration test-integration-storage test-helm-e2e test-helm-e2e-storage test-cli-e2e test-integration-subcmds
 
 test-unit:
 	bin/test-unit

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-helm:
 
 ############ TEST TARGETS ############
 
-test: vet lint test-unit test-integration test-integration-storage test-helm-e2e test-helm-e2e-storage test-cli-e2e
+test: vet lint test-unit test-integration test-integration-storage test-helm-e2e test-helm-e2e-storage test-cli-e2e test-integration-subcmds
 
 test-unit:
 	bin/test-unit


### PR DESCRIPTION
This verify that all subcmds functionalities are
passing integration tests.