### PR TITLE
Update ESec only when spec changed

### DIFF
--- a/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
@@ -329,7 +329,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 			result, err := reconciler.Reconcile(request)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(client.CreateCallCount()).To(Equal(0))
-			Expect(client.UpdateCallCount()).To(Equal(2))
+			Expect(client.UpdateCallCount()).To(Equal(1))
 			Expect(reconcile.Result{}).To(Equal(result))
 		})
 	})

--- a/pkg/kube/util/mutate/mutate.go
+++ b/pkg/kube/util/mutate/mutate.go
@@ -67,8 +67,12 @@ func ESecMutateFn(eSec *esv1.ExtendedSecret) controllerutil.MutateFn {
 	return func() error {
 		eSec.Labels = updated.Labels
 		eSec.Annotations = updated.Annotations
-		eSec.Spec = updated.Spec
-		eSec.Status.Generated = updated.Status.Generated
+		// Update only when spec has been changed
+		if !reflect.DeepEqual(eSec.Spec, updated.Spec) {
+			eSec.Spec = updated.Spec
+			eSec.Status.Generated = updated.Status.Generated
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Occurred an API server error `context deadline exceeded` when the controller created/updated ESec and controller did reconciliation repeatedly for this error. 

To remediate and speed up reconciliation, the controller only updates when spec has been changed.