### PR TITLE
The BOSH services we create do not need to update on config change

### DIFF
--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -177,7 +177,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 		},
 		Spec: essv1.ExtendedStatefulSetSpec{
 			Zones:                instanceGroup.AZs,
-			UpdateOnConfigChange: true,
+			UpdateOnConfigChange: false,
 			Template: v1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        instanceGroup.NameSanitized(),


### PR DESCRIPTION
The only referenced secrets are the desired manifest and instance group
manifest.