### PR TITLE
Switch operator to apply crds as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,11 @@ It's implemented as a k8s operator, an active controller component which acts up
 
 The `cf-operator` can be installed via `helm`. Make sure you have a running Kubernetes cluster and that tiller is reachable.
 
-Use this if you've never installed the operator before
+Use this if you've never installed the operator
 
 ```bash
 helm install --namespace cf-operator --name cf-operator https://cf-operators.s3.amazonaws.com/release/helm-charts/cf-operator-v0.4.0%2B1.g3d277af0.tgz
 ```
-
-Use this if the custom resources have already been created by a previous CF Operator installation
-
-```bash
-helm install --namespace cf-operator --name cf-operator https://cf-operators.s3.amazonaws.com/release/helm-charts/cf-operator-v0.4.0%2B1.g3d277af0.tgz --set "customResources.enableInstallation=false"
-````
 
 For more information about the `cf-operator` helm chart and how to configure it, please refer to [deploy/helm/cf-operator/README.md](deploy/helm/cf-operator/README.md)
 

--- a/bin/test-cli-e2e
+++ b/bin/test-cli-e2e
@@ -27,8 +27,4 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   kubectl create namespace "$TEST_NAMESPACE"
 fi
 
-bin/apply-crds
-
-kubectl get customresourcedefinitions
-
 ginkgo e2e/cli

--- a/bin/test-helm-e2e
+++ b/bin/test-helm-e2e
@@ -14,10 +14,6 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-# Add all required CRD´s
-bin/apply-crds
-kubectl get customresourcedefinitions
-
 # Build the required helm charts to run the cf-operator
 ./bin/build-helm
 

--- a/bin/test-helm-e2e-storage
+++ b/bin/test-helm-e2e-storage
@@ -14,10 +14,6 @@ if [ -z ${TEST_NAMESPACE+x} ]; then
   export TEST_NAMESPACE
 fi
 
-# Add all required CRD´s
-bin/apply-crds
-kubectl get customresourcedefinitions
-
 # Build the required helm charts to run the cf-operator
 ./bin/build-helm
 

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -21,7 +21,6 @@ echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests.log"
 setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
-bin/apply-crds
 
 kubectl get customresourcedefinitions
 

--- a/bin/test-integration-storage
+++ b/bin/test-integration-storage
@@ -21,8 +21,6 @@ echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests-*.log"
 setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
-bin/apply-crds
-
 kubectl get customresourcedefinitions
 
 # Build the required helm charts to run the cf-operator

--- a/bin/test-integration-subcmds
+++ b/bin/test-integration-subcmds
@@ -21,8 +21,6 @@ echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests-*.log"
 setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
-bin/apply-crds
-
 kubectl get customresourcedefinitions
 
 GOVER_FILE=${GOVER_FILE:-gover-integration.coverprofile}

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -144,7 +144,7 @@ func init() {
 	pf.Int("max-extendedjob-workers", 1, "Maximum of number concurrently running ExtendedJob controller")
 	pf.Int("max-extendedsecret-workers", 5, "Maximum of number concurrently running ExtendedSecret controller")
 	pf.Int("max-extendedstatefulset-workers", 1, "Maximum of number concurrently running ExtendedStatefulSet controller")
-	pf.Bool("apply-crd", false, "If true, apply CRDs on start")
+	pf.Bool("apply-crd", true, "If true, apply CRDs on start")
 	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
 	viper.BindPFlag("log-level", pf.Lookup("log-level"))
 	viper.BindPFlag("cf-operator-namespace", pf.Lookup("cf-operator-namespace"))

--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -12,8 +12,6 @@ To install the latest stable helm chart, with the `cf-operator` as the release n
 $ helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz
 ```
 
-
-
 ## Installing the chart from develop branch
 
 To install the helm chart directly from the [cf-operator repository](https://github.com/cloudfoundry-incubator/cf-operator) (any branch), the following parameters in the `values.yaml` need to be set in advance:
@@ -56,11 +54,6 @@ To delete the helm chart:
 $ helm delete cf-operator --purge
 ```
 
-__Note__: The Custom Resources defined in this chart, will not be deleted via `helm delete <release-name>`.
-If you will retrigger a helm installation of this chart, Kubernetes will complain that the CRD´s already exist.
-To avoid this issue, set the `customResources.enableInstallation` in the `values.yaml` to `false`.
-
-
 ## Configuration
 
 | Parameter                                         | Description                                                                       | Default                                        |
@@ -69,7 +62,6 @@ To avoid this issue, set the `customResources.enableInstallation` in the `values
 | `image.org`                                       | docker hub organization for the cf-operator image                                 | `cfcontainerization`                           |
 | `image.tag`                                       | docker image tag                                                                  | `foobar`                                       |
 | `image.pullPolicy`                                | Kubernetes image pullPolicy                                                       | `IfNotPresent`                                 |
-| `customResources.enableInstallation`              | Install cf-operator Custom Resources                                              | `true`                                         |
 | `rbacEnable`                                      | install required RBAC service account, roles and rolebindings                     | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name  | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`         |                                                |
@@ -93,12 +85,7 @@ The `cf-operator` watches four different types of custom resources:
 - ExtendedSecret
 - ExtendedStatefulset
 
-The `cf-operator` requires this CRD´s to be installed in the cluster, in order to work as expected. By default, the chart will install them in your cluster.
-To disable the installation of the custom resources:
-
-```bash
-$ helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz --set customResources.enableInstallation=false
-```
+The `cf-operator` requires this CRD´s to be installed in the cluster, in order to work as expected. By default, the `cf-operator` applies CRDs in your cluster automatically.
 
 To verify if the CRD´s are installed:
 

--- a/deploy/helm/cf-operator/templates/NOTES.txt
+++ b/deploy/helm/cf-operator/templates/NOTES.txt
@@ -1,6 +1,4 @@
-{{- $charI := (and (not .Release.IsInstall) .Values.customResources.createEtcdClusterCRD) -}}
-
-The {{ .Release.Name }} chart installed the following CRD´s:
+Running the operator will install the following CRD´s:
 
 - boshdeployments.fissile.cloudfoundry.org
 - extendedjobs.fissile.cloudfoundry.org

--- a/deploy/helm/cf-operator/templates/NOTES.txt
+++ b/deploy/helm/cf-operator/templates/NOTES.txt
@@ -1,5 +1,4 @@
 {{- $charI := (and (not .Release.IsInstall) .Values.customResources.createEtcdClusterCRD) -}}
-{{- if and .Release.IsInstall .Values.customResources.enableInstallation -}}
 
 The {{ .Release.Name }} chart installed the following CRD´s:
 
@@ -11,15 +10,6 @@ The {{ .Release.Name }} chart installed the following CRD´s:
 You can always verify if the CRD´s are installed, by running:
  $ kubectl get crds
 
-
-{{- else -}}
-
-The {{ .Release.Name }} chart, did not installed any CRD´s. Please, make sure the cf-operator CRD´s are in place.
-You can always verify if the CRD´s are installed, by running:
- $ kubectl get crds
-
-
-{{- end -}}
 
 
 {{- if and .Release.IsInstall }}

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -14,9 +14,6 @@ tolerations: []
 
 affinity: {}
 
-customResources:
-  enableInstallation: true
-
 rbacEnable: true
 
 serviceAccount:

--- a/dev-env-havener.yaml
+++ b/dev-env-havener.yaml
@@ -37,8 +37,6 @@ releases:
       tag: (( env DOCKER_IMAGE_TAG ))
       repository: (( env DOCKER_REPOSITORY ))
       org: (( env DOCKER_ORGANIZATION ))
-    customResources:
-      enableInstallation: (( env CRDS_ENABLED ))
 
 env:
   DOCKER_IMAGE_TAG: (( shell . bin/include/versioning && echo "${VERSION_TAG}" ))

--- a/docs/building.md
+++ b/docs/building.md
@@ -31,13 +31,7 @@ Follow this steps to build a proper docker image and generate a deployable helm 
 
     _**Note**_: This will automatically generate a docker image tag based on your current commit, tag and SHA.
 
-4. Apply Kubernetes Custom Resources
-
-    ```bash
-    bin/apply-crds
-    ```
-
-5. Generated helm charts with a proper docker image tag, org and repository
+4. Generated helm charts with a proper docker image tag, org and repository
 
     ```bash
     bin/build-helm
@@ -45,10 +39,10 @@ Follow this steps to build a proper docker image and generate a deployable helm 
 
     _**Note**_: This will generate a new directory under the base dir, named `helm/`
 
-6. Install the helm chart
+5. Install the helm chart(apply Kubernetes Custom Resources)
 
     ```bash
-    helm install --name cf-operator-test --namespace cf-operator-test helm/cf-operator --set customResources.enableInstallation=false
+    helm install --name cf-operator-test --namespace cf-operator-test helm/cf-operator
     ```
 
     _**Note**_: The cf-operator will be available under the `cf-operator-test` namespace, running as a pod.

--- a/docs/commands/cf-operator.md
+++ b/docs/commands/cf-operator.md
@@ -13,7 +13,7 @@ cf-operator [flags]
 ### Options
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
   -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
   -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")

--- a/docs/commands/cf-operator_util.md
+++ b/docs/commands/cf-operator_util.md
@@ -19,7 +19,7 @@ Calls a utility subcommand.
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
   -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
   -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")

--- a/docs/commands/cf-operator_util_bpm-configs.md
+++ b/docs/commands/cf-operator_util_bpm-configs.md
@@ -23,7 +23,7 @@ cf-operator util bpm-configs [flags]
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -b, --base-dir string                        (BASE_DIR) a path to the base directory
   -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")

--- a/docs/commands/cf-operator_util_instance-group.md
+++ b/docs/commands/cf-operator_util_instance-group.md
@@ -24,7 +24,7 @@ cf-operator util instance-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -b, --base-dir string                        (BASE_DIR) a path to the base directory
   -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")

--- a/docs/commands/cf-operator_util_template-render.md
+++ b/docs/commands/cf-operator_util_template-render.md
@@ -30,7 +30,7 @@ cf-operator util template-render [flags]
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -b, --base-dir string                        (BASE_DIR) a path to the base directory
   -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")

--- a/docs/commands/cf-operator_util_variable-interpolation.md
+++ b/docs/commands/cf-operator_util_variable-interpolation.md
@@ -24,7 +24,7 @@ cf-operator util variable-interpolation [flags]
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -b, --base-dir string                        (BASE_DIR) a path to the base directory
   -m, --bosh-manifest-path string              (BOSH_MANIFEST_PATH) path to the bosh manifest file
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")

--- a/docs/commands/cf-operator_version.md
+++ b/docs/commands/cf-operator_version.md
@@ -19,7 +19,7 @@ cf-operator version [flags]
 ### Options inherited from parent commands
 
 ```
-      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start
+      --apply-crd                              (APPLY_CRD) If true, apply CRDs on start (default true)
   -n, --cf-operator-namespace string           (CF_OPERATOR_NAMESPACE) Namespace to watch for BOSH deployments (default "default")
   -o, --docker-image-org string                (DOCKER_IMAGE_ORG) Dockerhub organization that provides the operator docker image (default "cfcontainerization")
   -r, --docker-image-repository string         (DOCKER_IMAGE_REPOSITORY) Dockerhub repository that provides the operator docker image (default "cf-operator")

--- a/docs/crds/fissile_v1alpha1_boshdeployment_crd.yaml
+++ b/docs/crds/fissile_v1alpha1_boshdeployment_crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.customResources.enableInstallation }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -49,4 +48,3 @@ spec:
                   name:
                     type: string
                     minLength: 1
-{{- end }}

--- a/docs/crds/fissile_v1alpha1_extendedjob_crd.yaml
+++ b/docs/crds/fissile_v1alpha1_extendedjob_crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.customResources.enableInstallation }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -62,4 +61,3 @@ spec:
               type: object
             updateOnConfigChange:
               type: boolean
-{{- end }}

--- a/docs/crds/fissile_v1alpha1_extendedsecret_crd.yaml
+++ b/docs/crds/fissile_v1alpha1_extendedsecret_crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.customResources.enableInstallation }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -20,4 +19,3 @@ spec:
   version: v1alpha1
   subresources:
     status: {}
-{{- end }}

--- a/docs/crds/fissile_v1alpha1_extendedstatefulset_crd.yaml
+++ b/docs/crds/fissile_v1alpha1_extendedstatefulset_crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.customResources.enableInstallation }}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -40,4 +39,3 @@ spec:
               description: "Indicates the availability zones that the ExtendedStatefulSet needs to span"
               items:
                 type: string
-{{- end }}

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,18 @@ Run with libraries fetched via go modules:
 export GO111MODULE=on
 ```
 
+## Custom Resource Definitions (CRDs)
+
+Kubernetes allows developers to extend the objects its APIs process and store using Custom Resource Definitions (CRDs). We are creating four [CRDs](../docs/crds): 
+
+- BOSHDeployment
+- ExtendedJob
+- ExtendedSecret
+- ExtendedStatefulSet
+
+The CRDs are also defined in code and applied automatically when cf-operator starts. If you are editing CRDs, you should update changes to this YAML files in sync.
+
+
 ## Creating a new Resource and Controller
 
 - create a new directory: `./pkg/kube/apis/<group_name>/<version>`
@@ -155,7 +167,6 @@ export GO111MODULE=on
 - add the new resource to `addToSchemes` in `pkg/controllers/controller.go`.
 - add the new controller to `addToManagerFuncs` in the same file.
 - create a custom resource definition in `deploy/helm/cf-operator/templates/`
-- add the custom resource definition to `bin/apply-crds`
 
 ### Reconcile Results
 

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -28,7 +28,7 @@ var _ = Describe("CLI", func() {
 			session, err := act("help")
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out).Should(Say(`Flags:
-      --apply-crd                              \(APPLY_CRD\) If true, apply CRDs on start
+      --apply-crd                              \(APPLY_CRD\) If true, apply CRDs on start \(default true\)
   -n, --cf-operator-namespace string           \(CF_OPERATOR_NAMESPACE\) Namespace to watch for BOSH deployments \(default "default"\)
   -o, --docker-image-org string                \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
   -r, --docker-image-repository string         \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)

--- a/e2e/kube/e2ehelper/e2e_helper.go
+++ b/e2e/kube/e2ehelper/e2e_helper.go
@@ -28,8 +28,6 @@ var (
 // being able to reach tiller, and eventually it
 // will install the cf-operator chart.
 func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error) {
-	var crdExist bool
-
 	// Ensure tiller is there, if not
 	// then create it, via "init"
 	err := testing.RunHelmBinaryWithCustomErr("version", "-s")
@@ -47,11 +45,6 @@ func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error
 		}
 	}
 
-	crdExist, err = ClusterCrdsExist()
-	if err != nil {
-		return "", nil, errors.Wrapf(err, "%s Checking cluster crd's existence failed.", e2eFailedMessage)
-	}
-
 	namespace, err = CreateTestNamespace()
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "%s Creating test namespace failed.", e2eFailedMessage)
@@ -63,7 +56,6 @@ func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error
 		"--name", fmt.Sprintf("%s-%s", testing.CFOperatorRelease, namespace),
 		"--namespace", namespace,
 		"--timeout", installTimeOutInSecs,
-		"--set", fmt.Sprintf("customResources.enableInstallation=%s", strconv.FormatBool(!crdExist)),
 		"--wait")
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "%s Helm install command failed.", e2eFailedMessage)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/go-test/deep v1.0.4
@@ -32,7 +31,7 @@ require (
 	github.com/onsi/gomega v1.6.0
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/prometheus/client_golang v0.9.4
+	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2


### PR DESCRIPTION
[#168259470](https://www.pivotaltracker.com/story/show/168259470)

* Removed `./bin/apply-crds` and CI applied same test scripts under `bin/`
* YAML CRD files still are kept in `docs`
* Updated doc about sync definitions