### PR TITLE
Support ExtendedSecret certs signed by the Kube API Server

### DIFF
--- a/docs/controllers/extendedsecret.md
+++ b/docs/controllers/extendedsecret.md
@@ -6,6 +6,7 @@
   - [Features](#features)
     - [Generated](#generated)
     - [Policies](#policies)
+    - [Auto-approving Certificates](#auto-approving-certificates)
   - [`ExtendedSecret` Examples](#extendedsecret-examples)
 
 ## Description
@@ -31,6 +32,24 @@ A pluggable implementation for generating certificates and passwords.
 ### Policies
 
 The developer can specify policies for rotation (e.g. automatic or not) and how secrets are created (e.g. password complexity, certificate expiration date, etc.).
+
+### Auto-approving Certificates
+
+A certificate `ExtendedSecret` can be signed by the Kube API Server. The ExtendedSecret Controller is be responsible for generating certificate signing request and creating CertificateSigningRequest:
+
+```yaml
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: generate-certificate
+spec:
+  request: ((encoded-cert-signing-request))
+  usages:
+  - digital signature
+  - key encipherment
+```
+
+The CertificateSigningRequest controller watches for `CertificateSigningRequest` and approves ExtendedSecret-owned CSRs and persists the generated certificate.
 
 ## `ExtendedSecret` Examples
 

--- a/docs/controllers/extendedsecret.md
+++ b/docs/controllers/extendedsecret.md
@@ -15,9 +15,14 @@
 
 `ExtendedSecret` supports generating the following:
 
-- certificates
-- passwords
-- rsa keys
+| Secret Type                     | spec.type     | certificate.signerType | certificate.isCA    |
+| ------------------------------- | ------------- | ---------------------- | ------------------- |
+| `passwords`                     | `password`    | not set                | not set             |
+| `rsa keys`                      | `rsa`         | not set                | not set             |
+| `ssh keys`                      | `ssh`         | not set                | not set             |
+| `self-signed root certificates` | `certificate` | `local`                | `true`              |
+| `self-signed certificates`      | `certificate` | `local`                | `false`             |
+| `cluster-signed certificates`   | `certificate` | `cluster`              | `false`             |
 
 > **Note:**
 >
@@ -35,7 +40,7 @@ The developer can specify policies for rotation (e.g. automatic or not) and how 
 
 ### Auto-approving Certificates
 
-A certificate `ExtendedSecret` can be signed by the Kube API Server. The ExtendedSecret Controller is be responsible for generating certificate signing request and creating CertificateSigningRequest:
+A certificate `ExtendedSecret` can be signed by the Kube API Server. The ExtendedSecret Controller is be responsible for generating certificate signing request and approving the request:
 
 ```yaml
 apiVersion: certificates.k8s.io/v1beta1

--- a/docs/examples/extended-secret/certificate.yaml
+++ b/docs/examples/extended-secret/certificate.yaml
@@ -1,94 +1,4 @@
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cert-ca
-type: Opaque
-stringData:
-  certificate: |-
-    -----BEGIN CERTIFICATE-----
-    MIIE9jCCAt6gAwIBAgIUEtrf/IIROoFcpubnPMMaNc00cwIwDQYJKoZIhvcNAQEN
-    BQAwEzERMA8GA1UEAxMIcm91dGVyQ0EwHhcNMTkwODA3MDQxNjAwWhcNMjAwODA2
-    MDQxNjAwWjATMREwDwYDVQQDEwhyb3V0ZXJDQTCCAiIwDQYJKoZIhvcNAQEBBQAD
-    ggIPADCCAgoCggIBAMs548l/BVFJivKZzXyv4koxHNI7suvyod6TroTE/xYDs13w
-    wk0oI7jrQ2/bz94ospcAoFDEWDA3PLzaueHJ4DG942pwp5nrq0bWrskf3i6dYqfK
-    defZ5huB769YKG+w1da4jkesohwIHtBU/sOu+lSXUpbvCnEAUjKhKbKee/8vUQWI
-    s1s2mLqsxC3jiBFXaeoo6m/uPZYYwsWgTG3OMOjskpOIGsIp3HU+F8NeNoBcuTFu
-    k2+GVBqHAiif1Tcoc4YXZst0v16sQL+WWmbb3d/mT4raqeWu/ni1X5ZOrNGn9wzN
-    EvUTDX4RmWAvj0FscYOvcxOh+ZacjVSrfjCksZGem+R+1XWR6qQHZQ77OGtMPe+6
-    9LBtxPpIPRF9+79iQwDiqFm1abG0os8A3HM0465qTU3UkBy8UuBCEM2BTEr9518/
-    qnttnQHKRlK7YaSVU4pMJBeFJXG3uYp1GYZw4Zt5WMxy/AQpCrbNXl0IYnjLqFqY
-    bkbPyr+HwdiEbuXbmYRXHWvaCh4A3zG746+4fb4lc4ZfVvqWtEZ2NiTGFcnA2XWa
-    3x+6GYHdYkss0jv6TRTG48Pjz+E0XhRyinfsM1/zlhJJmCkUnnJ4LS0+CUTqxeNu
-    TJH6CBSITu36eV/E7shcbouyGZsUYbw6QskdtjkCHX+kvf5XSofcPr33r3dlAgMB
-    AAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
-    BBTYpwJh/DRIAuvenjUPumY5rh9WjTANBgkqhkiG9w0BAQ0FAAOCAgEADl7RHiIg
-    4eDXmMAtayY50oxpGg9LJ9I41pBXqyH4PpeWHLoBz0vL42rUP8wp0ytoTCeOwXYt
-    BXWSwPKoJk618KfAExyT5gLaGXI9DgyoPMOp/Je83bGTt34avtxEFfmPxCGeLblf
-    V1nhVrEN5HFfBo3ZT9Ha5cWnzCx0b1GVyPRNHK4+uoteQVFaBDzm3vR+vE6Yxz0d
-    lmisZqm0d0vPjIN7FPJ74w9To4u/dGRRY2rSXeFpvsfiamhFxO2XP/oGS15Npx8s
-    iQcW6Ej59pdSIt76XGxJsElETCIbZchEFoTkNqmUuG0mQeMkk9SmQ9CXsGcnke/k
-    Mr88m+wCj5MTmWYzHLC2iDFLsFrIttwZ3Zxis8nFe6WXHekjjNV34WKD/oO0TPXJ
-    OzvQaFJEj8vd6j3C3vdrYQB2XWEeXox0xtd3B2I67Aomuy3iGiaT6YuTQ0ZhsUqP
-    J0LQE92fzBt2OcrDADD73M+RtSd1MNJsPl8/YXQ8AHPJaSJYEGSKhRp61rxSrj1U
-    TDruqFpyGFmpfYMDks7AxjKoJWMtgy/jJbWW5eFtSpgoQGEgo8Jd6uN6e2A/A8nS
-    ZYkcJSPIHSmmCAq5aTVpzMMBxZ9VsnkGUIMVV8nm760Olz0SMj+FumrKttu2CnPa
-    HZ7jr6SMopUidvDZRCpvXrIjZhdPbGYsv3g=
-    -----END CERTIFICATE-----
-  is_ca: "true"
-  private_key: |-
-    -----BEGIN RSA PRIVATE KEY-----
-    MIIJKQIBAAKCAgEAyznjyX8FUUmK8pnNfK/iSjEc0juy6/Kh3pOuhMT/FgOzXfDC
-    TSgjuOtDb9vP3iiylwCgUMRYMDc8vNq54cngMb3janCnmeurRtauyR/eLp1ip8p1
-    59nmG4Hvr1gob7DV1riOR6yiHAge0FT+w676VJdSlu8KcQBSMqEpsp57/y9RBYiz
-    WzaYuqzELeOIEVdp6ijqb+49lhjCxaBMbc4w6OySk4gawincdT4Xw142gFy5MW6T
-    b4ZUGocCKJ/VNyhzhhdmy3S/XqxAv5ZaZtvd3+ZPitqp5a7+eLVflk6s0af3DM0S
-    9RMNfhGZYC+PQWxxg69zE6H5lpyNVKt+MKSxkZ6b5H7VdZHqpAdlDvs4a0w977r0
-    sG3E+kg9EX37v2JDAOKoWbVpsbSizwDcczTjrmpNTdSQHLxS4EIQzYFMSv3nXz+q
-    e22dAcpGUrthpJVTikwkF4Ulcbe5inUZhnDhm3lYzHL8BCkKts1eXQhieMuoWphu
-    Rs/Kv4fB2IRu5duZhFcda9oKHgDfMbvjr7h9viVzhl9W+pa0RnY2JMYVycDZdZrf
-    H7oZgd1iSyzSO/pNFMbjw+PP4TReFHKKd+wzX/OWEkmYKRSecngtLT4JROrF425M
-    kfoIFIhO7fp5X8TuyFxui7IZmxRhvDpCyR22OQIdf6S9/ldKh9w+vfevd2UCAwEA
-    AQKCAgEAlBKm9N6W+kZSdjc4MLxabeJg9JFI6X/ND0adZuG+VsT1gOH2QI+Zj5fj
-    d/I5/825aiqrpI2bD+5/U78upuQXdUa9F4XjqFO9ZQzxJ1wP3/kOs+DhjcAHWE2R
-    XTonpFG9TQkFqhWPvEryYKs9QUkR3mavZ4feHL22Jmuk3R96i1FngFe9Dx21pHZT
-    LnhVYQVHB7UuM8Xrm5yI9cO5TFxq6JvOpK4LiSNFHSvT1qajoV1uFiVSSXUffICY
-    Qw9KJDlWCwKsBFwZP5rURoP/dGiIviWqGSr/lXmusja84eCLLOtsJyiYwnZSY2Ph
-    U+LzRyEDiIZim5BuMZ35oBKgDENDmOCbBfGoMC0RyYZP/LVX4s6Aq3iOpm73iUZg
-    rJni+HikPRxw3zm41r15Ja9QQCGC975dhWXpiBE5a+RQ/hou9kZiKXy1qdYexd3K
-    OnsiyPABImaI2ec+mRAEpxsIDm2Hs9Lrf8BfgNLsGkSsqan8ztk+Ok8Y1M9KPYw9
-    2h8+VD3/GVcM/LUPSxq5u/fLuKkGFwQ0Nr9GfFahXOKHhEkR1IK/pB2aCnOm0CIP
-    O8wngwr6hEhJqqgsyNj9aBtjXKQBEmBbuOvz5bH63w5/kJFy5/Bpc+JXhqOlDk1E
-    CDGEIgI0JWlpqNeXqscFCR8rRKGZXuGs5d+1F5Zy771nbOU7yHUCggEBAPArLpds
-    pb3QaZeD4fEcXk1RzB+Ni8EhWDMHGR7PwDixkOGGY7q+SgUkPhfsmE380F4AVb/H
-    fufd5zgo11G1P4K45lswNAzM4Upp6KSSH6TYKy0BddDn/fJcopz3BqQ988tCmEPt
-    4sNCQM8dHTENkTXAMuEKzS2Q1DvCSyDda9+AotF77NMPsd9FyvzdTOILM6DcbYhJ
-    GNVjHk22J0odFOeVjUtLeqFOwSKKP5CS+Csqw2OL7MxzHU8K/qQcCsI7JXVFkL5D
-    MG/lVnUgf/vqhJQJUYJgjVNp9Xl/6xMPFDNZlwpAO8w+l66gr0r1pIzbOsNl6eZk
-    SjSAsa3k88SRJHcCggEBANifToK4l4ee3XrICvOZrXrEhTdXg/yiC4E+VszJwdf7
-    2MoqOWMT1m8y5IUUorEPL+qSgR7UsJ89VZAPAo74REk3+801oF50yKoxLDK2xZiN
-    rB7CNujYpR3yVg4VRVPc20RY3xZJDGKOWFeGDs9ba1c9cq9THQkNf1/b8Q61rB7U
-    iQe3nhmmrNGXIp6Jv20PNEhIDtViurmzT7EdqDTuLI34+FmfaC9nZVruW/SqtN4e
-    7aPAj0pRUwzfUkwZc77W5W5i0BY2nOz3gfD9Zwx1OBmGvLcfifMNmerfAE0F8qWd
-    1j4u9vzAD5Gm86PJm7UPKkwZh7RwFbjOd7iinTB4xgMCggEAC67OEWejmFwvBsPP
-    ld7/Z1t3RoGoLrjkhXbu7eTFQPzCQ3Y6G7dt+loM+zTzI7gMmsYBZdbagYT13nF+
-    J+ddM4qzCfSKU6UTwH7uZjMFfwtU7leH16WxYLzI3EHX/N1WoqiWp5dG1KDAblLI
-    PL6gNbEnyHKyEGlfKZkF9o9O1Ax53x7cIlg9GtNWUH6jYsuQs16FpX+IybiMnNMj
-    jiNkBO/tc6A0Uux10KxQ80Ny9waZgpon5roiztmGEY2bqF8gL1g29kpmbMsHLaNr
-    FmIOGPVrFaCEv24EFuj2EnNFVEojYshFIGZbEo+Wd1sDqiZv8Vlfy2lNgshP3Fmq
-    0gENeQKCAQBIuWLwO+yTWWBdwh77HVLCbouSwszK2dQm9bjKU8nCKwjjBj3x500M
-    U/eoPf9IliKuC7VRlnIdY8f/7yoauXqjYiolAKXwUCC2EoAWHopD5vwr72Pj1CfK
-    3/rIC5gUyYbLcVKj9q4zwDokWBtMvhJRXY3NEogi6+chVYOePpukVhITBzAKyIwo
-    aSb0NqaPhJU21woz1Ut+4JYWjjBUZMmMeFNYM04U7A948aDpiQ3jrFp3qUPx3U+W
-    eLr2VW0oWpj38DCP5JHWdFmpgElCQ3AsEbH1gJ8dfCl6UpeVRDPsKgstITNGM2yG
-    p5gQGrUtmgPHPKL0jtScEKTc1asUBNflAoIBAQDiNv35TrXj2T7iUWZ193k+uIt4
-    kmfDodHmdk5gL8i7203XGc3UWusVoBwUn6RYO02tUmdYUYrf5qXM6a1IKbLxZvp1
-    Z9vBFldumr97yoEm6cacqWe3Wz8nHO0e0zqaOkdpm64cdjQ7sy1stedjEjBFEs+c
-    8wuIeKREgYbamLrGO694clxV2E5jZxFiyDmZaWPoVWFGvdEq2okRnLmVcAUcKAnn
-    6pxd+7ZT1Ibxt70Fum1G9qRJzlzbxVQHx7LzEUOD3T1TWhGFLNDVhS0A75ohF7OA
-    wvHxHWtIIkR7z2AEPlbmx2VboheAh5eqjOjtxeUettJAMiINCMkBIWVN+FaU
-    -----END RSA PRIVATE KEY-----
----
 apiVersion: fissile.cloudfoundry.org/v1alpha1
 kind: ExtendedSecret
 metadata:
@@ -96,17 +6,11 @@ metadata:
 spec:
   request:
     certificate:
-      CAKeyRef:
-        Key: private_key
-        Name: cert-ca
-      CARef:
-        Key: certificate
-        Name: cert-ca
       alternativeNames:
         - foo.com
         - '*.foo.com'
       commonName: routerSSL
       isCA: false
-      signerType: external
+      signerType: cluster
   secretName: gen-certificate
   type: certificate

--- a/docs/examples/extended-secret/certificate.yaml
+++ b/docs/examples/extended-secret/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nats-deployment.var-nats-ca
+  name: cert-ca
 type: Opaque
 stringData:
   certificate: |-
@@ -98,15 +98,15 @@ spec:
     certificate:
       CAKeyRef:
         Key: private_key
-        Name: nats-deployment.var-nats-ca
+        Name: cert-ca
       CARef:
         Key: certificate
-        Name: nats-deployment.var-nats-ca
+        Name: cert-ca
       alternativeNames:
         - foo.com
         - '*.foo.com'
       commonName: routerSSL
       isCA: false
       signerType: external
-  secretName: nats-deployment.var-nats-cert
+  secretName: gen-certificate
   type: certificate

--- a/docs/examples/extended-secret/certificate.yaml
+++ b/docs/examples/extended-secret/certificate.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nats-deployment.var-nats-ca
+type: Opaque
+stringData:
+  certificate: |-
+    -----BEGIN CERTIFICATE-----
+    MIIE9jCCAt6gAwIBAgIUEtrf/IIROoFcpubnPMMaNc00cwIwDQYJKoZIhvcNAQEN
+    BQAwEzERMA8GA1UEAxMIcm91dGVyQ0EwHhcNMTkwODA3MDQxNjAwWhcNMjAwODA2
+    MDQxNjAwWjATMREwDwYDVQQDEwhyb3V0ZXJDQTCCAiIwDQYJKoZIhvcNAQEBBQAD
+    ggIPADCCAgoCggIBAMs548l/BVFJivKZzXyv4koxHNI7suvyod6TroTE/xYDs13w
+    wk0oI7jrQ2/bz94ospcAoFDEWDA3PLzaueHJ4DG942pwp5nrq0bWrskf3i6dYqfK
+    defZ5huB769YKG+w1da4jkesohwIHtBU/sOu+lSXUpbvCnEAUjKhKbKee/8vUQWI
+    s1s2mLqsxC3jiBFXaeoo6m/uPZYYwsWgTG3OMOjskpOIGsIp3HU+F8NeNoBcuTFu
+    k2+GVBqHAiif1Tcoc4YXZst0v16sQL+WWmbb3d/mT4raqeWu/ni1X5ZOrNGn9wzN
+    EvUTDX4RmWAvj0FscYOvcxOh+ZacjVSrfjCksZGem+R+1XWR6qQHZQ77OGtMPe+6
+    9LBtxPpIPRF9+79iQwDiqFm1abG0os8A3HM0465qTU3UkBy8UuBCEM2BTEr9518/
+    qnttnQHKRlK7YaSVU4pMJBeFJXG3uYp1GYZw4Zt5WMxy/AQpCrbNXl0IYnjLqFqY
+    bkbPyr+HwdiEbuXbmYRXHWvaCh4A3zG746+4fb4lc4ZfVvqWtEZ2NiTGFcnA2XWa
+    3x+6GYHdYkss0jv6TRTG48Pjz+E0XhRyinfsM1/zlhJJmCkUnnJ4LS0+CUTqxeNu
+    TJH6CBSITu36eV/E7shcbouyGZsUYbw6QskdtjkCHX+kvf5XSofcPr33r3dlAgMB
+    AAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
+    BBTYpwJh/DRIAuvenjUPumY5rh9WjTANBgkqhkiG9w0BAQ0FAAOCAgEADl7RHiIg
+    4eDXmMAtayY50oxpGg9LJ9I41pBXqyH4PpeWHLoBz0vL42rUP8wp0ytoTCeOwXYt
+    BXWSwPKoJk618KfAExyT5gLaGXI9DgyoPMOp/Je83bGTt34avtxEFfmPxCGeLblf
+    V1nhVrEN5HFfBo3ZT9Ha5cWnzCx0b1GVyPRNHK4+uoteQVFaBDzm3vR+vE6Yxz0d
+    lmisZqm0d0vPjIN7FPJ74w9To4u/dGRRY2rSXeFpvsfiamhFxO2XP/oGS15Npx8s
+    iQcW6Ej59pdSIt76XGxJsElETCIbZchEFoTkNqmUuG0mQeMkk9SmQ9CXsGcnke/k
+    Mr88m+wCj5MTmWYzHLC2iDFLsFrIttwZ3Zxis8nFe6WXHekjjNV34WKD/oO0TPXJ
+    OzvQaFJEj8vd6j3C3vdrYQB2XWEeXox0xtd3B2I67Aomuy3iGiaT6YuTQ0ZhsUqP
+    J0LQE92fzBt2OcrDADD73M+RtSd1MNJsPl8/YXQ8AHPJaSJYEGSKhRp61rxSrj1U
+    TDruqFpyGFmpfYMDks7AxjKoJWMtgy/jJbWW5eFtSpgoQGEgo8Jd6uN6e2A/A8nS
+    ZYkcJSPIHSmmCAq5aTVpzMMBxZ9VsnkGUIMVV8nm760Olz0SMj+FumrKttu2CnPa
+    HZ7jr6SMopUidvDZRCpvXrIjZhdPbGYsv3g=
+    -----END CERTIFICATE-----
+  is_ca: "true"
+  private_key: |-
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIJKQIBAAKCAgEAyznjyX8FUUmK8pnNfK/iSjEc0juy6/Kh3pOuhMT/FgOzXfDC
+    TSgjuOtDb9vP3iiylwCgUMRYMDc8vNq54cngMb3janCnmeurRtauyR/eLp1ip8p1
+    59nmG4Hvr1gob7DV1riOR6yiHAge0FT+w676VJdSlu8KcQBSMqEpsp57/y9RBYiz
+    WzaYuqzELeOIEVdp6ijqb+49lhjCxaBMbc4w6OySk4gawincdT4Xw142gFy5MW6T
+    b4ZUGocCKJ/VNyhzhhdmy3S/XqxAv5ZaZtvd3+ZPitqp5a7+eLVflk6s0af3DM0S
+    9RMNfhGZYC+PQWxxg69zE6H5lpyNVKt+MKSxkZ6b5H7VdZHqpAdlDvs4a0w977r0
+    sG3E+kg9EX37v2JDAOKoWbVpsbSizwDcczTjrmpNTdSQHLxS4EIQzYFMSv3nXz+q
+    e22dAcpGUrthpJVTikwkF4Ulcbe5inUZhnDhm3lYzHL8BCkKts1eXQhieMuoWphu
+    Rs/Kv4fB2IRu5duZhFcda9oKHgDfMbvjr7h9viVzhl9W+pa0RnY2JMYVycDZdZrf
+    H7oZgd1iSyzSO/pNFMbjw+PP4TReFHKKd+wzX/OWEkmYKRSecngtLT4JROrF425M
+    kfoIFIhO7fp5X8TuyFxui7IZmxRhvDpCyR22OQIdf6S9/ldKh9w+vfevd2UCAwEA
+    AQKCAgEAlBKm9N6W+kZSdjc4MLxabeJg9JFI6X/ND0adZuG+VsT1gOH2QI+Zj5fj
+    d/I5/825aiqrpI2bD+5/U78upuQXdUa9F4XjqFO9ZQzxJ1wP3/kOs+DhjcAHWE2R
+    XTonpFG9TQkFqhWPvEryYKs9QUkR3mavZ4feHL22Jmuk3R96i1FngFe9Dx21pHZT
+    LnhVYQVHB7UuM8Xrm5yI9cO5TFxq6JvOpK4LiSNFHSvT1qajoV1uFiVSSXUffICY
+    Qw9KJDlWCwKsBFwZP5rURoP/dGiIviWqGSr/lXmusja84eCLLOtsJyiYwnZSY2Ph
+    U+LzRyEDiIZim5BuMZ35oBKgDENDmOCbBfGoMC0RyYZP/LVX4s6Aq3iOpm73iUZg
+    rJni+HikPRxw3zm41r15Ja9QQCGC975dhWXpiBE5a+RQ/hou9kZiKXy1qdYexd3K
+    OnsiyPABImaI2ec+mRAEpxsIDm2Hs9Lrf8BfgNLsGkSsqan8ztk+Ok8Y1M9KPYw9
+    2h8+VD3/GVcM/LUPSxq5u/fLuKkGFwQ0Nr9GfFahXOKHhEkR1IK/pB2aCnOm0CIP
+    O8wngwr6hEhJqqgsyNj9aBtjXKQBEmBbuOvz5bH63w5/kJFy5/Bpc+JXhqOlDk1E
+    CDGEIgI0JWlpqNeXqscFCR8rRKGZXuGs5d+1F5Zy771nbOU7yHUCggEBAPArLpds
+    pb3QaZeD4fEcXk1RzB+Ni8EhWDMHGR7PwDixkOGGY7q+SgUkPhfsmE380F4AVb/H
+    fufd5zgo11G1P4K45lswNAzM4Upp6KSSH6TYKy0BddDn/fJcopz3BqQ988tCmEPt
+    4sNCQM8dHTENkTXAMuEKzS2Q1DvCSyDda9+AotF77NMPsd9FyvzdTOILM6DcbYhJ
+    GNVjHk22J0odFOeVjUtLeqFOwSKKP5CS+Csqw2OL7MxzHU8K/qQcCsI7JXVFkL5D
+    MG/lVnUgf/vqhJQJUYJgjVNp9Xl/6xMPFDNZlwpAO8w+l66gr0r1pIzbOsNl6eZk
+    SjSAsa3k88SRJHcCggEBANifToK4l4ee3XrICvOZrXrEhTdXg/yiC4E+VszJwdf7
+    2MoqOWMT1m8y5IUUorEPL+qSgR7UsJ89VZAPAo74REk3+801oF50yKoxLDK2xZiN
+    rB7CNujYpR3yVg4VRVPc20RY3xZJDGKOWFeGDs9ba1c9cq9THQkNf1/b8Q61rB7U
+    iQe3nhmmrNGXIp6Jv20PNEhIDtViurmzT7EdqDTuLI34+FmfaC9nZVruW/SqtN4e
+    7aPAj0pRUwzfUkwZc77W5W5i0BY2nOz3gfD9Zwx1OBmGvLcfifMNmerfAE0F8qWd
+    1j4u9vzAD5Gm86PJm7UPKkwZh7RwFbjOd7iinTB4xgMCggEAC67OEWejmFwvBsPP
+    ld7/Z1t3RoGoLrjkhXbu7eTFQPzCQ3Y6G7dt+loM+zTzI7gMmsYBZdbagYT13nF+
+    J+ddM4qzCfSKU6UTwH7uZjMFfwtU7leH16WxYLzI3EHX/N1WoqiWp5dG1KDAblLI
+    PL6gNbEnyHKyEGlfKZkF9o9O1Ax53x7cIlg9GtNWUH6jYsuQs16FpX+IybiMnNMj
+    jiNkBO/tc6A0Uux10KxQ80Ny9waZgpon5roiztmGEY2bqF8gL1g29kpmbMsHLaNr
+    FmIOGPVrFaCEv24EFuj2EnNFVEojYshFIGZbEo+Wd1sDqiZv8Vlfy2lNgshP3Fmq
+    0gENeQKCAQBIuWLwO+yTWWBdwh77HVLCbouSwszK2dQm9bjKU8nCKwjjBj3x500M
+    U/eoPf9IliKuC7VRlnIdY8f/7yoauXqjYiolAKXwUCC2EoAWHopD5vwr72Pj1CfK
+    3/rIC5gUyYbLcVKj9q4zwDokWBtMvhJRXY3NEogi6+chVYOePpukVhITBzAKyIwo
+    aSb0NqaPhJU21woz1Ut+4JYWjjBUZMmMeFNYM04U7A948aDpiQ3jrFp3qUPx3U+W
+    eLr2VW0oWpj38DCP5JHWdFmpgElCQ3AsEbH1gJ8dfCl6UpeVRDPsKgstITNGM2yG
+    p5gQGrUtmgPHPKL0jtScEKTc1asUBNflAoIBAQDiNv35TrXj2T7iUWZ193k+uIt4
+    kmfDodHmdk5gL8i7203XGc3UWusVoBwUn6RYO02tUmdYUYrf5qXM6a1IKbLxZvp1
+    Z9vBFldumr97yoEm6cacqWe3Wz8nHO0e0zqaOkdpm64cdjQ7sy1stedjEjBFEs+c
+    8wuIeKREgYbamLrGO694clxV2E5jZxFiyDmZaWPoVWFGvdEq2okRnLmVcAUcKAnn
+    6pxd+7ZT1Ibxt70Fum1G9qRJzlzbxVQHx7LzEUOD3T1TWhGFLNDVhS0A75ohF7OA
+    wvHxHWtIIkR7z2AEPlbmx2VboheAh5eqjOjtxeUettJAMiINCMkBIWVN+FaU
+    -----END RSA PRIVATE KEY-----
+---
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: ExtendedSecret
+metadata:
+  name: generate-certificate
+spec:
+  request:
+    certificate:
+      CAKeyRef:
+        Key: private_key
+        Name: nats-deployment.var-nats-ca
+      CARef:
+        Key: certificate
+        Name: nats-deployment.var-nats-ca
+      alternativeNames:
+        - foo.com
+        - '*.foo.com'
+      commonName: routerSSL
+      isCA: false
+      signerType: external
+  secretName: nats-deployment.var-nats-cert
+  type: certificate

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -170,17 +170,17 @@ var _ = Describe("Examples", func() {
 					By("Creating bosh deployment")
 					kubectlHelper := testing.NewKubectl()
 					err := testing.Create(namespace, yamlFilePath)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error creating instance")
 
 					By("Checking for pods")
 					err = kubectlHelper.Wait(namespace, "ready", "pod/nats-deployment-nats-v1-0", kubectlHelper.PollTimeout)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error waiting for pod/nats-deployment-nats-v1-0")
 
 					err = kubectlHelper.Wait(namespace, "ready", "pod/nats-deployment-nats-v1-1", kubectlHelper.PollTimeout)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error waiting for pod/nats-deployment-nats-v1-1")
 
 					err = testing.RestartOperator(namespace)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error restarting cf-operator")
 
 					By("Checking for pods not created")
 					err = kubectlHelper.Wait(namespace, "ready", "pod/nats-deployment-nats-v2-0", 10*time.Second)
@@ -188,15 +188,15 @@ var _ = Describe("Examples", func() {
 
 					By("Checking for secrets not created")
 					exist, err := kubectlHelper.SecretExists(namespace, "nats-deployment.bpm.nats-v2")
-					Expect(err).To(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error getting secret/nats-deployment.bpm.nats-v2")
 					Expect(exist).To(BeFalse(), "error unexpected bpm info secret is created")
 
 					exist, err = kubectlHelper.SecretExists(namespace, "nats-deployment.desired-manifest-v2")
-					Expect(err).To(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error getting secret/nats-deployment.desired-manifest-v2")
 					Expect(exist).To(BeFalse(), "error unexpected desire manifest is created")
 
 					exist, err = kubectlHelper.SecretExists(namespace, "nats-deployment.ig-resolved.nats-v2")
-					Expect(err).To(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred(), "error getting secret/nats-deployment.ig-resolved.nats-v2")
 					Expect(exist).To(BeFalse(), "error unexpected properties secret is created")
 				})
 			})
@@ -404,9 +404,9 @@ var _ = Describe("Examples", func() {
 
 				By("Checking the generated certificate")
 				err = kubectlHelper.WaitForSecret(namespace, "gen-certificate")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "error waiting for secret")
 				err = testing.SecretCheckData(namespace, "gen-certificate", ".data.certificate")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "error getting for secret")
 			})
 
 			It("Test cases must be written for all example use cases in docs", func() {

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Examples", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 				// If this testcase fails that means a test case is missing for an example in the docs folder
-				Expect(countFile).To(Equal(26))
+				Expect(countFile).To(Equal(27))
 			})
 		})
 	})

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -395,6 +395,20 @@ var _ = Describe("Examples", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
+			It("API server signed certificate example must work", func() {
+				yamlFilePath := examplesDir + "extended-secret/certificate.yaml"
+
+				By("Creating an ExtendedSecret")
+				err := testing.Create(namespace, yamlFilePath)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking the generated certificate")
+				err = kubectlHelper.WaitForSecret(namespace, "gen-certificate")
+				Expect(err).ToNot(HaveOccurred())
+				err = testing.SecretCheckData(namespace, "gen-certificate", ".data.certificate")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			It("Test cases must be written for all example use cases in docs", func() {
 				countFile := 0
 				err := filepath.Walk(examplesDir, func(path string, info os.FileInfo, err error) error {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module code.cloudfoundry.org/cf-operator
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7
@@ -12,38 +11,38 @@ require (
 	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
-	github.com/directxman12/zapr v0.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/go-test/deep v1.0.1
+	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20180924190550-6f2cf27854a4 // indirect
 	github.com/gonvenience/bunt v1.1.1
-	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
+	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hpcloud/tail v1.0.0
 	github.com/imdario/mergo v0.3.6
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0 // indirect
+	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/nkovacs/streamquote v1.0.0 // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.2.1
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/viovanov/bosh-template-go v0.0.0-20190801125410-a195ef3de03a
 	go.uber.org/zap v1.9.1
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
@@ -54,7 +53,7 @@ require (
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/kube-openapi v0.0.0-20190510232812-a01b7d5d6c22 // indirect
 	sigs.k8s.io/controller-runtime v0.2.0-beta.4
-	sigs.k8s.io/kind v0.4.0 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/bosh/converter/kube_converter.go
+++ b/pkg/bosh/converter/kube_converter.go
@@ -36,11 +36,11 @@ func (kc *KubeConverter) Variables(manifestName string, variables []bdm.Variable
 				},
 			},
 			Spec: esv1.ExtendedSecretSpec{
-				Type:       esv1.Type(v.Type),
+				Type:       v.Type,
 				SecretName: secretName,
 			},
 		}
-		if esv1.Type(v.Type) == esv1.Certificate {
+		if v.Type == esv1.Certificate {
 			certRequest := esv1.CertificateRequest{
 				CommonName:       v.Options.CommonName,
 				AlternativeNames: v.Options.AlternativeNames,

--- a/pkg/credsgen/fakes/generator.go
+++ b/pkg/credsgen/fakes/generator.go
@@ -22,6 +22,21 @@ type FakeGenerator struct {
 		result1 credsgen.Certificate
 		result2 error
 	}
+	GenerateCertificateSigningRequestStub        func(credsgen.CertificateGenerationRequest) ([]byte, []byte, error)
+	generateCertificateSigningRequestMutex       sync.RWMutex
+	generateCertificateSigningRequestArgsForCall []struct {
+		arg1 credsgen.CertificateGenerationRequest
+	}
+	generateCertificateSigningRequestReturns struct {
+		result1 []byte
+		result2 []byte
+		result3 error
+	}
+	generateCertificateSigningRequestReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 []byte
+		result3 error
+	}
 	GeneratePasswordStub        func(string, credsgen.PasswordGenerationRequest) string
 	generatePasswordMutex       sync.RWMutex
 	generatePasswordArgsForCall []struct {
@@ -126,6 +141,72 @@ func (fake *FakeGenerator) GenerateCertificateReturnsOnCall(i int, result1 creds
 		result1 credsgen.Certificate
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequest(arg1 credsgen.CertificateGenerationRequest) ([]byte, []byte, error) {
+	fake.generateCertificateSigningRequestMutex.Lock()
+	ret, specificReturn := fake.generateCertificateSigningRequestReturnsOnCall[len(fake.generateCertificateSigningRequestArgsForCall)]
+	fake.generateCertificateSigningRequestArgsForCall = append(fake.generateCertificateSigningRequestArgsForCall, struct {
+		arg1 credsgen.CertificateGenerationRequest
+	}{arg1})
+	fake.recordInvocation("GenerateCertificateSigningRequest", []interface{}{arg1})
+	fake.generateCertificateSigningRequestMutex.Unlock()
+	if fake.GenerateCertificateSigningRequestStub != nil {
+		return fake.GenerateCertificateSigningRequestStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.generateCertificateSigningRequestReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequestCallCount() int {
+	fake.generateCertificateSigningRequestMutex.RLock()
+	defer fake.generateCertificateSigningRequestMutex.RUnlock()
+	return len(fake.generateCertificateSigningRequestArgsForCall)
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequestCalls(stub func(credsgen.CertificateGenerationRequest) ([]byte, []byte, error)) {
+	fake.generateCertificateSigningRequestMutex.Lock()
+	defer fake.generateCertificateSigningRequestMutex.Unlock()
+	fake.GenerateCertificateSigningRequestStub = stub
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequestArgsForCall(i int) credsgen.CertificateGenerationRequest {
+	fake.generateCertificateSigningRequestMutex.RLock()
+	defer fake.generateCertificateSigningRequestMutex.RUnlock()
+	argsForCall := fake.generateCertificateSigningRequestArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequestReturns(result1 []byte, result2 []byte, result3 error) {
+	fake.generateCertificateSigningRequestMutex.Lock()
+	defer fake.generateCertificateSigningRequestMutex.Unlock()
+	fake.GenerateCertificateSigningRequestStub = nil
+	fake.generateCertificateSigningRequestReturns = struct {
+		result1 []byte
+		result2 []byte
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeGenerator) GenerateCertificateSigningRequestReturnsOnCall(i int, result1 []byte, result2 []byte, result3 error) {
+	fake.generateCertificateSigningRequestMutex.Lock()
+	defer fake.generateCertificateSigningRequestMutex.Unlock()
+	fake.GenerateCertificateSigningRequestStub = nil
+	if fake.generateCertificateSigningRequestReturnsOnCall == nil {
+		fake.generateCertificateSigningRequestReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 []byte
+			result3 error
+		})
+	}
+	fake.generateCertificateSigningRequestReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 []byte
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeGenerator) GeneratePassword(arg1 string, arg2 credsgen.PasswordGenerationRequest) string {
@@ -320,6 +401,8 @@ func (fake *FakeGenerator) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.generateCertificateMutex.RLock()
 	defer fake.generateCertificateMutex.RUnlock()
+	fake.generateCertificateSigningRequestMutex.RLock()
+	defer fake.generateCertificateSigningRequestMutex.RUnlock()
 	fake.generatePasswordMutex.RLock()
 	defer fake.generatePasswordMutex.RUnlock()
 	fake.generateRSAKeyMutex.RLock()

--- a/pkg/credsgen/generator.go
+++ b/pkg/credsgen/generator.go
@@ -43,6 +43,7 @@ type RSAKey struct {
 type Generator interface {
 	GeneratePassword(name string, request PasswordGenerationRequest) string
 	GenerateCertificate(name string, request CertificateGenerationRequest) (Certificate, error)
+	GenerateCertificateSigningRequest(request CertificateGenerationRequest) ([]byte, []byte, error)
 	GenerateSSHKey(name string) (SSHKey, error)
 	GenerateRSAKey(name string) (RSAKey, error)
 }

--- a/pkg/credsgen/in_memory_generator/certificate.go
+++ b/pkg/credsgen/in_memory_generator/certificate.go
@@ -70,12 +70,6 @@ func (g InMemoryGenerator) generateCertificate(request credsgen.CertificateGener
 	}
 
 	// Generate certificate
-	certReq := &csr.CertificateRequest{KeyRequest: &csr.BasicKeyRequest{A: g.Algorithm, S: g.Bits}}
-
-	certReq.Hosts = append(certReq.Hosts, request.CommonName)
-	certReq.Hosts = append(certReq.Hosts, request.AlternativeNames...)
-	certReq.CN = certReq.Hosts[0]
-
 	signingReq, privateKey, err := g.GenerateCertificateSigningRequest(request)
 	if err != nil {
 		return credsgen.Certificate{}, err

--- a/pkg/credsgen/in_memory_generator/certificate.go
+++ b/pkg/credsgen/in_memory_generator/certificate.go
@@ -38,8 +38,10 @@ func (g InMemoryGenerator) GenerateCertificate(name string, request credsgen.Cer
 	return certificate, nil
 }
 
-// GenerateCertificateSigningRequest Generates certificate signing request and private key
+// GenerateCertificateSigningRequest Generates a certificate signing request and private key
 func (g InMemoryGenerator) GenerateCertificateSigningRequest(request credsgen.CertificateGenerationRequest) ([]byte, []byte, error) {
+	cfssllog.Level = cfssllog.LevelWarning
+
 	var csReq, privateKey []byte
 
 	// Generate certificate request

--- a/pkg/credsgen/in_memory_generator/certificate.go
+++ b/pkg/credsgen/in_memory_generator/certificate.go
@@ -85,7 +85,7 @@ func (g InMemoryGenerator) generateCertificate(request credsgen.CertificateGener
 		return credsgen.Certificate{}, errors.Wrap(err, "Parsing CA private key failed.")
 	}
 
-	//Sign certificate
+	// Sign certificate
 	signingProfile := &config.SigningProfile{
 		Usage:        []string{"server auth", "client auth"},
 		Expiry:       time.Duration(g.Expiry*24) * time.Hour,

--- a/pkg/kube/apis/extendedsecret/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedsecret/v1alpha1/types.go
@@ -36,6 +36,10 @@ const (
 var (
 	// LabelKind is the label key for secret kind
 	LabelKind = fmt.Sprintf("%s/secret-kind", apis.GroupName)
+	// AnnotationCertSecretName is the annotation key for certificate secret name
+	AnnotationCertSecretName = fmt.Sprintf("%s/cert-secret-name", apis.GroupName)
+	// AnnotationExSecretNamespace is the annotation key for ex-secret-namespace
+	AnnotationExSecretNamespace = fmt.Sprintf("%s/ex-secret-namespace", apis.GroupName)
 )
 
 const (

--- a/pkg/kube/apis/extendedsecret/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedsecret/v1alpha1/types.go
@@ -29,8 +29,10 @@ type SignerType = string
 
 // Valid values for signer types
 const (
-	LocalSigner    SignerType = "local"
-	ExternalSigner SignerType = "external"
+	// LocalSigner defines the local as certificate signer
+	LocalSigner SignerType = "local"
+	// ClusterSigner defines the cluster as certificate signer
+	ClusterSigner SignerType = "cluster"
 )
 
 var (

--- a/pkg/kube/apis/extendedsecret/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedsecret/v1alpha1/types.go
@@ -38,8 +38,8 @@ var (
 	LabelKind = fmt.Sprintf("%s/secret-kind", apis.GroupName)
 	// AnnotationCertSecretName is the annotation key for certificate secret name
 	AnnotationCertSecretName = fmt.Sprintf("%s/cert-secret-name", apis.GroupName)
-	// AnnotationExSecretNamespace is the annotation key for ex-secret-namespace
-	AnnotationExSecretNamespace = fmt.Sprintf("%s/ex-secret-namespace", apis.GroupName)
+	// AnnotationESecNamespace is the annotation key for ex-secret-namespace
+	AnnotationESecNamespace = fmt.Sprintf("%s/ex-secret-namespace", apis.GroupName)
 )
 
 const (

--- a/pkg/kube/apis/extendedsecret/v1alpha1/types.go
+++ b/pkg/kube/apis/extendedsecret/v1alpha1/types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	certv1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
@@ -12,15 +13,24 @@ import (
 // It's used as input for the Kube code generator
 // Run "make generate" after modifying this file
 
-// Type defines the type of the generated secret
-type Type string
+// SecretType defines the type of the generated secret
+type SecretType = string
 
-// Valid values for ref types
+// Valid values for secret types
 const (
-	Password    Type = "password"
-	Certificate Type = "certificate"
-	SSHKey      Type = "ssh"
-	RSAKey      Type = "rsa"
+	Password    SecretType = "password"
+	Certificate SecretType = "certificate"
+	SSHKey      SecretType = "ssh"
+	RSAKey      SecretType = "rsa"
+)
+
+// SignerType defines the type of the certificate signer
+type SignerType = string
+
+// Valid values for signer types
+const (
+	LocalSigner    SignerType = "local"
+	ExternalSigner SignerType = "external"
 )
 
 var (
@@ -41,11 +51,13 @@ type SecretReference struct {
 
 // CertificateRequest specifies the details for the certificate generation
 type CertificateRequest struct {
-	CommonName       string          `json:"commonName"`
-	AlternativeNames []string        `json:"alternativeNames"`
-	IsCA             bool            `json:"isCA"`
-	CARef            SecretReference `json:"CARef"`
-	CAKeyRef         SecretReference `json:"CAKeyRef"`
+	CommonName       string            `json:"commonName"`
+	AlternativeNames []string          `json:"alternativeNames"`
+	IsCA             bool              `json:"isCA"`
+	CARef            SecretReference   `json:"CARef"`
+	CAKeyRef         SecretReference   `json:"CAKeyRef"`
+	SignerType       SignerType        `json:"signerType,omitempty"`
+	Usages           []certv1.KeyUsage `json:"usages,omitempty"`
 }
 
 // Request specifies details for the secret generation
@@ -55,9 +67,9 @@ type Request struct {
 
 // ExtendedSecretSpec defines the desired state of ExtendedSecret
 type ExtendedSecretSpec struct {
-	Type       Type    `json:"type"`
-	Request    Request `json:"request"`
-	SecretName string  `json:"secretName"`
+	Type       SecretType `json:"type"`
+	Request    Request    `json:"request"`
+	SecretName string     `json:"secretName"`
 }
 
 // ExtendedSecretStatus defines the observed state of ExtendedSecret

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -44,7 +44,8 @@ var addToManagerFuncs = []func(context.Context, *config.Config, manager.Manager)
 	extendedjob.AddTrigger,
 	extendedjob.AddErrand,
 	extendedjob.AddJob,
-	extendedsecret.Add,
+	extendedsecret.AddExtendedSecret,
+	extendedsecret.AddCertificateSigningRequest,
 	extendedstatefulset.AddExtendedStatefulSet,
 	extendedstatefulset.AddStatefulSetCleanup,
 }

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_controller.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_controller.go
@@ -1,0 +1,71 @@
+package extendedsecret
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	certv1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	certv1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
+)
+
+// AddCertificateSigningRequest creates a new CertificateSigningRequest Controller and adds it to the Manager
+func AddCertificateSigningRequest(ctx context.Context, config *config.Config, mgr manager.Manager) error {
+	ctx = ctxlog.NewContextWithRecorder(ctx, "csr-reconciler", mgr.GetEventRecorderFor("csr-recorder"))
+	certClient, err := certv1client.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return errors.Wrap(err, "Could not get kube client")
+	}
+	r := NewCertificateSigningRequestReconciler(ctx, config, mgr, certClient, controllerutil.SetControllerReference)
+
+	// Create a new controller
+	c, err := controller.New("certificatesigningrequest-controller", mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: config.MaxExtendedSecretWorkers,
+	})
+	if err != nil {
+		return errors.Wrap(err, "Adding certificate signing request controller to manager failed.")
+	}
+
+	// Watch for changes to CertificateSigningRequests
+	p := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			o := e.Object.(*certv1.CertificateSigningRequest)
+
+			return ownedByExSecret(o.OwnerReferences)
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			o := e.ObjectNew.(*certv1.CertificateSigningRequest)
+
+			return ownedByExSecret(o.OwnerReferences)
+
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &certv1.CertificateSigningRequest{}}, &handler.EnqueueRequestForObject{}, p)
+	if err != nil {
+		return errors.Wrapf(err, "Watching extended secrets failed in certificate signing request controller.")
+	}
+
+	return nil
+}
+
+func ownedByExSecret(owners []metav1.OwnerReference) bool {
+	for _, owner := range owners {
+		if owner.Kind == "ExtendedSecret" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler.go
@@ -119,7 +119,7 @@ func (r *ReconcileCertificateSigningRequest) Reconcile(request reconcile.Request
 
 	err = r.approveRequest(ctx, instance.Name)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, errors.Wrap(err, "approving cert request failed")
 	}
 
 	return reconcile.Result{}, nil
@@ -180,7 +180,7 @@ func (r *ReconcileCertificateSigningRequest) getSecret(ctx context.Context, name
 	secret := &corev1.Secret{}
 	err := r.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
 	if err != nil {
-		return secret, errors.Wrapf(err, "Error getting secret '%s/%s'", namespace, secretName)
+		return secret, errors.Wrapf(err, "could not get secret '%s/%s'", namespace, secretName)
 	}
 	return secret, nil
 }
@@ -191,7 +191,7 @@ func (r *ReconcileCertificateSigningRequest) deleteSecret(ctx context.Context, s
 
 	err := r.client.Delete(ctx, secret)
 	if err != nil {
-		return errors.Wrapf(err, "Error deleting secret '%s/%s'", secret.Namespace, secret.Name)
+		return errors.Wrapf(err, "could not delete secret '%s/%s'", secret.Namespace, secret.Name)
 	}
 
 	return nil

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler.go
@@ -1,0 +1,209 @@
+package extendedsecret
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	certv1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	certv1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
+)
+
+// NewCertificateSigningRequestReconciler returns a new Reconciler
+func NewCertificateSigningRequestReconciler(ctx context.Context, config *config.Config, mgr manager.Manager, certClient certv1client.CertificatesV1beta1Interface, srf setReferenceFunc) reconcile.Reconciler {
+	return &ReconcileCertificateSigningRequest{
+		ctx:          ctx,
+		config:       config,
+		client:       mgr.GetClient(),
+		certClient:   certClient,
+		scheme:       mgr.GetScheme(),
+		setReference: srf,
+	}
+}
+
+// ReconcileCertificateSigningRequest reconciles an CertificateSigningRequest object
+type ReconcileCertificateSigningRequest struct {
+	ctx          context.Context
+	config       *config.Config
+	client       client.Client
+	certClient   certv1client.CertificatesV1beta1Interface
+	scheme       *runtime.Scheme
+	setReference setReferenceFunc
+}
+
+// Reconcile approves pending CSR and creates its certificate secret
+func (r *ReconcileCertificateSigningRequest) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	instance := &certv1.CertificateSigningRequest{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
+	defer cancel()
+
+	ctxlog.Infof(ctx, "Reconciling certificateSigningRequest '%s'", request.Name)
+	err := r.client.Get(ctx, request.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			ctxlog.Info(ctx, "Skip reconcile: certificateSigningRequest not found")
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		ctxlog.Info(ctx, "Error reading the object")
+		return reconcile.Result{}, errors.Wrap(err, "Error reading certificateSigningRequest")
+	}
+
+	if len(instance.Status.Certificate) != 0 {
+		annotations := instance.GetAnnotations()
+		if annotations == nil {
+			ctxlog.WithEvent(instance, "NotFoundError").Errorf(ctx, "Empty annotations of certificateSigningRequest '%s'", instance.Name)
+			return reconcile.Result{}, nil
+		}
+		secretName, ok := annotations[esv1.AnnotationCertSecretName]
+		if !ok {
+			ctxlog.WithEvent(instance, "NotFoundError").Errorf(ctx, "failed to lookup cert secret name from certificateSigningRequest '%s' annotations", instance.Name)
+			return reconcile.Result{}, nil
+		}
+		namespace, ok := annotations[esv1.AnnotationExSecretNamespace]
+		if !ok {
+			ctxlog.WithEvent(instance, "NotFoundError").Errorf(ctx, "failed to lookup exSecret namespace from certificateSigningRequest '%s' annotations", instance.Name)
+			return reconcile.Result{}, nil
+		}
+
+		privatekeySecret, err := r.getSecret(ctx, namespace, names.PrivateKeySecretName(instance.Name))
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		certSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secretName,
+				Namespace:       namespace,
+				OwnerReferences: instance.OwnerReferences,
+				Labels: map[string]string{
+					esv1.LabelKind: esv1.GeneratedSecretKind,
+				},
+			},
+			Data: map[string][]byte{
+				"certificate": instance.Status.Certificate,
+				"private_key": privatekeySecret.Data["private_key"],
+				"is_ca":       privatekeySecret.Data["is_ca"],
+			},
+		}
+
+		err = r.createSecret(ctx, certSecret)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		err = r.deleteSecret(ctx, privatekeySecret)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	err = r.approveRequest(ctx, instance.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// approveRequest approves the certificateSigningRequest
+func (r *ReconcileCertificateSigningRequest) approveRequest(ctx context.Context, csrName string) error {
+	csr, err := r.certClient.CertificateSigningRequests().Get(csrName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "could not get certificateSigningRequest '%s'", csrName)
+	}
+
+	if isApproved(csr.Status.Conditions) {
+		ctxlog.Debugf(ctx, "Skip approve: certificateSigningRequest %s has already been approved", csrName)
+		return nil
+	}
+
+	ctxlog.Debugf(ctx, "Approving certificateSigningRequest '%s'", csrName)
+
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+		Type:    certv1.CertificateApproved,
+		Reason:  "AutoApproved",
+		Message: "This CSR was approved by csr-controller",
+	})
+
+	_, err = r.certClient.CertificateSigningRequests().UpdateApproval(csr)
+	if err != nil {
+		return errors.Wrapf(err, "could not update approval of certificateSigningRequest '%s'", csrName)
+	}
+
+	ctxlog.Debugf(ctx, "CertificateSigningRequest '%s' has been updated", csrName)
+
+	return nil
+}
+
+// createSecret creates secret
+func (r *ReconcileCertificateSigningRequest) createSecret(ctx context.Context, secret *corev1.Secret) error {
+	ctxlog.Debugf(ctx, "Creating secret '%s'", secret.Name)
+
+	obj := secret.DeepCopy()
+	op, err := controllerutil.CreateOrUpdate(ctx, r.client, obj, func() error {
+		obj.StringData = secret.StringData
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "could not create or update secret '%s'", secret.GetName())
+	}
+
+	ctxlog.Debugf(ctx, "Secret '%s' has been %s", secret.Name, op)
+
+	return nil
+}
+
+// getSecret gets secret
+func (r *ReconcileCertificateSigningRequest) getSecret(ctx context.Context, namespace string, secretName string) (*corev1.Secret, error) {
+	ctxlog.Debugf(ctx, "getting secret '%s'", secretName)
+
+	secret := &corev1.Secret{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
+	if err != nil {
+		return secret, errors.Wrapf(err, "Error getting secret '%s/%s'", namespace, secretName)
+	}
+	return secret, nil
+}
+
+// deleteSecret deletes secret
+func (r *ReconcileCertificateSigningRequest) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
+	ctxlog.Debugf(ctx, "Deleting secret '%s'", secret.Name)
+
+	err := r.client.Delete(ctx, secret)
+	if err != nil {
+		return errors.Wrapf(err, "Error deleting secret '%s/%s'", secret.Namespace, secret.Name)
+	}
+
+	return nil
+}
+
+// isApproved returns true if the certificateSigningRequest has already been approved
+func isApproved(conditions []certv1.CertificateSigningRequestCondition) bool {
+	for _, condition := range conditions {
+		if condition.Type == certv1.CertificateApproved {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler_test.go
@@ -51,8 +51,8 @@ var _ = Describe("ReconcileCertificateSigningRequest", func() {
 				Name:      "foo",
 				Namespace: "default",
 				Annotations: map[string]string{
-					esv1.AnnotationCertSecretName:    "fake-cert",
-					esv1.AnnotationExSecretNamespace: "fake-namespace",
+					esv1.AnnotationCertSecretName: "fake-cert",
+					esv1.AnnotationESecNamespace:  "fake-namespace",
 				},
 			},
 			Spec: certv1.CertificateSigningRequestSpec{
@@ -61,7 +61,7 @@ var _ = Describe("ReconcileCertificateSigningRequest", func() {
 		}
 		privateKeySecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      names.PrivateKeySecretName(csr.Name),
+				Name:      names.CsrPrivateKeySecretName(csr.Name),
 				Namespace: "fake-namespace",
 			},
 			Data: map[string][]byte{
@@ -84,7 +84,7 @@ var _ = Describe("ReconcileCertificateSigningRequest", func() {
 				csr.DeepCopyInto(object)
 				return nil
 			case *corev1.Secret:
-				if nn.Name == names.PrivateKeySecretName(csr.Name) {
+				if nn.Name == names.CsrPrivateKeySecretName(csr.Name) {
 					privateKeySecret.DeepCopyInto(object)
 					return nil
 				}
@@ -227,7 +227,7 @@ var _ = Describe("ReconcileCertificateSigningRequest", func() {
 			client.DeleteCalls(func(context context.Context, object runtime.Object, opts ...crc.DeleteOptionFunc) error {
 				switch object := object.(type) {
 				case *corev1.Secret:
-					Expect(object.GetName()).To(Equal(names.PrivateKeySecretName(csr.Name)))
+					Expect(object.GetName()).To(Equal(names.CsrPrivateKeySecretName(csr.Name)))
 					return nil
 				}
 				return nil
@@ -284,7 +284,7 @@ var _ = Describe("ReconcileCertificateSigningRequest", func() {
 					csr.DeepCopyInto(object)
 					return nil
 				case *corev1.Secret:
-					if nn.Name == names.PrivateKeySecretName(csr.Name) {
+					if nn.Name == names.CsrPrivateKeySecretName(csr.Name) {
 						return apierrors.NewNotFound(schema.GroupResource{}, "not found")
 					}
 					return nil

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_reconciler_test.go
@@ -1,0 +1,329 @@
+package extendedsecret_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	certv1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	certv1clientfakes "k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake"
+	ktesting "k8s.io/client-go/testing"
+	crc "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	esv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedsecret/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned/scheme"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
+	escontroller "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedsecret"
+	cfakes "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
+	cfcfg "code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
+	helper "code.cloudfoundry.org/cf-operator/pkg/testhelper"
+)
+
+var _ = Describe("ReconcileCertificateSigningRequest", func() {
+	var (
+		manager          *cfakes.FakeManager
+		reconciler       reconcile.Reconciler
+		request          reconcile.Request
+		ctx              context.Context
+		log              *zap.SugaredLogger
+		config           *cfcfg.Config
+		client           *cfakes.FakeClient
+		certClient       *certv1clientfakes.FakeCertificatesV1beta1
+		csr              *certv1.CertificateSigningRequest
+		privateKeySecret *corev1.Secret
+		setReferenceFunc func(owner, object metav1.Object, scheme *runtime.Scheme) error = func(owner, object metav1.Object, scheme *runtime.Scheme) error { return nil }
+	)
+
+	BeforeEach(func() {
+		csr = &certv1.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+				Annotations: map[string]string{
+					esv1.AnnotationCertSecretName:    "fake-cert",
+					esv1.AnnotationExSecretNamespace: "fake-namespace",
+				},
+			},
+			Spec: certv1.CertificateSigningRequestSpec{
+				Request: []byte("fake-certificate-signing-request"),
+			},
+		}
+		privateKeySecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      names.PrivateKeySecretName(csr.Name),
+				Namespace: "fake-namespace",
+			},
+			Data: map[string][]byte{
+				"private_key": []byte("fake-private-key"),
+				"is_ca":       []byte("false"),
+			},
+		}
+
+		controllers.AddToScheme(scheme.Scheme)
+		manager = &cfakes.FakeManager{}
+		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
+		config = &cfcfg.Config{CtxTimeOut: 10 * time.Second}
+		_, log = helper.NewTestLogger()
+		ctx = ctxlog.NewParentContext(log)
+
+		client = &cfakes.FakeClient{}
+		client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+			switch object := object.(type) {
+			case *certv1.CertificateSigningRequest:
+				csr.DeepCopyInto(object)
+				return nil
+			case *corev1.Secret:
+				if nn.Name == names.PrivateKeySecretName(csr.Name) {
+					privateKeySecret.DeepCopyInto(object)
+					return nil
+				}
+			}
+			return apierrors.NewNotFound(schema.GroupResource{}, "not found")
+		})
+
+		manager.GetClientReturns(client)
+
+		certClient = &certv1clientfakes.FakeCertificatesV1beta1{
+			Fake: &ktesting.Fake{},
+		}
+	})
+
+	JustBeforeEach(func() {
+		reconciler = escontroller.NewCertificateSigningRequestReconciler(ctx, config, manager, certClient, setReferenceFunc)
+	})
+
+	Context("when reconciling pending CSR", func() {
+		BeforeEach(func() {
+			certClient.AddReactor("get", "certificatesigningrequests", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action, ok := action.(ktesting.GetActionImpl); ok {
+					Expect(action.Name).To(Equal(csr.Name))
+					return true, csr, nil
+				}
+				return true, &certv1.CertificateSigningRequest{}, apierrors.NewNotFound(schema.GroupResource{}, "not found")
+			})
+			certClient.AddReactor("update", "certificatesigningrequests", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action, ok := action.(ktesting.UpdateActionImpl); ok {
+					switch object := action.Object.(type) {
+					case *certv1.CertificateSigningRequest:
+						Expect(object.Status.Conditions).To(ContainElement(certv1.CertificateSigningRequestCondition{
+							Type:    certv1.CertificateApproved,
+							Reason:  "AutoApproved",
+							Message: "This CSR was approved by csr-controller",
+						}))
+						return true, csr, nil
+					}
+				}
+
+				return true, &certv1.CertificateSigningRequest{}, apierrors.NewBadRequest("fake-error")
+			})
+		})
+		It("approves CSR", func() {
+			result, err := reconciler.Reconcile(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcile.Result{}).To(Equal(result))
+		})
+
+		It("skips if the resource was not found", func() {
+			client.GetReturns(apierrors.NewNotFound(schema.GroupResource{}, "not found"))
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("handles an error when getting certificateSigningRequest", func() {
+			client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object.(type) {
+				case *certv1.CertificateSigningRequest:
+					return apierrors.NewBadRequest("fake-error")
+				}
+				return apierrors.NewNotFound(schema.GroupResource{}, "not found")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Error reading certificateSigningRequest"))
+		})
+
+		It("handles an error when getting pending certificateSigningRequest", func() {
+			certClient.PrependReactor("get", "certificatesigningrequests", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action, ok := action.(ktesting.GetActionImpl); ok {
+					Expect(action.Name).To(Equal(csr.Name))
+					return true, &certv1.CertificateSigningRequest{}, apierrors.NewNotFound(schema.GroupResource{}, "not found")
+				}
+				return true, &certv1.CertificateSigningRequest{}, nil
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not get certificateSigningRequest"))
+		})
+
+		It("skips if pending certificateSigningRequest has been approved", func() {
+			certClient.PrependReactor("get", "certificatesigningrequests", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				if action, ok := action.(ktesting.GetActionImpl); ok {
+					Expect(action.Name).To(Equal(csr.Name))
+					csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+						Type:    certv1.CertificateApproved,
+						Reason:  "AutoApproved",
+						Message: "This CSR was approved by csr-controller",
+					})
+					return true, csr, nil
+				}
+				return true, &certv1.CertificateSigningRequest{}, apierrors.NewNotFound(schema.GroupResource{}, "not found")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("handles an error when updating approval of certificateSigningRequest", func() {
+			certClient.PrependReactor("update", "certificatesigningrequests", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &certv1.CertificateSigningRequest{}, apierrors.NewBadRequest("fake-error")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not update approval of certificateSigningRequest"))
+		})
+	})
+
+	Context("when reconciling approved CSR", func() {
+		BeforeEach(func() {
+			csr.Status = certv1.CertificateSigningRequestStatus{
+				Conditions: []certv1.CertificateSigningRequestCondition{
+					{
+						Type:    certv1.CertificateApproved,
+						Reason:  "AutoApproved",
+						Message: "This CSR was approved by csr-controller",
+					},
+				},
+				Certificate: []byte("fake-issued-certificate"),
+			}
+
+			client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOptionFunc) error {
+				switch object := object.(type) {
+				case *corev1.Secret:
+					Expect(object.Name).To(Equal("fake-cert"))
+					Expect(object.Data).To(HaveKeyWithValue("certificate", csr.Status.Certificate))
+					Expect(object.Data).To(HaveKeyWithValue("private_key", privateKeySecret.Data["private_key"]))
+					Expect(object.Data).To(HaveKeyWithValue("is_ca", privateKeySecret.Data["is_ca"]))
+					return nil
+				}
+
+				return apierrors.NewBadRequest("fake-error")
+			})
+
+			client.DeleteCalls(func(context context.Context, object runtime.Object, opts ...crc.DeleteOptionFunc) error {
+				switch object := object.(type) {
+				case *corev1.Secret:
+					Expect(object.GetName()).To(Equal(names.PrivateKeySecretName(csr.Name)))
+					return nil
+				}
+				return nil
+			})
+		})
+
+		It("creates cert secret and cleans up resources", func() {
+			result, err := reconciler.Reconcile(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcile.Result{}).To(Equal(result))
+			Expect(client.GetCallCount()).To(Equal(3))
+			Expect(client.CreateCallCount()).To(Equal(1))
+			Expect(client.DeleteCallCount()).To(Equal(1))
+		})
+
+		It("Skips reconcile when getting nil annotations", func() {
+			csr.Annotations = nil
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(client.GetCallCount()).To(Equal(1))
+			Expect(client.CreateCallCount()).To(Equal(0))
+			Expect(client.DeleteCallCount()).To(Equal(0))
+		})
+
+		It("Skips reconcile when getting cert secret name", func() {
+			csr.Annotations = map[string]string{}
+
+			result, err := reconciler.Reconcile(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcile.Result{}).To(Equal(result))
+			Expect(client.GetCallCount()).To(Equal(1))
+			Expect(client.CreateCallCount()).To(Equal(0))
+			Expect(client.DeleteCallCount()).To(Equal(0))
+		})
+
+		It("Skips reconcile when getting exSecret's namespace", func() {
+			csr.Annotations = map[string]string{
+				esv1.AnnotationCertSecretName: "fake-cert",
+			}
+
+			result, err := reconciler.Reconcile(request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reconcile.Result{}).To(Equal(result))
+			Expect(client.GetCallCount()).To(Equal(1))
+			Expect(client.CreateCallCount()).To(Equal(0))
+			Expect(client.DeleteCallCount()).To(Equal(0))
+		})
+
+		It("handles an error when getting private key secret", func() {
+			client.GetCalls(func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object := object.(type) {
+				case *certv1.CertificateSigningRequest:
+					csr.DeepCopyInto(object)
+					return nil
+				case *corev1.Secret:
+					if nn.Name == names.PrivateKeySecretName(csr.Name) {
+						return apierrors.NewNotFound(schema.GroupResource{}, "not found")
+					}
+					return nil
+				}
+				return apierrors.NewNotFound(schema.GroupResource{}, "not found")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not get secret"))
+			Expect(client.GetCallCount()).To(Equal(2))
+			Expect(client.CreateCallCount()).To(Equal(0))
+			Expect(client.DeleteCallCount()).To(Equal(0))
+		})
+
+		It("handles an error when creating certificate secret", func() {
+			client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOptionFunc) error {
+				return apierrors.NewBadRequest("fake-error")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not create or update secret"))
+			Expect(client.GetCallCount()).To(Equal(3))
+			Expect(client.CreateCallCount()).To(Equal(1))
+			Expect(client.DeleteCallCount()).To(Equal(0))
+		})
+
+		It("handles an error when deleting private key secret", func() {
+			client.DeleteCalls(func(context context.Context, object runtime.Object, opts ...crc.DeleteOptionFunc) error {
+				return apierrors.NewBadRequest("fake-error")
+			})
+
+			_, err := reconciler.Reconcile(request)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not delete secret"))
+			Expect(client.GetCallCount()).To(Equal(3))
+			Expect(client.CreateCallCount()).To(Equal(1))
+			Expect(client.DeleteCallCount()).To(Equal(1))
+		})
+	})
+})

--- a/pkg/kube/controllers/extendedsecret/extendedsecret_controller.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_controller.go
@@ -23,11 +23,11 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
 
-// Add creates a new ExtendedSecrets Controller and adds it to the Manager
-func Add(ctx context.Context, config *config.Config, mgr manager.Manager) error {
+// AddExtendedSecret creates a new ExtendedSecrets Controller and adds it to the Manager
+func AddExtendedSecret(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "ext-secret-reconciler", mgr.GetEventRecorderFor("ext-secret-recorder"))
 	log := ctxlog.ExtractLogger(ctx)
-	r := NewReconciler(ctx, config, mgr, credsgen.NewInMemoryGenerator(log), controllerutil.SetControllerReference)
+	r := NewExtendedSecretReconciler(ctx, config, mgr, credsgen.NewInMemoryGenerator(log), controllerutil.SetControllerReference)
 
 	// Create a new controller
 	c, err := controller.New("extendedsecret-controller", mgr, controller.Options{

--- a/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler.go
@@ -257,7 +257,7 @@ func (r *ReconcileExtendedSecret) createCertificateSecret(ctx context.Context, i
 		// private key Secret which will be merged to certificate Secret later
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      names.PrivateKeySecretName(instance.Name),
+				Name:      names.CsrPrivateKeySecretName(instance.Name),
 				Namespace: instance.GetNamespace(),
 			},
 			StringData: map[string]string{
@@ -366,7 +366,7 @@ func (r *ReconcileExtendedSecret) createCertificateSigningRequest(ctx context.Co
 		annotations = map[string]string{}
 	}
 	annotations[esv1.AnnotationCertSecretName] = instance.Spec.SecretName
-	annotations[esv1.AnnotationExSecretNamespace] = instance.Namespace
+	annotations[esv1.AnnotationESecNamespace] = instance.Namespace
 
 	csrObj := &certv1.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
@@ -75,7 +75,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 	})
 
 	JustBeforeEach(func() {
-		reconciler = escontroller.NewReconciler(ctx, config, manager, generator, setReferenceFunc)
+		reconciler = escontroller.NewExtendedSecretReconciler(ctx, config, manager, generator, setReferenceFunc)
 	})
 
 	Context("if the resource can not be resolved", func() {

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -160,8 +160,8 @@ func OrdinalFromPodName(name string) int {
 	return podOrdinal
 }
 
-// PrivateKeySecretName returns a Secret name for a given ExtendedSecret
-func PrivateKeySecretName(extendedSecretName string) string {
+// CsrPrivateKeySecretName returns a Secret name for a given ExtendedSecret
+func CsrPrivateKeySecretName(extendedSecretName string) string {
 	return extendedSecretName + "-csr-private-key"
 }
 

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -162,7 +162,7 @@ func OrdinalFromPodName(name string) int {
 
 // PrivateKeySecretName returns a Secret name for a given ExtendedSecret
 func PrivateKeySecretName(extendedSecretName string) string {
-	return extendedSecretName + "csr-private-key"
+	return extendedSecretName + "-csr-private-key"
 }
 
 func randSuffix(str string) (string, error) {

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -160,9 +160,14 @@ func OrdinalFromPodName(name string) int {
 	return podOrdinal
 }
 
-// CsrPrivateKeySecretName returns a Secret name for a given ExtendedSecret
-func CsrPrivateKeySecretName(extendedSecretName string) string {
-	return extendedSecretName + "-csr-private-key"
+// CSRName returns a CertificateSigningRequest name for a given ExtendedSecret
+func CSRName(namespace, extendedSecretName string) string {
+	return fmt.Sprintf("%s-%s", truncate(namespace, 19), truncate(extendedSecretName, 19))
+}
+
+// CsrPrivateKeySecretName returns a Secret name for a given CertificateSigningRequest private key
+func CsrPrivateKeySecretName(csrName string) string {
+	return csrName + "-csr-private-key"
 }
 
 func randSuffix(str string) (string, error) {

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -160,6 +160,11 @@ func OrdinalFromPodName(name string) int {
 	return podOrdinal
 }
 
+// PrivateKeySecretName returns a Secret name for a given ExtendedSecret
+func PrivateKeySecretName(extendedSecretName string) string {
+	return extendedSecretName + "csr-private-key"
+}
+
 func randSuffix(str string) (string, error) {
 	randBytes := make([]byte, 16)
 	_, err := rand.Read(randBytes)

--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -92,6 +92,9 @@ func (k *Kubectl) WaitForSecret(namespace string, secretName string) error {
 func (k *Kubectl) SecretExists(namespace string, secretName string) (bool, error) {
 	out, err := runBinary(kubeCtlCmd, "--namespace", namespace, "get", "secret", secretName)
 	if err != nil {
+		if strings.Contains(string(out), "Error from server (NotFound)") {
+			return false, nil
+		}
 		return false, errors.Wrapf(err, "Getting secret %s failed. %s", secretName, string(out))
 	}
 	if strings.Contains(string(out), secretName) {


### PR DESCRIPTION
[#167555390](https://www.pivotaltracker.com/story/show/167555390)

- Added two options to support CSR for ExtendedSecret:
```
SignerType       SignerType        `json:"signerType,omitempty"`
Usages           []certv1.KeyUsage `json:"usages,omitempty"`
```

- Added CSR controller to watch CSR and approve it and then persists certificate signed by Kube API Server

Verification steps: 
```
$ k apply -f ./docs/examples/extended-secret/certificate.yaml

$ k get secret
NAME                                   TYPE                                  DATA   AGE
...
nats-deployment.var-nats-cert    # This cert signed by API Server
```