### PR TITLE
Remove watch on secret update from BPM controller

### DIFF
--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -22,8 +22,10 @@ import (
 	vss "code.cloudfoundry.org/cf-operator/pkg/kube/util/versionedsecretstore"
 )
 
-// AddBPM creates a new BPM Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
+// AddBPM creates a new BPM controller to watch for BPM configs and instance
+// group manifests.  It will reconcile those into k8s resources
+// (ExtendedStatefulSet, ExtendedJob), which represent BOSH instance groups and
+// BOSH errands.
 func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "bpm-reconciler", mgr.GetEventRecorderFor("bpm-recorder"))
 	r := NewBPMReconciler(

--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -59,19 +59,7 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 		},
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			o := e.ObjectNew.(*corev1.Secret)
-			shouldProcessEvent := isBPMInfoSecret(o)
-			if shouldProcessEvent {
-				ctxlog.NewPredicateEvent(o).Debug(
-					ctx, e.MetaNew, bdv1.SecretReference,
-					fmt.Sprintf("Update predicate passed for %s, new secret with label %s, value %s",
-						e.MetaNew.GetName(), bdv1.LabelDeploymentSecretType, o.GetLabels()[bdv1.LabelDeploymentSecretType]),
-				)
-			}
-
-			return shouldProcessEvent
-		},
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
 	}
 
 	// We have to watch the BPM secret. It gives us information about how to

--- a/pkg/kube/controllers/boshdeployment/deployment_controller.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_controller.go
@@ -22,8 +22,9 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/reference"
 )
 
-// AddDeployment creates a new BOSHDeployment Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
+// AddDeployment creates a new BOSHDeployment controller to watch for
+// BOSHDeployment manifest custom resources and start the rendering, which will
+// finally produce the "desired manifest", the instance group manifests and the BPM configs.
 func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "boshdeployment-reconciler", mgr.GetEventRecorderFor("boshdeployment-recorder"))
 	r := NewDeploymentReconciler(

--- a/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
+++ b/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
@@ -22,8 +22,8 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
 )
 
-// AddGeneratedVariable creates a new generated variable Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
+// AddGeneratedVariable creates a new generated variable controller to watch for the intermidiate "with-ops" manifest and
+// reconcile it into one ExtendedSecret for each explicit variable.
 func AddGeneratedVariable(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "generated-variable-reconciler", mgr.GetEventRecorderFor("generated-variable-recorder"))
 	r := NewGeneratedVariableReconciler(

--- a/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
+++ b/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
@@ -3,7 +3,6 @@ package boshdeployment
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -60,21 +59,7 @@ func AddGeneratedVariable(ctx context.Context, config *config.Config, mgr manage
 		},
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldSecret := e.ObjectOld.(*corev1.Secret)
-			newSecret := e.ObjectNew.(*corev1.Secret)
-			shouldProcessEvent := isManifestWithOps(newSecret.Name) && !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
-
-			if shouldProcessEvent {
-				ctxlog.NewPredicateEvent(newSecret).Debug(
-					ctx, e.MetaNew, bdv1.SecretReference,
-					fmt.Sprintf("Update predicate passed for %s, existing secret with the %s suffix has been updated",
-						e.MetaNew.GetName(), names.DeploymentSecretTypeManifestWithOps.String()),
-				)
-			}
-
-			return shouldProcessEvent
-		},
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
 	}
 
 	// This is a manifest with ops files secret that has changed.

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -37,6 +37,9 @@ const (
 	WebhookConfigDir = "/tmp"
 )
 
+// Theses funcs construct controllers and add them to the controller-runtime
+// manager. The manager will set fields on the controllers and start them, when
+// itself is started.
 var addToManagerFuncs = []func(context.Context, *config.Config, manager.Manager) error{
 	boshdeployment.AddDeployment,
 	boshdeployment.AddGeneratedVariable,

--- a/pkg/kube/controllers/extendedjob/errand_controller.go
+++ b/pkg/kube/controllers/extendedjob/errand_controller.go
@@ -25,8 +25,8 @@ import (
 	vss "code.cloudfoundry.org/cf-operator/pkg/kube/util/versionedsecretstore"
 )
 
-// AddErrand creates a new ExtendedJob controller to start errands when their
-// trigger strategy matches
+// AddErrand creates a new ExtendedJob controller to start errands, when their
+// trigger strategy matches 'now' or 'once', or their configuration changed.
 func AddErrand(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	f := controllerutil.SetControllerReference
 	ctx = ctxlog.NewContextWithRecorder(ctx, "ext-job-errand-reconciler", mgr.GetEventRecorderFor("ext-job-errand-recorder"))

--- a/pkg/kube/controllers/extendedjob/job_controller.go
+++ b/pkg/kube/controllers/extendedjob/job_controller.go
@@ -20,7 +20,8 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
 
-// AddJob creates a new ExtendedJob controller and adds it to the Manager
+// AddJob creates a new Job controller to collect the output from jobs, persist
+// that output as a secret and delete the k8s job afterwards.
 func AddJob(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	client, err := corev1client.NewForConfig(mgr.GetConfig())
 	if err != nil {

--- a/pkg/kube/controllers/extendedsecret/certificatesigningrequest_controller.go
+++ b/pkg/kube/controllers/extendedsecret/certificatesigningrequest_controller.go
@@ -19,7 +19,8 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
 
-// AddCertificateSigningRequest creates a new CertificateSigningRequest Controller and adds it to the Manager
+// AddCertificateSigningRequest creates a new CertificateSigningRequest controller to watch for new and changed
+// certificate signing request. Reconciliation will approve them and create a secret.
 func AddCertificateSigningRequest(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "csr-reconciler", mgr.GetEventRecorderFor("csr-recorder"))
 	certClient, err := certv1client.NewForConfig(mgr.GetConfig())

--- a/pkg/kube/controllers/extendedsecret/extendedsecret_controller.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_controller.go
@@ -22,7 +22,8 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
 
-// AddExtendedSecret creates a new ExtendedSecrets Controller and adds it to the Manager
+// AddExtendedSecret creates a new ExtendedSecrets controller to watch for the
+// custom resource and reconcile it into k8s secrets.
 func AddExtendedSecret(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "ext-secret-reconciler", mgr.GetEventRecorderFor("ext-secret-recorder"))
 	log := ctxlog.ExtractLogger(ctx)

--- a/pkg/kube/controllers/extendedstatefulset/extendedstatefulset_controller.go
+++ b/pkg/kube/controllers/extendedstatefulset/extendedstatefulset_controller.go
@@ -24,7 +24,8 @@ import (
 	vss "code.cloudfoundry.org/cf-operator/pkg/kube/util/versionedsecretstore"
 )
 
-// AddExtendedStatefulSet creates a new ExtendedStatefulSet controller and adds it to the Manager
+// AddExtendedStatefulSet creates a new ExtendedStatefulSet controller to watch for the custom resource and
+// reconcile it into statefulsets.
 func AddExtendedStatefulSet(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "ext-statefulset-reconciler", mgr.GetEventRecorderFor("ext-statefulset-recorder"))
 	store := vss.NewVersionedSecretStore(mgr.GetClient())

--- a/pkg/kube/controllers/extendedstatefulset/statefulset_cleanup_controller.go
+++ b/pkg/kube/controllers/extendedstatefulset/statefulset_cleanup_controller.go
@@ -17,7 +17,8 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
 )
 
-// AddStatefulSetCleanup creates a new statefulset cleanup controller and adds it to the Manager
+// AddStatefulSetCleanup creates a new statefulset cleanup controller and adds it to the manager.
+// The purpose of this controller is to delete the temporary statefulset used to keep the volumes alive.
 func AddStatefulSetCleanup(ctx context.Context, config *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContextWithRecorder(ctx, "statefulset-cleanup-reconciler", mgr.GetEventRecorderFor("statefulset-cleanup-recorder"))
 	r := NewStatefulSetCleanupReconciler(ctx, config, mgr)


### PR DESCRIPTION
BPM controller looks for IG manifests and BPM configs, both are
versioned secrets. Versioned secrets are not mutated, a new one with an
increased version (as part of the name) is created for every change.

Therefore it's not necessary to watch a versioned secret for updates. Unless they are 'user controlled' maybe?