### PR TITLE
Move to scf namespace when deploying the operator

### DIFF
--- a/dev-env-havener.yaml
+++ b/dev-env-havener.yaml
@@ -30,7 +30,7 @@
 name: cf-operator-quarks
 releases:
 - name: cf-operator
-  namespace: quarks
+  namespace: scf
   location: deploy/helm/cf-operator/
   overrides:
     image:
@@ -71,9 +71,9 @@ before:
     ./bin/build-image
     ./bin/apply-crds
 
-    export RELEASE_NAMESPACE="quarks"
-    kubectl -n "${RELEASE_NAMESPACE}" delete mutatingwebhookconfiguration cf-operator-hook-quarks --ignore-not-found=true
-    kubectl -n "${RELEASE_NAMESPACE}" delete validatingwebhookconfiguration cf-operator-hook-quarks --ignore-not-found=true
+    export RELEASE_NAMESPACE="scf"
+    kubectl -n "${RELEASE_NAMESPACE}" delete mutatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
+    kubectl -n "${RELEASE_NAMESPACE}" delete validatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
     kubectl -n "${RELEASE_NAMESPACE}" delete secret cf-operator-webhook-server-cert --ignore-not-found=true
 
 after:
@@ -82,7 +82,7 @@ after:
   - -c
   - |
     #!/bin/bash
-    export RELEASE_NAMESPACE="quarks"
+    export RELEASE_NAMESPACE="scf"
     echo -e "\nCurrent generated mutating webhooks"
     kubectl -n "${RELEASE_NAMESPACE}" get mutatingwebhookconfigurations
 


### PR DESCRIPTION
This allows you to test SCF v3 in 2 steps on a minikube:
- havener deploy --config dev-env-havener.yaml
- bazel run //dev/scf:apply <- from `https://github.com/SUSE/scf/tree/v3-develop`