### PR TITLE
Copy packages to shared volume and mount as /var/vcap/packages

### DIFF
--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -287,7 +287,7 @@ func containerRunCopier() corev1.Container {
 func jobSpecCopierContainer(releaseName string, jobImage string, volumeMountName string) corev1.Container {
 	inContainerReleasePath := filepath.Join(VolumeRenderingDataMountPath, "jobs-src", releaseName)
 	return corev1.Container{
-		Name:  names.Sanitize(fmt.Sprintf("spec-copier-%s", releaseName)),
+		Name:  names.Sanitize("spec-copier-%s", releaseName),
 		Image: jobImage,
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -397,7 +397,7 @@ func boshPreStartInitContainer(
 	securityContext.RunAsUser = &rootUserID
 
 	return corev1.Container{
-		Name:         names.Sanitize(fmt.Sprintf("bosh-pre-start-%s", jobName)),
+		Name:         names.Sanitize("bosh-pre-start-%s", jobName),
 		Image:        jobImage,
 		VolumeMounts: deduplicateVolumeMounts(volumeMounts),
 		Command:      []string{"/usr/bin/dumb-init", "--"},
@@ -438,7 +438,7 @@ func bpmPreStartInitContainer(
 	securityContext.RunAsUser = &rootUserID
 
 	return corev1.Container{
-		Name:         names.Sanitize(fmt.Sprintf("bpm-pre-start-%s", process.Name)),
+		Name:         names.Sanitize("bpm-pre-start-%s", process.Name),
 		Image:        jobImage,
 		VolumeMounts: deduplicateVolumeMounts(volumeMounts),
 		Command:      []string{"/usr/bin/dumb-init", "--"},
@@ -466,7 +466,7 @@ func bpmProcessContainer(
 	securityContext *corev1.SecurityContext,
 	postStart postStart,
 ) corev1.Container {
-	name := names.Sanitize(fmt.Sprintf("%s-%s", jobName, processName))
+	name := names.Sanitize("%s-%s", jobName, processName)
 
 	if securityContext == nil {
 		securityContext = &corev1.SecurityContext{}

--- a/pkg/bosh/converter/volume.go
+++ b/pkg/bosh/converter/volume.go
@@ -38,6 +38,11 @@ const (
 	// VolumeDataDirMountPath is the mount path for the ephemeral (data) directory.
 	VolumeDataDirMountPath = bdm.DataDir
 
+	// VolumePackagesDirName is the volume name for the packages directory.
+	VolumePackagesDirName = "packages-dir"
+	// VolumePackagesDirMountPath is the mount path for the ephemeral packages directory.
+	VolumePackagesDirMountPath = "/var/vcap/packages"
+
 	// VolumeSysDirName is the volume name for the sys directory.
 	VolumeSysDirName = "sys-dir"
 	// VolumeSysDirMountPath is the mount path for the sys directory.
@@ -87,6 +92,10 @@ func generateDefaultDisks(manifestName string, instanceGroup *bdm.InstanceGroup,
 			// https://bosh.io/docs/vm-config/#jobs-and-packages
 			Volume:      dataDirVolume(),
 			VolumeMount: dataDirVolumeMount(),
+		},
+		{
+			Volume:      packagesVolume(),
+			VolumeMount: packagesVolumeMount(),
 		},
 		{
 			Volume:      sysDirVolume(),

--- a/pkg/bosh/converter/volume.go
+++ b/pkg/bosh/converter/volume.go
@@ -193,7 +193,7 @@ func generateBPMDisks(manifestName string, instanceGroup *bdm.InstanceGroup, bpm
 			}
 
 			for i, unrestrictedVolume := range process.Unsafe.UnrestrictedVolumes {
-				volumeName := names.Sanitize(fmt.Sprintf("%s-%s-%s-%b", UnrestrictedVolumeBaseName, job.Name, process.Name, i))
+				volumeName := names.Sanitize("%s-%s-%s-%b", UnrestrictedVolumeBaseName, job.Name, process.Name, i)
 				unrestrictedDisk := BPMResourceDisk{
 					Volume: &corev1.Volume{
 						Name:         volumeName,
@@ -269,7 +269,7 @@ func generatePersistentVolumeClaim(manifestName string, instanceGroup *bdm.Insta
 	// Spec of a persistentVolumeClaim
 	persistentVolumeClaim := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.Sanitize(fmt.Sprintf("%s-%s-%s", manifestName, instanceGroup.Name, "pvc")),
+			Name:      names.Sanitize("%s-%s-%s", manifestName, instanceGroup.Name, "pvc"),
 			Namespace: namespace,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/bosh/converter/volume_factory.go
+++ b/pkg/bosh/converter/volume_factory.go
@@ -158,6 +158,22 @@ func dataDirVolumeMount() *corev1.VolumeMount {
 	}
 }
 
+func packagesVolume() *corev1.Volume {
+	return &corev1.Volume{
+		Name:         VolumePackagesDirName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+}
+
+func packagesVolumeMount() *corev1.VolumeMount {
+	return &corev1.VolumeMount{
+		Name:      VolumePackagesDirName,
+		MountPath: VolumePackagesDirMountPath,
+		// TODO: /var/vcap/packages should be read-only.
+		// ReadOnly:  true,
+	}
+}
+
 func sysDirVolume() *corev1.Volume {
 	return &corev1.Volume{
 		Name:         VolumeSysDirName,

--- a/pkg/kube/controllers/extendedstatefulset/pod_mutator.go
+++ b/pkg/kube/controllers/extendedstatefulset/pod_mutator.go
@@ -3,7 +3,6 @@ package extendedstatefulset
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -157,7 +156,7 @@ func (m *PodMutator) addVolumeSpec(pod *corev1.Pod, volumeClaimTemplatesMap map[
 			_, foundVolumeClaimTemplate := volumeClaimTemplatesMap[volumeMount.Name]
 			if foundVolumeClaimTemplate {
 				podOrdinal := names.OrdinalFromPodName(pod.GetName())
-				persistentVolumeClaim := names.Sanitize(fmt.Sprintf("%s-%s-%s-%d", volumeMount.Name, "volume-management", getNameWithOutVersion(statefulSet.Name, 1), podOrdinal))
+				persistentVolumeClaim := names.Sanitize("%s-%s-%s-%d", volumeMount.Name, "volume-management", getNameWithOutVersion(statefulSet.Name, 1), podOrdinal)
 
 				volume, foundVolume := volumeMap[volumeMount.Name]
 				if !foundVolume {

--- a/pkg/kube/util/names/names.go
+++ b/pkg/kube/util/names/names.go
@@ -97,8 +97,11 @@ func CalculateIGSecretPrefix(secretType DeploymentSecretType, deploymentName str
 
 var allowedKubeChars = regexp.MustCompile("[^-a-z0-9]*")
 
-// Sanitize produces valid k8s names, i.e. for containers: [a-z0-9]([-a-z0-9]*[a-z0-9])?
-func Sanitize(name string) string {
+// Sanitize produces valid k8s names, i.e. for containers: [a-z0-9]([-a-z0-9]*[a-z0-9])?. It has the
+// same signature as fmt.Sprintf and can be used to format strings according to the documentation of
+// the fmt package (https://godoc.org/fmt).
+func Sanitize(format string, a ...interface{}) string {
+	name := fmt.Sprintf(format, a...)
 	name = strings.Replace(name, "_", "-", -1)
 	name = strings.ToLower(name)
 	name = allowedKubeChars.ReplaceAllLiteralString(name, "")


### PR DESCRIPTION
For each release, an init container will copy the packages into a shared ephemeral volume that later gets mounted as `/var/vcap/packages` in the main containers.

It solves the problem of jobs using packages from other jobs in the same instance group and reduces the number of patches required on SCF to make buildpacks and smoke-tests work.