### PR TITLE
Enable AZs when converting Bosh services to ESts

### DIFF
--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -175,6 +175,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 			Annotations: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations,
 		},
 		Spec: essv1.ExtendedStatefulSetSpec{
+			Zones:                instanceGroup.AZs,
 			UpdateOnConfigChange: true,
 			Template: v1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -129,6 +129,9 @@ var _ = Describe("kube converter", func() {
 					Expect(extStS.GetLabels()).To(HaveKeyWithValue(manifest.LabelInstanceGroupName, "diego-cell"))
 					Expect(extStS.GetLabels()).To(HaveKeyWithValue(manifest.LabelDeploymentVersion, "1"))
 
+					// Test ESts spec
+					Expect(extStS.Spec.Zones).To(Equal(m.InstanceGroups[1].AZs))
+
 					stS := extStS.Spec.Template.Spec.Template
 					Expect(stS.Name).To(Equal("diego-cell"))
 

--- a/pkg/kube/controllers/extendedstatefulset/extendedstatefulset_reconciler.go
+++ b/pkg/kube/controllers/extendedstatefulset/extendedstatefulset_reconciler.go
@@ -260,7 +260,7 @@ func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *
 
 	// Update available-zone specified properties
 	if zoneName != "" {
-		// Reset name prefix with zoneIndex
+		// Override name prefix with zoneIndex
 		statefulSetNamePrefix = fmt.Sprintf("%s-z%d", exStatefulSet.GetName(), zoneIndex)
 
 		labels[estsv1.LabelAZIndex] = strconv.Itoa(zoneIndex)
@@ -277,7 +277,7 @@ func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *
 
 		podAnnotations[estsv1.AnnotationZones] = string(zonesBytes)
 
-		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneIndex, zoneName)
+		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneName)
 	}
 
 	// Set az-index as 0 for single zoneName
@@ -299,7 +299,7 @@ func (r *ReconcileExtendedStatefulSet) generateSingleStatefulSet(exStatefulSet *
 }
 
 // updateAffinity Update current statefulSet Affinity from AZ specification
-func (r *ReconcileExtendedStatefulSet) updateAffinity(statefulSet *v1beta2.StatefulSet, zoneNodeLabel string, zoneIndex int, zoneName string) *v1beta2.StatefulSet {
+func (r *ReconcileExtendedStatefulSet) updateAffinity(statefulSet *v1beta2.StatefulSet, zoneNodeLabel string, zoneName string) *v1beta2.StatefulSet {
 	nodeInZoneSelector := corev1.NodeSelectorRequirement{
 		Key:      zoneNodeLabel,
 		Operator: corev1.NodeSelectorOpIn,

--- a/pkg/kube/controllers/extendedstatefulset/volumes.go
+++ b/pkg/kube/controllers/extendedstatefulset/volumes.go
@@ -146,7 +146,7 @@ func (r *ReconcileExtendedStatefulSet) generateVolumeManagementSingleStatefulSet
 		statefulSet.Spec.Template.SetLabels(podLabels)
 		statefulSet.Spec.Template.SetAnnotations(podAnnotations)
 
-		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneIndex, zoneName)
+		statefulSet = r.updateAffinity(statefulSet, exStatefulSet.Spec.ZoneNodeLabel, zoneName)
 	}
 
 	// Set updated properties


### PR DESCRIPTION
[#167995306](https://www.pivotaltracker.com/story/show/167995306)

For high-availability, the controller will create one Sts containing full replicas for each zone, so `Sts count  = instance_group.AZs * instance_group.instances`.
- When updating a new zone, the controller will create new Sts for the new zone and relative clusterIP services for each replica.
- When deleting an existing zone, the controller will delete relative Sts.