### PR TITLE
Add DisableLogSidecar field into AgentSettings struct

### DIFF
--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nats-deployment.var-custom-password
+type: Opaque
+stringData:
+  password: custom_password
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-manifest
+data:
+  manifest: |
+    ---
+    name: nats-manifest
+    releases:
+    - name: nats
+      version: "26"
+      url: docker.io/cfcontainerization
+      stemcell:
+        os: opensuse-42.3
+        version: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+    instance_groups:
+    - name: nats
+      instances: 1
+      jobs:
+      - name: nats
+        release: nats
+        properties:
+          nats:
+            user: admin
+            password: ((custom_password))
+      env:
+        bosh:
+          agent: 
+            settings:
+              disable_log_sidecar: true
+    variables:
+    - name: custom_password
+      type: password
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-foo
+data:
+  ops: |
+    - type: replace
+      path: /instance_groups/name=nats?/instances
+      value: 2
+---
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: BOSHDeployment
+metadata:
+  name: nats-deployment
+spec:
+  manifest:
+    name: nats-manifest
+    type: configmap
+  ops:
+  - name: ops-foo
+    type: configmap

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -109,7 +109,9 @@ func (kc *KubeConverter) BPMResources(manifestName string, version string, insta
 		Disks: allDisks,
 	}
 
-	cfac := NewContainerFactory(manifestName, instanceGroup.Name, version, releaseImageProvider, bpmConfigs)
+	disableLogSideCar := instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.DisableLogSidecar
+
+	cfac := NewContainerFactory(manifestName, instanceGroup.Name, version, disableLogSideCar, releaseImageProvider, bpmConfigs)
 
 	switch instanceGroup.LifeCycle {
 	case "service", "":

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -109,9 +109,14 @@ func (kc *KubeConverter) BPMResources(manifestName string, version string, insta
 		Disks: allDisks,
 	}
 
-	disableLogSideCar := instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.DisableLogSidecar
-
-	cfac := NewContainerFactory(manifestName, instanceGroup.Name, version, disableLogSideCar, releaseImageProvider, bpmConfigs)
+	cfac := NewContainerFactory(
+		manifestName,
+		instanceGroup.Name,
+		version,
+		instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.DisableLogSidecar,
+		releaseImageProvider,
+		bpmConfigs,
+	)
 
 	switch instanceGroup.LifeCycle {
 	case "service", "":

--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -26,16 +26,18 @@ type ContainerFactory struct {
 	manifestName         string
 	instanceGroupName    string
 	version              string
+	disableLogSidecar    bool
 	releaseImageProvider ReleaseImageProvider
 	bpmConfigs           bpm.Configs
 }
 
 // NewContainerFactory returns a new ContainerFactory for a BOSH instant group
-func NewContainerFactory(manifestName string, instanceGroupName string, version string, releaseImageProvider ReleaseImageProvider, bpmConfigs bpm.Configs) *ContainerFactory {
+func NewContainerFactory(manifestName string, instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider ReleaseImageProvider, bpmConfigs bpm.Configs) *ContainerFactory {
 	return &ContainerFactory{
 		manifestName:         manifestName,
 		instanceGroupName:    instanceGroupName,
 		version:              version,
+		disableLogSidecar:    disableLogSidecar,
 		releaseImageProvider: releaseImageProvider,
 		bpmConfigs:           bpmConfigs,
 	}
@@ -203,8 +205,13 @@ func (c *ContainerFactory) JobsToContainers(
 		}
 	}
 
-	logsTailer := logsTailerContainer(c.instanceGroupName)
-	containers = append(containers, logsTailer)
+	// When disableLogSidecar is true, it will stop
+	// appending the sidecar, default behaviour is to
+	// colocate it always in the pod.
+	if !c.disableLogSidecar {
+		logsTailer := logsTailerContainer(c.instanceGroupName)
+		containers = append(containers, logsTailer)
+	}
 
 	return containers, nil
 }

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -115,9 +115,10 @@ var (
 // These annotations and labels are added to kube resources.
 // Affinity is added into the pod's definition.
 type AgentSettings struct {
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Affinity    *corev1.Affinity  `json:"affinity,omitempty"`
+	Annotations       map[string]string `json:"annotations,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Affinity          *corev1.Affinity  `json:"affinity,omitempty"`
+	DisableLogSidecar bool              `json:"disable_log_sidecar,omitempty" yaml:"disable_log_sidecar,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata


### PR DESCRIPTION
This should allow users to disable the default sidecar
running in all pods for logging purposes.

If you will like to disable it, you need to define the following under the `instance_group` item:
```
      env:
        bosh:
          agent: 
            settings:
              disable_log_sidecar: true
```