### PR TITLE
Add error for invalid cf-operator docker image reference

### DIFF
--- a/bin/test-integration-storage
+++ b/bin/test-integration-storage
@@ -21,10 +21,8 @@ echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests-*.log"
 setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
-kubectl get customresourcedefinitions
 
-# Build the required helm charts to run the cf-operator
-./bin/build-helm
+kubectl get customresourcedefinitions
 
 GOVER_FILE=${GOVER_FILE:-gover-integration.coverprofile}
 
@@ -44,7 +42,7 @@ fi
 
 NODES=${NODES:-3}
 FLAKE_ATTEMPTS=${FLAKE_ATTEMPTS:-3}
-ginkgo \
+ginkgo ${FOCUS:+ --focus "$FOCUS"} \
   --randomizeAllSpecs \
   --nodes="$NODES" \
   --slowSpecThreshold=50 \

--- a/bin/tools
+++ b/bin/tools
@@ -1,6 +1,9 @@
 #!/bin/bash
-set -e
+export GO111MODULE=on
 
+pushd ~
 go get -u golang.org/x/lint/golint
 go get -u github.com/maxbrunsfeld/counterfeiter
 go get -u github.com/onsi/ginkgo/ginkgo
+go get -u honnef.co/go/tools/...
+popd

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	cfFailedMessage = "cf-operator command failed."
 	// Port on which the controller-runtime manager listens
 	managerPort = 2999
 )
@@ -36,6 +35,10 @@ var (
 	log              *zap.SugaredLogger
 	debugGracePeriod = time.Second * 5
 )
+
+func wrapError(err error, msg string) error {
+	return errors.Wrap(err, "cf-operator command failed. "+msg)
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "cf-operator",
@@ -46,10 +49,10 @@ var rootCmd = &cobra.Command{
 
 		restConfig, err := kubeConfig.NewGetter(log).Get(viper.GetString("kubeconfig"))
 		if err != nil {
-			return errors.Wrapf(err, "%s Couldn't fetch Kubeconfig. Ensure kubeconfig is present to continue.", cfFailedMessage)
+			return wrapError(err, "Couldn't fetch Kubeconfig. Ensure kubeconfig is present to continue.")
 		}
 		if err := kubeConfig.NewChecker(log).Check(restConfig); err != nil {
-			return errors.Wrapf(err, "%s Couldn't check Kubeconfig. Ensure kubeconfig is correct to continue.", cfFailedMessage)
+			return wrapError(err, "Couldn't check Kubeconfig. Ensure kubeconfig is correct to continue.")
 		}
 
 		cfOperatorNamespace := viper.GetString("cf-operator-namespace")
@@ -60,7 +63,7 @@ var rootCmd = &cobra.Command{
 			viper.GetString("docker-image-tag"),
 		)
 		if err != nil {
-			return errors.Wrapf(err, "%s Couldn't parse cf-operator docker image reference.", cfFailedMessage)
+			return wrapError(err, "Couldn't parse cf-operator docker image reference.")
 		}
 
 		log.Infof("Starting cf-operator %s with namespace %s", version.Version, cfOperatorNamespace)
@@ -72,7 +75,7 @@ var rootCmd = &cobra.Command{
 		provider := viper.GetString("provider")
 
 		if serviceHost == "" && provider == "" {
-			log.Fatalf("%s operator-webhook-service-host flag is not set (env variable: CF_OPERATOR_WEBHOOK_SERVICE_HOST).", cfFailedMessage)
+			return wrapError(errors.New("couldn't determine webhook server"), "operator-webhook-service-host flag is not set (env variable: CF_OPERATOR_WEBHOOK_SERVICE_HOST)")
 		}
 
 		config := config.NewConfig(
@@ -93,7 +96,7 @@ var rootCmd = &cobra.Command{
 			ctxlog.Info(ctx, "Applying CRDs...")
 			err := operator.ApplyCRDs(restConfig)
 			if err != nil {
-				return errors.Wrap(err, "failed to apply crds")
+				return wrapError(err, "Couldn't apply CRDs.")
 			}
 		}
 
@@ -105,14 +108,14 @@ var rootCmd = &cobra.Command{
 			Host:               "0.0.0.0",
 		})
 		if err != nil {
-			return errors.Wrapf(err, cfFailedMessage)
+			return wrapError(err, "Failed to create new manager.")
 		}
 
 		ctxlog.Info(ctx, "Waiting for configurations to be applied into a BOSHDeployment resource...")
 
 		err = mgr.Start(signals.SetupSignalHandler())
 		if err != nil {
-			return errors.Wrapf(err, "%s Failed to start cf-operator manager", cfFailedMessage)
+			return wrapError(err, "Failed to start cf-operator manager.")
 		}
 		return nil
 	},

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -53,11 +53,15 @@ var rootCmd = &cobra.Command{
 		}
 
 		cfOperatorNamespace := viper.GetString("cf-operator-namespace")
-		converter.SetupOperatorDockerImage(
+
+		err = converter.SetupOperatorDockerImage(
 			viper.GetString("docker-image-org"),
 			viper.GetString("docker-image-repository"),
 			viper.GetString("docker-image-tag"),
 		)
+		if err != nil {
+			return errors.Wrapf(err, "%s Couldn't parse cf-operator docker image reference.", cfFailedMessage)
+		}
 
 		log.Infof("Starting cf-operator %s with namespace %s", version.Version, cfOperatorNamespace)
 		log.Infof("cf-operator docker image: %s", converter.GetOperatorDockerImage())

--- a/e2e/kube/e2ehelper/e2e_helper.go
+++ b/e2e/kube/e2ehelper/e2e_helper.go
@@ -10,7 +10,6 @@ import (
 	"github.com/onsi/ginkgo/config"
 	"github.com/pkg/errors"
 
-	"code.cloudfoundry.org/cf-operator/integration/environment"
 	"code.cloudfoundry.org/cf-operator/testing"
 )
 
@@ -24,10 +23,13 @@ var (
 	namespace string
 )
 
+// TearDownFunc tears down the resource
+type TearDownFunc func() error
+
 // SetUpEnvironment ensures helm binary can run,
 // being able to reach tiller, and eventually it
 // will install the cf-operator chart.
-func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error) {
+func SetUpEnvironment(chartPath string) (string, TearDownFunc, error) {
 	// Ensure tiller is there, if not
 	// then create it, via "init"
 	err := testing.RunHelmBinaryWithCustomErr("version", "-s")
@@ -62,7 +64,7 @@ func SetUpEnvironment(chartPath string) (string, environment.TearDownFunc, error
 	}
 
 	// Add sleep for workaround for CI timeouts
-	time.Sleep(10* time.Second)
+	time.Sleep(10 * time.Second)
 
 	teardownFunc := func() error {
 		var messages string

--- a/e2e/kube/storage/suite_test.go
+++ b/e2e/kube/storage/suite_test.go
@@ -10,8 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"code.cloudfoundry.org/cf-operator/integration/environment"
 )
 
 func TestKubeStorage(t *testing.T) {
@@ -20,7 +18,7 @@ func TestKubeStorage(t *testing.T) {
 }
 
 var (
-	nsTeardown environment.TearDownFunc
+	nsTeardown e2ehelper.TearDownFunc
 	namespace  string
 )
 

--- a/e2e/kube/suite_test.go
+++ b/e2e/kube/suite_test.go
@@ -10,12 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"code.cloudfoundry.org/cf-operator/e2e/kube/e2ehelper"
-	"code.cloudfoundry.org/cf-operator/integration/environment"
 )
 
 var (
 	nsIndex   int
-	teardown  environment.TearDownFunc
+	teardown  e2ehelper.TearDownFunc
 	namespace string
 )
 

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
@@ -103,8 +101,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
-github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -341,10 +337,6 @@ k8s.io/kube-openapi v0.0.0-20190510232812-a01b7d5d6c22 h1:f0BTap/vrgs21vVbJ1ySds
 k8s.io/kube-openapi v0.0.0-20190510232812-a01b7d5d6c22/go.mod h1:iU+ZGYsNlvU9XKUSso6SQfKTCCw7lFduMZy26Mgr2Fw=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 h1:VBM/0P5TWxwk+Nw6Z+lAw3DKgO76g90ETOiA6rfLV1Y=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-sigs.k8s.io/controller-runtime v0.2.0 h1:5gL30PXOisGZl+Osi4CmLhvMUj77BO3wJeouKF2va50=
-sigs.k8s.io/controller-runtime v0.2.0/go.mod h1:ZHqrRDZi3f6BzONcvlUxkqCKgwasGk5FZrnSv9TVZF4=
-sigs.k8s.io/controller-runtime v0.2.1 h1:XwUV7gwU/2Uerl9Vb5TpoA3wMQgOxI/LdLq8UhkSSRA=
-sigs.k8s.io/controller-runtime v0.2.1/go.mod h1:9dyohw3ZtoXQuV1e766PHUn+cmrRCIcBh6XIMFNMZ+I=
 sigs.k8s.io/controller-runtime v0.2.2 h1:JT/vJJhUjjL9NZNwnm8AXmqCBUXSCFKmTaNjwDi28N0=
 sigs.k8s.io/controller-runtime v0.2.2/go.mod h1:9dyohw3ZtoXQuV1e766PHUn+cmrRCIcBh6XIMFNMZ+I=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -198,7 +198,8 @@ func (e *Environment) startKubeClients(kubeConfig *rest.Config) (err error) {
 	return
 }
 
-func (e *Environment) setupCFOperator(namespace string) (err error) {
+func (e *Environment) setupCFOperator(namespace string) error {
+	var err error
 	whh, found := os.LookupEnv("CF_OPERATOR_WEBHOOK_SERVICE_HOST")
 	if !found {
 		return errors.Errorf("Please set CF_OPERATOR_WEBHOOK_SERVICE_HOST to the host/ip the operator runs on and try again")
@@ -246,7 +247,10 @@ func (e *Environment) setupCFOperator(namespace string) (err error) {
 		return errors.Errorf("required environment variable DOCKER_IMAGE_TAG not set")
 	}
 
-	converter.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag)
+	err = converter.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag)
+	if err != nil {
+		return err
+	}
 
 	loggerPath := helper.LogfilePath(fmt.Sprintf("cf-operator-tests-%d.log", e.ID))
 	e.ObservedLogs, e.Log = helper.NewTestLoggerWithPath(loggerPath)
@@ -261,7 +265,7 @@ func (e *Environment) setupCFOperator(namespace string) (err error) {
 		Host:               "0.0.0.0",
 	})
 
-	return
+	return err
 }
 
 func (e *Environment) startOperator() chan struct{} {

--- a/integration/storage/suite_test.go
+++ b/integration/storage/suite_test.go
@@ -37,5 +37,9 @@ var _ = AfterSuite(func() {
 		if err != nil {
 			fmt.Printf("WARNING: failed to delete namespace %s: %v\n", namespace, err)
 		}
+		err = cmdHelper.DeleteWebhooks(namespace)
+		if err != nil {
+			fmt.Printf("WARNING: failed to delete mutatingwebhookconfiguration in %s: %v\n", namespace, err)
+		}
 	}
 })

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,6 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter/fakes"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/disk"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
-	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
 	essv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedstatefulset/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util"
@@ -107,7 +107,7 @@ var _ = Describe("kube converter", func() {
 				})
 
 				It("converts the instance group to an ExtendedJob when this the lifecycle is set to auto-errand", func() {
-					m.InstanceGroups[0].LifeCycle = bdm.IGTypeAutoErrand
+					m.InstanceGroups[0].LifeCycle = manifest.IGTypeAutoErrand
 					resources, err := act(bpmConfigs[0], m.InstanceGroups[0])
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(resources.Errands).To(HaveLen(1))

--- a/pkg/bosh/converter/docker_image.go
+++ b/pkg/bosh/converter/docker_image.go
@@ -1,34 +1,17 @@
 package converter
 
-// DockerSource describes a docker image on docker hub
-type DockerSource struct {
-	// Organization is the organization which provides the operator image
-	Organization string
-	// Repository is the repository which provides the operator image
-	Repository string
-	// Tag is the tag of the operator image
-	Tag string
-}
+import "code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
 
-// GetName returns the name of the docker image
-// More info: https://kubernetes.io/docs/concepts/containers/images
-func (d DockerSource) GetName() string {
-	return d.Organization + "/" + d.Repository + ":" + d.Tag
-}
-
-// OperatorDockerImage is the location of the operators own docker image
-var OperatorDockerImage = &DockerSource{}
+// operatorDockerImage is the location of the operators own docker image
+var operatorDockerImage = ""
 
 // SetupOperatorDockerImage initializes the package scoped variable
-func SetupOperatorDockerImage(org, repo, tag string) {
-	OperatorDockerImage = &DockerSource{
-		Organization: org,
-		Repository:   repo,
-		Tag:          tag,
-	}
+func SetupOperatorDockerImage(org, repo, tag string) (err error) {
+	operatorDockerImage, err = names.GetDockerSourceName(org, repo, tag)
+	return err
 }
 
 // GetOperatorDockerImage returns the image name of the operator docker image
 func GetOperatorDockerImage() string {
-	return OperatorDockerImage.GetName()
+	return operatorDockerImage
 }

--- a/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
+++ b/pkg/kube/controllers/extendedsecret/extendedsecret_reconciler_test.go
@@ -23,7 +23,6 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/client/clientset/versioned/scheme"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers"
 	escontroller "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/extendedsecret"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
 	cfakes "code.cloudfoundry.org/cf-operator/pkg/kube/controllers/fakes"
 	cfcfg "code.cloudfoundry.org/cf-operator/pkg/kube/util/config"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util/ctxlog"
@@ -72,7 +71,7 @@ var _ = Describe("ReconcileExtendedSecret", func() {
 			}
 			return nil
 		})
-		client.StatusCalls(func() crc.StatusWriter { return &fakes.FakeStatusWriter{} })
+		client.StatusCalls(func() crc.StatusWriter { return &cfakes.FakeStatusWriter{} })
 		manager.GetClientReturns(client)
 	})
 

--- a/pkg/kube/operator/operator_test.go
+++ b/pkg/kube/operator/operator_test.go
@@ -9,7 +9,8 @@ import (
 var _ = Describe("operator", func() {
 	Describe("GetOperatorDockerImage", func() {
 		It("returns the location of the docker image", func() {
-			converter.SetupOperatorDockerImage("foo", "bar", "1.2.3")
+			err := converter.SetupOperatorDockerImage("foo", "bar", "1.2.3")
+			Expect(err).ToNot(HaveOccurred())
 			Expect(converter.GetOperatorDockerImage()).To(Equal("foo/bar:1.2.3"))
 		})
 	})

--- a/pkg/kube/util/names/docker_source.go
+++ b/pkg/kube/util/names/docker_source.go
@@ -1,0 +1,27 @@
+package names
+
+import (
+	"errors"
+	"path"
+)
+
+// GetDockerSourceName returns the name of the docker image
+// More info:
+//   * https://kubernetes.io/docs/concepts/containers/images
+//   * <hub-user>/<repo-name>[:<tag>]
+//   * ACCOUNT.dkr.ecr.REGION.amazonaws.com/imagename:tag
+//
+// prefix: [<host>[:<port>]/][<org>/]
+// repo: <name>
+// tag :[:<tag>]
+func GetDockerSourceName(prefix, repo, tag string) (string, error) {
+	source := ""
+	if repo == "" {
+		return "", errors.New("repository is mandatory")
+	}
+	source = path.Join(prefix, repo)
+	if tag != "" {
+		source = source + ":" + tag
+	}
+	return source, nil
+}

--- a/pkg/kube/util/names/docker_source_test.go
+++ b/pkg/kube/util/names/docker_source_test.go
@@ -1,0 +1,57 @@
+package names_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
+)
+
+var _ = Describe("DockerSource", func() {
+	type test struct {
+		org    string
+		repo   string
+		tag    string
+		result string
+	}
+
+	Context("GetName", func() {
+		Context("when name is valid", func() {
+			tests := []test{
+				{org: "cfcontainerization", repo: "cf-operator", tag: "0.1-dev",
+					result: "cfcontainerization/cf-operator:0.1-dev"},
+				{org: "cfcontainerization", repo: "cf-operator",
+					result: "cfcontainerization/cf-operator"},
+				{org: "", repo: "cf-operator", tag: "0.1-dev",
+					result: "cf-operator:0.1-dev"},
+				{org: "", repo: "cf-operator",
+					result: "cf-operator"},
+			}
+
+			It("produces valid docker image sources", func() {
+				for _, t := range tests {
+					name, err := GetDockerSourceName(t.org, t.repo, t.tag)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(name).To(Equal(t.result), fmt.Sprintf("%#v", t))
+				}
+			})
+		})
+
+		Context("when name is invalid", func() {
+			tests := []test{
+				{org: "", repo: "", tag: "0.1-dev"},
+				{org: "fake-org", repo: "", tag: "0.1-dev"},
+				{org: "fake-org", repo: ""},
+			}
+
+			It("returns an error", func() {
+				for _, t := range tests {
+					_, err := GetDockerSourceName(t.org, t.repo, t.tag)
+					Expect(err).To(HaveOccurred())
+				}
+			})
+		})
+	})
+})

--- a/pkg/testhelper/fake_client_call_queue.go
+++ b/pkg/testhelper/fake_client_call_queue.go
@@ -9,15 +9,19 @@ import (
 
 type expectFunc func(context.Context, runtime.Object) error
 
+// CallQueue represents a list of expected function calls
 type CallQueue struct {
 	n     int
 	calls []expectFunc
 }
 
+// NewCallQueue returns a new list of expected functions
 func NewCallQueue(funcs ...expectFunc) CallQueue {
 	return CallQueue{calls: funcs}
 }
 
+// Calls can be used with counterfeiters *Calls functions
+// to set the stub functions
 func (q *CallQueue) Calls(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 	n := q.n
 	if n >= len(q.calls) {


### PR DESCRIPTION
When the command line args for cf-operators docker image source are invalid, throw an error.

Also some clean ups, which I needed to get `make test` run locally. 

[#167509239](https://www.pivotaltracker.com/story/show/167509239)