### PR TITLE
Add Dockerfile for s390x

### DIFF
--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,3 +1,5 @@
+ARG quarkz_base_version="0.0.0"
+
 FROM s390x/alpine AS dumb-init
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_s390x /usr/bin/dumb-init
 RUN chmod +x /usr/bin/dumb-init
@@ -16,8 +18,8 @@ RUN if [ "${GO111MODULE}" = "on" ]; then go mod download; fi
 COPY . .
 RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
-
-FROM cfcontainerization/quarkz:0.0.0  
+ 
+FROM cfcontainerization/quarkz:$quarkz_base_version
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 USER vcap

--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,0 +1,26 @@
+FROM s390x/alpine AS dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_s390x /usr/bin/dumb-init
+RUN chmod +x /usr/bin/dumb-init
+
+FROM s390x/golang:1.12 AS build
+ARG GO111MODULE="on"
+ENV GO111MODULE $GO111MODULE
+
+WORKDIR /go/src/code.cloudfoundry.org/cf-operator
+# First, download dependencies so we can cache this layer
+COPY go.mod .
+COPY go.sum .
+RUN if [ "${GO111MODULE}" = "on" ]; then go mod download; fi
+
+# Copy the rest of the source code and build
+COPY . .
+RUN make build && \
+    cp -p binaries/cf-operator /usr/local/bin/cf-operator
+
+FROM cfcontainerization/quarkz:0.0.0  
+RUN groupadd -g 1000 vcap && \
+    useradd -r -u 1000 -g vcap vcap
+USER vcap
+COPY --from=dumb-init /usr/bin/dumb-init /usr/bin/dumb-init
+COPY --from=build /usr/local/bin/cf-operator /usr/local/bin/cf-operator
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "cf-operator"]


### PR DESCRIPTION
An s390x version of the Dockerfile is needed to build the cf-operator on s390x. 
I made some changes to the current Dockerfile to use s390x alpine image, dumb-init, golang and also [cfcontainerization/quarkz:0.0.0](https://github.com/cfcontainerizationbot/cf-operator-base/blob/master/Dockerfile) image which uses opensuse/leap:15:1.  As s390x doesn't support opensuse/leap, I had to use the tumbleweed one and tag it as a leap image.