### PR TITLE
fix: kubectl v1.16 output format has changed, which breaks e2e-tests.

### DIFF
--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -201,7 +201,7 @@ func (k *Kubectl) checkPodTerminateLabelFilter(namespace string, labelName strin
 		return false, errors.Wrapf(err, "Kubectl get pod failed with label %s failed. %s", labelName, string(out))
 
 	}
-	if string(out) == "No resources found.\n" {
+	if strings.HasPrefix(string(out), "No resources found") {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
The output format of kubectl has changed in version 1.16
from
```bash
$ kubectl get pods -n $NAMESPACE
No resources found.
```
to
```bash
$ kubectl get pods -n $NAMESPACE
No resources found in $NAMESPACE namespace.
```

This broke the `test-helm-e2e` make target.
Our changes replaces the equality check with a `HasPrefix` match.