### PR TITLE
Patch webhooks instead of deleting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,19 @@ For more information about the `cf-operator` helm chart and how to configure it,
 
 ### Recovering from a crash
 
-If the operator pod crashes, it cannot be restarted in the same namespace before the existing mutating webhook configuration for that namespace is temporarily patched.
+If the operator pod crashes, it cannot be restarted in the same namespace before the existing mutating webhook configuration for that namespace is removed.
 The operator uses mutating webhooks to modify pods on the fly and Kubernetes fails to create pods if the webhook server is unreachable.
 The webhook configurations are installed cluster wide and don't belong to a single namespace, just like custom resources.
 
-To patch the webhook configurations for the cf-operator namespace run:
+To remove the webhook configurations for the cf-operator namespace run:
 
+```bash
+CF_OPERATOR_NAMESPACE=cf-operator
+kubectl delete mutatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
+kubectl delete validatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
+```
+
+From **Kubernetes 1.15** onwards, it is possible to instead patch the webhook configurations for the cf-operator namespace via:
 ```bash
 CF_OPERATOR_NAMESPACE=cf-operator
 kubectl patch mutatingwebhookconfigurations "cf-operator-hook-$CF_OPERATOR_NAMESPACE" -p '

--- a/README.md
+++ b/README.md
@@ -35,16 +35,24 @@ For more information about the `cf-operator` helm chart and how to configure it,
 
 ### Recovering from a crash
 
-If the operator pod crashes, it cannot be restarted in the same namespace before the existing mutating webhook configuration for that namespace is removed.
+If the operator pod crashes, it cannot be restarted in the same namespace before the existing mutating webhook configuration for that namespace is temporarily patched.
 The operator uses mutating webhooks to modify pods on the fly and Kubernetes fails to create pods if the webhook server is unreachable.
 The webhook configurations are installed cluster wide and don't belong to a single namespace, just like custom resources.
 
-To remove the webhook configurations for the cf-operator namespace run:
+To patch the webhook configurations for the cf-operator namespace run:
 
 ```bash
 CF_OPERATOR_NAMESPACE=cf-operator
-kubectl delete mutatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
-kubectl delete validatingwebhookconfiguration "cf-operator-hook-$CF_OPERATOR_NAMESPACE"
+kubectl patch mutatingwebhookconfigurations "cf-operator-hook-$CF_OPERATOR_NAMESPACE" -p '
+webhooks:
+- name: mutate-pods.fissile.cloudfoundry.org
+  objectSelector:
+    matchExpressions:
+    - key: name
+      operator: NotIn
+      values:
+      - "cf-operator"
+'
 ```
 
 ## Using your fresh installation


### PR DESCRIPTION
To avoid having to delete the webhooks after a crash, we tried to integrate an `objectSelector` which excludes the `cf-operator` pod from the `MutatingWebhook`. However, this is a larger change because it requires updating to a newer version of `k8s.io/apimachinery`. As a first step, we added it to the README as a patch.

Do you think adding an exception for cf-operator to the webhook is a good idea? If so, we could try to provide a PR that does this directly in the go-code. 