### PR TITLE
Bumped dumb-init and improved Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 binaries/
 build/
 tmp/
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM alpine AS dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/bin/dumb-init
+RUN chmod +x /usr/bin/dumb-init
+
 FROM golang:1.12.2 AS build
 ARG GO111MODULE="on"
 ENV GO111MODULE $GO111MODULE
@@ -14,10 +18,9 @@ RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 
 FROM cfcontainerization/cf-operator-base@sha256:2bb233fea55317729ebba6636976459e56d3c6605eaf3c54774449e9507341a5
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/bin/dumb-init
-RUN chmod +x /usr/bin/dumb-init
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 USER vcap
+COPY --from=dumb-init /usr/bin/dumb-init /usr/bin/dumb-init
 COPY --from=build /usr/local/bin/cf-operator /usr/local/bin/cf-operator
-ENTRYPOINT ["cf-operator"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "cf-operator"]


### PR DESCRIPTION
Also, start cf-operator with dumb-init. It includes any containers that get created when using the cf-operator util subcommand.