### PR TITLE
Increase Reconcile ctx timeouts

### DIFF
--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// CtxTimeOut is the default context.Context timeout
-	CtxTimeOut = 10 * time.Second
+	CtxTimeOut = 30 * time.Second
 )
 
 // Config controls the behaviour of different controllers


### PR DESCRIPTION
[#167968068](https://www.pivotaltracker.com/story/show/167968068)

For every call we do to the API for created/update/delete events, we pass a context with a deadline.

Increase the default timeout from 10s to 30s. While for SCF v3, it seems that during many of this api calls, the current times are very close to the deadline of the context. Leading to `deadline exceeded` errors.