### PR TITLE
rename ops-foo -> ops-scale in boshdeployment examples

### DIFF
--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
@@ -44,7 +44,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ops-foo
+  name: ops-scale
 data:
   ops: |
     - type: replace
@@ -60,5 +60,5 @@ spec:
     name: nats-manifest
     type: configmap
   ops:
-  - name: ops-foo
+  - name: ops-scale
     type: configmap

--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
@@ -39,7 +39,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ops-foo
+  name: ops-scale
 data:
   ops: |
     - type: replace
@@ -55,5 +55,5 @@ spec:
     name: nats-manifest
     type: configmap
   ops:
-  - name: ops-foo
+  - name: ops-scale
     type: configmap

--- a/docs/examples/bosh-deployment/boshdeployment-with-persistent-disk.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-persistent-disk.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ops-foo
+  name: ops-scale
 data:
   ops: |
     - type: replace
@@ -61,5 +61,5 @@ spec:
     name: nats-manifest
     type: configmap
   ops:
-  - name: ops-foo
+  - name: ops-scale
     type: configmap

--- a/docs/examples/bosh-deployment/boshdeployment.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ops-foo
+  name: ops-scale
 data:
   ops: |
     - type: replace
@@ -55,5 +55,5 @@ spec:
     name: nats-manifest
     type: configmap
   ops:
-  - name: ops-foo
+  - name: ops-scale
     type: configmap


### PR DESCRIPTION
Whilst the internal operator name can be anything, let's give it a meaningful name.