### PR TITLE
Document how to recover from a crashed operator (fixes #436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com
 
 For more information about the `cf-operator` helm chart and how to configure it, please refer to [deploy/helm/cf-operator/README.md](deploy/helm/cf-operator/README.md)
 
+### Recovering from a crash
+
+If the operator pod crashes, it cannot be restarted in the same namespace before the existing mutating webhook configuration for that namespace is removed.
+The operator uses mutating webhooks to modify pods on the fly and Kubernetes fails to create pods if the webhook server is unreachable.
+The webhook configurations are installed cluster wide and don't belong to a single namespace, just like custom resources.
+
+To remove the webhook configurations for the cf-operator namespace run:
+
+```bash
+CF_OPERATOR_NAMESPACE=cf-operator
+kubectl delete mutatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
+kubectl delete validatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
+```
+
 ## Using your fresh installation
 
 With a running `cf-operator` pod, you can try one of the files (see [docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml](docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml) ), as follows:

--- a/dev-env-havener.yaml
+++ b/dev-env-havener.yaml
@@ -72,8 +72,8 @@ before:
     ./bin/apply-crds
 
     export RELEASE_NAMESPACE="scf"
-    kubectl -n "${RELEASE_NAMESPACE}" delete mutatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
-    kubectl -n "${RELEASE_NAMESPACE}" delete validatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
+    kubectl delete mutatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
+    kubectl delete validatingwebhookconfiguration cf-operator-hook-${RELEASE_NAMESPACE} --ignore-not-found=true
     kubectl -n "${RELEASE_NAMESPACE}" delete secret cf-operator-webhook-server-cert --ignore-not-found=true
 
 after:
@@ -84,13 +84,13 @@ after:
     #!/bin/bash
     export RELEASE_NAMESPACE="scf"
     echo -e "\nCurrent generated mutating webhooks"
-    kubectl -n "${RELEASE_NAMESPACE}" get mutatingwebhookconfigurations
+    kubectl get mutatingwebhookconfigurations
 
     echo -e "\nCurrent generated validation webhooks"
-    kubectl -n "${RELEASE_NAMESPACE}" get validatingwebhookconfigurations
+    kubectl get validatingwebhookconfigurations
 
     echo -e "\nCurrent generated CRDs webhooks"
-    kubectl -n "${RELEASE_NAMESPACE}" get customresourcedefinitions
+    kubectl get customresourcedefinitions
 
     echo -e "\nCurrent pods"
     kubectl -n "${RELEASE_NAMESPACE}" get pods


### PR DESCRIPTION
The situation cannot be improved before we require Kubernetes 1.15+ and
make use of an [object selector](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector) to exclude
the operator pod [#167425277](https://www.pivotaltracker.com/story/show/167425277).

[#167371882](https://www.pivotaltracker.com/story/show/167371882)