### PR TITLE
Try to fix deleting namespace error in CI

### DIFF
--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -216,7 +216,7 @@ func CreateNamespace(name string) error {
 func DeleteNamespace(ns string) error {
 	fmt.Printf("Cleaning up namespace %s \n", ns)
 
-	_, err := runBinary(kubeCtlCmd, "delete", "--wait=false", "--ignore-not-found", "namespace", ns)
+	_, err := runBinary(kubeCtlCmd, "delete", "--wait=false", "--ignore-not-found", "--grace-period=30", "namespace", ns)
 	if err != nil {
 		return errors.Wrapf(err, "Deleting namespace %s failed", ns)
 	}


### PR DESCRIPTION
Fixes:

https://ci.flintstone.cf.cloud.ibm.com/teams/quarks/pipelines/cf-operator-check/jobs/test/builds/618#L5d27a446:328

```
WARNING: failed to delete namespace test1565575724-405: Deleting namespace test1565575724-405 failed: [kubectl delete --wait=false --ignore-not-found namespace test1565575724-405] cmd, failed with the following error: Error from server (Conflict): Operation cannot be fulfilled on namespaces "test1565575724-405": The system is ensuring all content is removed from this namespace.  Upon completion, this namespace will automatically be purged by the system.
```

- Gave grace time to delete integration namespace