### PR TITLE
Bosh dns core dns

### DIFF
--- a/cmd/internal/bpm_configs.go
+++ b/cmd/internal/bpm_configs.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,6 +32,16 @@ instance group.
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		defer func() {
 			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Sleeping ...\n")
+				time.Sleep(debugGracePeriod)
+			}
+		}()
+
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Fprintf(os.Stderr, "Recovered in f: %v\n%s\n", r, string(debug.Stack()))
+				fmt.Fprintf(os.Stderr, "Sleeping ...\n")
 				time.Sleep(debugGracePeriod)
 			}
 		}()

--- a/cmd/internal/bpm_configs.go
+++ b/cmd/internal/bpm_configs.go
@@ -31,16 +31,11 @@ instance group.
 `,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("recovered in f: %v\n%s", r, string(debug.Stack()))
+			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				fmt.Fprintf(os.Stderr, "Sleeping ...\n")
-				time.Sleep(debugGracePeriod)
-			}
-		}()
-
-		defer func() {
-			if r := recover(); r != nil {
-				fmt.Fprintf(os.Stderr, "Recovered in f: %v\n%s\n", r, string(debug.Stack()))
 				fmt.Fprintf(os.Stderr, "Sleeping ...\n")
 				time.Sleep(debugGracePeriod)
 			}

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+
 	"github.com/go-logr/zapr"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -70,6 +72,8 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return wrapError(err, "Couldn't parse cf-operator docker image reference.")
 		}
+
+		manifest.SetupBoshDNSDockerImage(viper.GetString("bosh-dns-docker-image"))
 
 		log.Infof("Starting cf-operator %s with namespace %s", version.Version, watchNamespace)
 		log.Infof("cf-operator docker image: %s", converter.GetOperatorDockerImage())
@@ -151,6 +155,7 @@ func init() {
 	pf.StringP("docker-image-org", "o", "cfcontainerization", "Dockerhub organization that provides the operator docker image")
 	pf.StringP("docker-image-repository", "r", "cf-operator", "Dockerhub repository that provides the operator docker image")
 	pf.StringP("docker-image-tag", "t", version.Version, "Tag of the operator docker image")
+	pf.StringP("bosh-dns-docker-image", "", "coredns/coredns:1.6.3", "The docker image used for emulating bosh DNS (a CoreDNS image)")
 	pf.StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
 	pf.StringP("log-level", "l", "debug", "Only print log messages from this level onward")
 	pf.Int("max-boshdeployment-workers", 1, "Maximum number of workers concurrently running BOSHDeployment controller")
@@ -168,6 +173,7 @@ func init() {
 	viper.BindPFlag("docker-image-org", pf.Lookup("docker-image-org"))
 	viper.BindPFlag("docker-image-repository", pf.Lookup("docker-image-repository"))
 	viper.BindPFlag("docker-image-tag", rootCmd.PersistentFlags().Lookup("docker-image-tag"))
+	viper.BindPFlag("bosh-dns-docker-image", rootCmd.PersistentFlags().Lookup("bosh-dns-docker-image"))
 	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
 	viper.BindPFlag("log-level", pf.Lookup("log-level"))
 	viper.BindPFlag("max-boshdeployment-workers", pf.Lookup("max-boshdeployment-workers"))
@@ -186,6 +192,7 @@ func init() {
 		"docker-image-org":                       "DOCKER_IMAGE_ORG",
 		"docker-image-repository":                "DOCKER_IMAGE_REPOSITORY",
 		"docker-image-tag":                       "DOCKER_IMAGE_TAG",
+		"bosh-dns-docker-image":                  "BOSH_DNS_DOCKER_IMAGE",
 		"kubeconfig":                             "KUBECONFIG",
 		"log-level":                              "LOG_LEVEL",
 		"max-boshdeployment-workers":             "MAX_BOSHDEPLOYMENT_WORKERS",

--- a/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
@@ -20,6 +20,13 @@ data:
       - name: bosh-dns-aliases
         properties:
           aliases:
+            - domain: myalias.service.cf.internal
+              targets:
+                - deployment: cf
+                  domain: bosh
+                  instance_group: nats
+                  network: default
+                  query: _
             - domain: nats.service.cf.internal
               targets:
                 - deployment: cf

--- a/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-manifest
+data:
+  manifest: |
+    ---
+    name: nats-manifest
+    releases:
+    - name: nats
+      version: "26"
+      url: docker.io/cfcontainerization
+      stemcell:
+        os: opensuse-42.3
+        version: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+    addons:
+    - name: bosh-dns-aliases
+      jobs:
+      - name: bosh-dns-aliases
+        properties:
+          aliases:
+            - domain: nats.service.cf.internal
+              targets:
+                - deployment: cf
+                  domain: bosh
+                  instance_group: nats
+                  network: default
+                  query: _
+    instance_groups:
+    - name: nats
+      instances: 1
+      jobs:
+      - name: nats
+        release: nats
+        properties:
+          nats:
+            user: admin
+            password: "test"
+          quarks:
+            ports:
+            - name: "nats"
+              protocol: "TCP"
+              internal: 4222
+            - name: "nats-routes"
+              protocol: TCP
+              internal: 4223
+---
+apiVersion: fissile.cloudfoundry.org/v1alpha1
+kind: BOSHDeployment
+metadata:
+  name: nats-deployment
+spec:
+  manifest:
+    name: nats-manifest
+    type: configmap

--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -26,6 +26,7 @@
     - [Persistent Disks](#Persistent-Disks)
     - [Manual ("implicit") variables](#Manual-%22implicit%22-variables)
     - [Pre_render_scripts](#Pre_render_scripts)
+    - [BOSH DNS](#BOSH-DNS)
   - [Flow](#Flow)
   - [Naming Conventions](#Naming-Conventions)
 
@@ -572,6 +573,29 @@ instance_groups:
             touch /tmp
 
 ```
+
+### BOSH DNS
+
+The BOSH DNS addon is implemented using a separate DNS server (coredns). For each BOSHDeployment, which enables this addon, an additional DNS server is created within the namespace.
+This DNS server rewrites all BOSH dns requests to standard k8s queries (e.g. `api.service.cf.internal` -> `api.<namespace>.svc.cluster.local`) and forwards them to the k8s DNS server. 
+All pods created from the BOSHDeployment are configured to use this DNS server.
+
+Additionally the headless services are created on base of the specified aliases. The following alias
+
+```yaml
+  - domain: blobstore.service.cf.internal
+    targets:
+    - deployment: cf
+      domain: bosh
+      instance_group: singleton-blobstore
+      network: default
+      query: '*'
+```
+
+will create a headless service with the name `blobstore` instead of `<deployment-name>-singleton-blobstore`.
+
+For migration purpose, the DNS service does also a rewrite of all previous headless service names 
+(e.g. `<deployment-name>-singleton-blobstore` is rewritten to `blobstore.<namespace>.svc.cluster.local`).
 
 
 ## Flow

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -29,6 +29,7 @@ var _ = Describe("CLI", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session.Out).Should(Say(`Flags:
       --apply-crd                                \(APPLY_CRD\) If true, apply CRDs on start \(default true\)
+      --bosh-dns-docker-image string             \(BOSH_DNS_DOCKER_IMAGE\) The docker image used for emulating bosh DNS \(a CoreDNS image\) \(default "coredns/coredns:\d+.\d+.\d+"\)
   -n, --cf-operator-namespace string             \(CF_OPERATOR_NAMESPACE\) The operator namespace \(default "default"\)
       --ctx-timeout int                          \(CTX_TIMEOUT\) context timeout for each k8s API request in seconds \(default 30\)
   -o, --docker-image-org string                  \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)

--- a/e2e/kube/examples_count_test.go
+++ b/e2e/kube/examples_count_test.go
@@ -19,6 +19,6 @@ var _ = Describe("Examples Directory Files", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		// If this testcase fails that means a test case is missing for an example in the docs folder
-		Expect(countFile).To(Equal(27))
+		Expect(countFile).To(Equal(28))
 	})
 })

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -331,7 +331,7 @@ var _ = Describe("Examples Directory", func() {
 			example = "bosh-deployment/boshdeployment-with-bosh-dns.yaml"
 		})
 
-		It("resolves bosh and k8s domains", func() {
+		It("resolves bosh domains", func() {
 			By("Getting expected IP")
 			podName := "nats-deployment-nats-v1-0"
 			podWait(fmt.Sprintf("pod/%s", podName))
@@ -341,10 +341,6 @@ var _ = Describe("Examples Directory", func() {
 
 			By("DNS lookup")
 			resolvableNames := []string{
-				fmt.Sprintf("myalias.%s.svc.cluster.local", namespace),
-				fmt.Sprintf("myalias.%s.svc.cluster.local.", namespace),
-				fmt.Sprintf("myalias.%s.svc", namespace),
-				fmt.Sprintf("myalias.%s", namespace),
 				fmt.Sprintf("nats-deployment-nats.%s", namespace),
 				fmt.Sprintf("nats-deployment-nats.%s.svc", namespace),
 				fmt.Sprintf("nats-deployment-nats.%s.svc.cluster.local", namespace),
@@ -354,7 +350,8 @@ var _ = Describe("Examples Directory", func() {
 				"nats",
 				"nats.service.cf.internal",
 				"nats.service.cf.internal.",
-				"nats-deployment-nats"}
+				"nats-deployment-nats",
+			}
 
 			for _, name := range resolvableNames {
 				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), ip)
@@ -366,9 +363,7 @@ var _ = Describe("Examples Directory", func() {
 			unresolvableNames := []string{
 				"myalias.",
 				"myalias.service.",
-				fmt.Sprintf("myalias.%s.svc.cluster", namespace),
-				fmt.Sprintf("myalias.%s.svc.cluster.", namespace),
-				fmt.Sprintf("myalias.%s.svc.", namespace)}
+			}
 
 			for _, name := range unresolvableNames {
 				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s || true", name), "NXDOMAIN")

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -356,7 +356,7 @@ var _ = Describe("Examples Directory", func() {
 				"nats-deployment-nats"}
 
 			for _, name := range resolvableNames {
-				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), ip)
+				err = kubectl.RunCommandOnceWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), ip)
 				Expect(err).ToNot(HaveOccurred())
 
 			}
@@ -369,9 +369,8 @@ var _ = Describe("Examples Directory", func() {
 				addNamespace("myalias.%s.svc.")}
 
 			for _, name := range unresolvableNames {
-				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), "NXDOMAIN")
-				Expect(err).ToNot(HaveOccurred())
-
+				err = kubectl.RunCommandOnceWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), ip)
+				Expect(err).To(HaveOccurred()) //TODO right now, this fails because nslookup has a returncode != 0, this is not exactly what we want to check
 			}
 		})
 	})

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -54,10 +54,10 @@ var _ = Describe("Examples Directory", func() {
 			podWait("pod/example-extendedstatefulset-v2-1")
 
 			By("Checking the updated value in the env")
-			err = kubectl.RunCommandWithCheckString(namespace, "example-extendedstatefulset-v2-0", []string{"env"}, "SPECIAL_KEY=value1Updated")
+			err = kubectl.RunCommandWithCheckString(namespace, "example-extendedstatefulset-v2-0", "env", "SPECIAL_KEY=value1Updated")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = kubectl.RunCommandWithCheckString(namespace, "example-extendedstatefulset-v2-1", []string{"env"}, "SPECIAL_KEY=value1Updated")
+			err = kubectl.RunCommandWithCheckString(namespace, "example-extendedstatefulset-v2-1", "env", "SPECIAL_KEY=value1Updated")
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -357,7 +357,7 @@ var _ = Describe("Examples Directory", func() {
 				"nats-deployment-nats"}
 
 			for _, name := range resolvableNames {
-				err = kubectl.RunCommandWithCheckString(namespace, podName, []string{"nslookup", name}, ip)
+				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), ip)
 				Expect(err).ToNot(HaveOccurred())
 
 			}
@@ -371,7 +371,7 @@ var _ = Describe("Examples Directory", func() {
 				fmt.Sprintf("myalias.%s.svc.", namespace)}
 
 			for _, name := range unresolvableNames {
-				err = kubectl.RunCommandWithCheckString(namespace, podName, []string{"sh", "-c", fmt.Sprintf("nslookup %s || true", name)}, "NXDOMAIN")
+				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s || true", name), "NXDOMAIN")
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -360,6 +360,19 @@ var _ = Describe("Examples Directory", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 			}
+
+			By("negativ DNS lookup")
+			unresolvableNames := []string{"myalias.",
+				"myalias.service.",
+				addNamespace("myalias.%s.svc.cluster"),
+				addNamespace("myalias.%s.svc.cluster."),
+				addNamespace("myalias.%s.svc.")}
+
+			for _, name := range unresolvableNames {
+				err = kubectl.RunCommandWithCheckString(namespace, podName, fmt.Sprintf("nslookup %s", name), "NXDOMAIN")
+				Expect(err).ToNot(HaveOccurred())
+
+			}
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/jmoiron/sqlx v1.2.0 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49 // indirect
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/onsi/ginkgo v1.10.2
 	github.com/onsi/gomega v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -53,3 +53,5 @@ require (
 	sigs.k8s.io/controller-runtime v0.2.2
 	sigs.k8s.io/yaml v1.1.0
 )
+
+go 1.13

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -72,7 +72,7 @@ func (e *Environment) setupCFOperator() error {
 
 			stdOutput, err := cmd.CombinedOutput()
 			if err != nil {
-				fmt.Printf("SSH TUNNEL FAILED: %f\nOUTPUT: %s", err, string(stdOutput))
+				fmt.Printf("SSH TUNNEL FAILED: %s\nOUTPUT: %s", err.Error(), string(stdOutput))
 			}
 		}()
 	}

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -149,7 +149,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: &admGroupID,
 							},
-							Subdomain: dns.HeadlessServiceName(instanceGroup.Name, manifestName),
+							Subdomain: dns.HeadlessServiceName(instanceGroup.Name),
 						},
 					},
 				},
@@ -236,7 +236,7 @@ func (kc *KubeConverter) serviceToKubeServices(manifestName string, dns manifest
 		}
 	}
 
-	for i, headlessServiceName := range dns.FindServiceNames(instanceGroup.Name, manifestName) {
+	for i, headlessServiceName := range dns.FindServiceNames(instanceGroup.Name) {
 		headlessService := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        headlessServiceName,

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -157,7 +157,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 		},
 	}
 
-	dns.ConfigurePod(&extSts.Spec.Template.Spec.Template.Spec)
+	extSts.Spec.Template.Spec.Template.Spec = dns.DNSSetting(extSts.Spec.Template.Spec.Template.Spec)
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName != "" {
 		extSts.Spec.Template.Spec.Template.Spec.ServiceAccountName = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName
@@ -328,7 +328,7 @@ func (kc *KubeConverter) errandToExtendedJob(
 		},
 	}
 
-	dns.ConfigurePod(&eJob.Spec.Template.Spec)
+	eJob.Spec.Template.Spec.DNSPolicy, eJob.Spec.Template.Spec.DNSConfig = dns.DNSSetting()
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
 		eJob.Spec.Template.Spec.Affinity = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -158,7 +158,10 @@ func (kc *KubeConverter) serviceToExtendedSts(
 	}
 
 	spec := &extSts.Spec.Template.Spec.Template.Spec
-	spec.DNSPolicy, spec.DNSConfig = dns.DNSSetting()
+	spec.DNSPolicy, spec.DNSConfig, err = dns.DNSSetting()
+	if err != nil {
+		return essv1.ExtendedStatefulSet{}, err
+	}
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName != "" {
 		extSts.Spec.Template.Spec.Template.Spec.ServiceAccountName = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName
@@ -329,7 +332,11 @@ func (kc *KubeConverter) errandToExtendedJob(
 		},
 	}
 
-	eJob.Spec.Template.Spec.DNSPolicy, eJob.Spec.Template.Spec.DNSConfig = dns.DNSSetting()
+	eJob.Spec.Template.Spec.DNSPolicy, eJob.Spec.Template.Spec.DNSConfig, err = dns.DNSSetting()
+
+	if err != nil {
+		return ejv1.ExtendedJob{}, err
+	}
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity != nil {
 		eJob.Spec.Template.Spec.Affinity = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Affinity

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -157,7 +157,8 @@ func (kc *KubeConverter) serviceToExtendedSts(
 		},
 	}
 
-	extSts.Spec.Template.Spec.Template.Spec = dns.DNSSetting(extSts.Spec.Template.Spec.Template.Spec)
+	spec := &extSts.Spec.Template.Spec.Template.Spec
+	spec.DNSPolicy, spec.DNSConfig = dns.DNSSetting()
 
 	if instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName != "" {
 		extSts.Spec.Template.Spec.Template.Spec.ServiceAccountName = instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.ServiceAccountName

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -40,7 +40,7 @@ var _ = Describe("kube converter", func() {
 				func(manifestName string, instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs) converter.ContainerFactory {
 					return containerFactory
 				})
-			resources, err := kubeConverter.BPMResources(m.Name, m.DNS(), "1", instanceGroup, m, bpmConfigs)
+			resources, err := kubeConverter.BPMResources(m.Name, m.DNS, "1", instanceGroup, m, bpmConfigs)
 			return resources, err
 		}
 

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -40,7 +40,7 @@ var _ = Describe("kube converter", func() {
 				func(manifestName string, instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs) converter.ContainerFactory {
 					return containerFactory
 				})
-			resources, err := kubeConverter.BPMResources(m.Name, "1", instanceGroup, m, bpmConfigs)
+			resources, err := kubeConverter.BPMResources(m.Name, m.DNS("test"), "1", instanceGroup, m, bpmConfigs)
 			return resources, err
 		}
 

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -40,7 +40,7 @@ var _ = Describe("kube converter", func() {
 				func(manifestName string, instanceGroupName string, version string, disableLogSidecar bool, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs) converter.ContainerFactory {
 					return containerFactory
 				})
-			resources, err := kubeConverter.BPMResources(m.Name, m.DNS("test"), "1", instanceGroup, m, bpmConfigs)
+			resources, err := kubeConverter.BPMResources(m.Name, m.DNS(), "1", instanceGroup, m, bpmConfigs)
 			return resources, err
 		}
 

--- a/pkg/bosh/converter/fakes/kube_converter.go
+++ b/pkg/bosh/converter/fakes/kube_converter.go
@@ -12,14 +12,15 @@ import (
 )
 
 type FakeKubeConverter struct {
-	BPMResourcesStub        func(string, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) (*converter.BPMResources, error)
+	BPMResourcesStub        func(string, manifest.DomainNameService, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) (*converter.BPMResources, error)
 	bPMResourcesMutex       sync.RWMutex
 	bPMResourcesArgsForCall []struct {
 		arg1 string
-		arg2 string
-		arg3 *manifest.InstanceGroup
-		arg4 converter.ReleaseImageProvider
-		arg5 bpm.Configs
+		arg2 manifest.DomainNameService
+		arg3 string
+		arg4 *manifest.InstanceGroup
+		arg5 converter.ReleaseImageProvider
+		arg6 bpm.Configs
 	}
 	bPMResourcesReturns struct {
 		result1 *converter.BPMResources
@@ -47,20 +48,21 @@ type FakeKubeConverter struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeKubeConverter) BPMResources(arg1 string, arg2 string, arg3 *manifest.InstanceGroup, arg4 converter.ReleaseImageProvider, arg5 bpm.Configs) (*converter.BPMResources, error) {
+func (fake *FakeKubeConverter) BPMResources(arg1 string, arg2 manifest.DomainNameService, arg3 string, arg4 *manifest.InstanceGroup, arg5 converter.ReleaseImageProvider, arg6 bpm.Configs) (*converter.BPMResources, error) {
 	fake.bPMResourcesMutex.Lock()
 	ret, specificReturn := fake.bPMResourcesReturnsOnCall[len(fake.bPMResourcesArgsForCall)]
 	fake.bPMResourcesArgsForCall = append(fake.bPMResourcesArgsForCall, struct {
 		arg1 string
-		arg2 string
-		arg3 *manifest.InstanceGroup
-		arg4 converter.ReleaseImageProvider
-		arg5 bpm.Configs
-	}{arg1, arg2, arg3, arg4, arg5})
-	fake.recordInvocation("BPMResources", []interface{}{arg1, arg2, arg3, arg4, arg5})
+		arg2 manifest.DomainNameService
+		arg3 string
+		arg4 *manifest.InstanceGroup
+		arg5 converter.ReleaseImageProvider
+		arg6 bpm.Configs
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("BPMResources", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.bPMResourcesMutex.Unlock()
 	if fake.BPMResourcesStub != nil {
-		return fake.BPMResourcesStub(arg1, arg2, arg3, arg4, arg5)
+		return fake.BPMResourcesStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -75,17 +77,17 @@ func (fake *FakeKubeConverter) BPMResourcesCallCount() int {
 	return len(fake.bPMResourcesArgsForCall)
 }
 
-func (fake *FakeKubeConverter) BPMResourcesCalls(stub func(string, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) (*converter.BPMResources, error)) {
+func (fake *FakeKubeConverter) BPMResourcesCalls(stub func(string, manifest.DomainNameService, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) (*converter.BPMResources, error)) {
 	fake.bPMResourcesMutex.Lock()
 	defer fake.bPMResourcesMutex.Unlock()
 	fake.BPMResourcesStub = stub
 }
 
-func (fake *FakeKubeConverter) BPMResourcesArgsForCall(i int) (string, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) {
+func (fake *FakeKubeConverter) BPMResourcesArgsForCall(i int) (string, manifest.DomainNameService, string, *manifest.InstanceGroup, converter.ReleaseImageProvider, bpm.Configs) {
 	fake.bPMResourcesMutex.RLock()
 	defer fake.bPMResourcesMutex.RUnlock()
 	argsForCall := fake.bPMResourcesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeKubeConverter) BPMResourcesReturns(result1 *converter.BPMResources, result2 error) {

--- a/pkg/bosh/converter/kube_converter_test.go
+++ b/pkg/bosh/converter/kube_converter_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 
-
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter/fakes"

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -306,7 +306,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
-				DNS:           bdm.NewSimpleDomainNameService(),
+				DNS:           bdm.NewSimpleDomainNameService(""),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -339,7 +339,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
-				DNS:           bdm.NewSimpleDomainNameService(),
+				DNS:           bdm.NewSimpleDomainNameService(""),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -368,7 +368,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
-				DNS:           bdm.NewSimpleDomainNameService(),
+				DNS:           bdm.NewSimpleDomainNameService(""),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -415,7 +415,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
-				DNS:           bdm.NewSimpleDomainNameService(),
+				DNS:           bdm.NewSimpleDomainNameService(""),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -472,7 +472,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
-				DNS:           bdm.NewSimpleDomainNameService(),
+				DNS:           bdm.NewSimpleDomainNameService(""),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -754,7 +754,7 @@ instance_groups:
 		It("loads dns from addons", func() {
 			deployment := &bdc.BOSHDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-deployment",
+					Name: "scf",
 				},
 				Spec: bdc.BOSHDeploymentSpec{
 					Manifest: bdc.ResourceReference{
@@ -769,7 +769,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			dns := m.DNS
 			Expect(dns).NotTo(BeNil())
-			Expect(dns.HeadlessServiceName("singleton-uaa", "scf")).To(Equal("uaa"))
+			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("uaa"))
 		})
 
 		It("handles multi-line implicit vars", func() {

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -762,7 +762,7 @@ instance_groups:
 			m, _, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
 
 			Expect(err).ToNot(HaveOccurred())
-			dns := m.DNS("test")
+			dns := m.DNS()
 			Expect(dns).NotTo(BeNil())
 			Expect(dns.HeadlessServiceName("singleton-uaa", "scf")).To(Equal("uaa"))
 		})

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -769,7 +769,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			dns := m.DNS
 			Expect(dns).NotTo(BeNil())
-			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("uaa"))
+			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("foo-singleton-uaa"))
 		})
 
 		It("handles multi-line implicit vars", func() {

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -129,6 +129,42 @@ variables:
 			},
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "manifest-with-dns",
+					Namespace: "default",
+				},
+				Data: map[string]string{bdc.ManifestSpecName: `---
+name: foo
+addons:
+- name: bosh-dns-aliases
+  jobs:
+  - name: bosh-dns-aliases
+    release: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: 'uaa.service.cf.internal'
+        targets:
+        - query: '_'
+          instance_group: singleton-uaa
+          deployment: cf
+          network: default
+          domain: bosh
+instance_groups:
+  - name: component1
+    instances: 1
+    jobs:
+    - name: job1
+      properties:
+        url: https://uaa.service.cf.internal:8443/test/
+variables:
+  - name: router_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: uaa.service.cf.internal
+`},
+			},
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "manifest-with-multiline-implicit-var",
 					Namespace: "default",
 				},
@@ -269,6 +305,7 @@ instance_groups:
 						Instances: 2,
 					},
 				},
+				AddOnsApplied: true,
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -300,6 +337,7 @@ instance_groups:
 						Instances: 2,
 					},
 				},
+				AddOnsApplied: true,
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -327,6 +365,7 @@ instance_groups:
 						Instances: 1,
 					},
 				},
+				AddOnsApplied: true,
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -372,6 +411,7 @@ instance_groups:
 						Instances: 2,
 					},
 				},
+				AddOnsApplied: true,
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -427,6 +467,7 @@ instance_groups:
 						Instances: 4,
 					},
 				},
+				AddOnsApplied: true,
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -703,6 +744,27 @@ instance_groups:
 			Expect(m.Variables[1].Options.CommonName).To(Equal("example.com"))
 			Expect(len(implicitVars)).To(Equal(1))
 			Expect(implicitVars[0]).To(Equal("foo-deployment.var-system-domain"))
+		})
+
+		It("loads dns from addons", func() {
+			deployment := &bdc.BOSHDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo-deployment",
+				},
+				Spec: bdc.BOSHDeploymentSpec{
+					Manifest: bdc.ResourceReference{
+						Type: bdc.ConfigMapReference,
+						Name: "manifest-with-dns",
+					},
+					Ops: []bdc.ResourceReference{},
+				},
+			}
+			m, _, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
+
+			Expect(err).ToNot(HaveOccurred())
+			dns := m.DNS("test")
+			Expect(dns).NotTo(BeNil())
+			Expect(dns.HeadlessServiceName("singleton-uaa", "scf")).To(Equal("uaa"))
 		})
 
 		It("handles multi-line implicit vars", func() {

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -306,6 +306,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
+				DNS:           bdm.NewSimpleDomainNameService(),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -338,6 +339,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
+				DNS:           bdm.NewSimpleDomainNameService(),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -366,6 +368,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
+				DNS:           bdm.NewSimpleDomainNameService(),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -412,6 +415,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
+				DNS:           bdm.NewSimpleDomainNameService(),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -468,6 +472,7 @@ instance_groups:
 					},
 				},
 				AddOnsApplied: true,
+				DNS:           bdm.NewSimpleDomainNameService(),
 			}
 
 			manifest, implicitVars, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
@@ -762,7 +767,7 @@ instance_groups:
 			m, _, err := resolver.WithOpsManifest(context.Background(), deployment, "default")
 
 			Expect(err).ToNot(HaveOccurred())
-			dns := m.DNS()
+			dns := m.DNS
 			Expect(dns).NotTo(BeNil())
 			Expect(dns.HeadlessServiceName("singleton-uaa", "scf")).To(Equal("uaa"))
 		})

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -18,11 +18,9 @@ import (
 // InstanceGroupResolver gathers data for jobs in the manifest, it handles links and returns a deployment manifest
 // that only has information pertinent to an instance group.
 type InstanceGroupResolver struct {
-	baseDir       string
-	manifest      Manifest
-	dns           DomainNameService
-	instanceGroup *InstanceGroup
-
+	baseDir          string
+	manifest         Manifest
+	instanceGroup    *InstanceGroup
 	jobReleaseSpecs  map[string]map[string]JobSpec
 	jobProviderLinks JobProviderLinks
 }
@@ -37,7 +35,6 @@ func NewInstanceGroupResolver(basedir, namespace string, manifest Manifest, inst
 	return &InstanceGroupResolver{
 		baseDir:          basedir,
 		manifest:         manifest,
-		dns:              manifest.DNS(),
 		instanceGroup:    ig,
 		jobReleaseSpecs:  map[string]map[string]JobSpec{},
 		jobProviderLinks: JobProviderLinks{},
@@ -105,7 +102,7 @@ func (dg *InstanceGroupResolver) resolveManifest() error {
 // collectReleaseSpecsAndProviderLinks will collect all release specs and generate bosh links for provider jobs
 func (dg *InstanceGroupResolver) collectReleaseSpecsAndProviderLinks() error {
 	for _, instanceGroup := range dg.manifest.InstanceGroups {
-		serviceName := dg.dns.HeadlessServiceName(instanceGroup.Name, dg.manifest.Name)
+		serviceName := dg.manifest.DNS.HeadlessServiceName(instanceGroup.Name, dg.manifest.Name)
 
 		for jobIdx, job := range instanceGroup.Jobs {
 			// make sure a map entry exists for the current job release

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -20,7 +20,7 @@ import (
 type InstanceGroupResolver struct {
 	baseDir       string
 	manifest      Manifest
-	namespace     string
+	dns           DomainNameService
 	instanceGroup *InstanceGroup
 
 	jobReleaseSpecs  map[string]map[string]JobSpec
@@ -37,7 +37,7 @@ func NewInstanceGroupResolver(basedir, namespace string, manifest Manifest, inst
 	return &InstanceGroupResolver{
 		baseDir:          basedir,
 		manifest:         manifest,
-		namespace:        namespace,
+		dns:              manifest.DNS(namespace),
 		instanceGroup:    ig,
 		jobReleaseSpecs:  map[string]map[string]JobSpec{},
 		jobProviderLinks: JobProviderLinks{},
@@ -105,7 +105,7 @@ func (dg *InstanceGroupResolver) resolveManifest() error {
 // collectReleaseSpecsAndProviderLinks will collect all release specs and generate bosh links for provider jobs
 func (dg *InstanceGroupResolver) collectReleaseSpecsAndProviderLinks() error {
 	for _, instanceGroup := range dg.manifest.InstanceGroups {
-		serviceName := instanceGroup.HeadlessServiceName(dg.manifest.Name)
+		serviceName := dg.dns.HeadlessServiceName(instanceGroup.Name, dg.manifest.Name)
 
 		for jobIdx, job := range instanceGroup.Jobs {
 			// make sure a map entry exists for the current job release

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -37,7 +37,7 @@ func NewInstanceGroupResolver(basedir, namespace string, manifest Manifest, inst
 	return &InstanceGroupResolver{
 		baseDir:          basedir,
 		manifest:         manifest,
-		dns:              manifest.DNS(namespace),
+		dns:              manifest.DNS(),
 		instanceGroup:    ig,
 		jobReleaseSpecs:  map[string]map[string]JobSpec{},
 		jobProviderLinks: JobProviderLinks{},

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -102,7 +102,7 @@ func (dg *InstanceGroupResolver) resolveManifest() error {
 // collectReleaseSpecsAndProviderLinks will collect all release specs and generate bosh links for provider jobs
 func (dg *InstanceGroupResolver) collectReleaseSpecsAndProviderLinks() error {
 	for _, instanceGroup := range dg.manifest.InstanceGroups {
-		serviceName := dg.manifest.DNS.HeadlessServiceName(instanceGroup.Name, dg.manifest.Name)
+		serviceName := dg.manifest.DNS.HeadlessServiceName(instanceGroup.Name)
 
 		for jobIdx, job := range instanceGroup.Jobs {
 			// make sure a map entry exists for the current job release

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -124,6 +124,13 @@ func (dns *boshDomainNameService) DNSSetting() (corev1.DNSPolicy, *corev1.PodDNS
 	}, nil
 }
 
+var boshDNSDockerImage = ""
+
+// SetupBoshDNSDockerImage initializes the package scoped variable
+func SetupBoshDNSDockerImage(image string) {
+	boshDNSDockerImage = image
+}
+
 // Reconcile see interface
 func (dns *boshDomainNameService) Reconcile(ctx context.Context, namespace string, c client.Client, setOwner func(object metav1.Object) error) error {
 	const appName = "bosh-dns"
@@ -172,7 +179,7 @@ func (dns *boshDomainNameService) Reconcile(ctx context.Context, namespace strin
 						{
 							Name:  "coredns",
 							Args:  []string{"-conf", "/etc/coredns/Corefile"},
-							Image: "coredns/coredns:1.6.3",
+							Image: boshDNSDockerImage,
 							Ports: []corev1.ContainerPort{dnsUDPPort, dnsTCPPort, metricsPort},
 							VolumeMounts: []corev1.VolumeMount{
 								{MountPath: "/etc/coredns", Name: volumeName, ReadOnly: true},

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -248,11 +248,11 @@ func GetNameserverFromResolveConfig(content []byte) string {
 type simpleDomainNameService struct {
 }
 
-var simple DomainNameService = &simpleDomainNameService{}
+var _ DomainNameService = &simpleDomainNameService{}
 
 // NewSimpleDomainNameService emulates old behaviour without bosh dns
 func NewSimpleDomainNameService() DomainNameService {
-	return simple
+	return &simpleDomainNameService{}
 }
 
 // FindServiceNames see interface

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -39,7 +39,7 @@ type DomainNameService interface {
 	HeadlessServiceName(instanceGroupName string) string
 
 	// DNSSetting get the DNS settings for POD
-	DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig)
+	DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig, error)
 
 	// Reconcile DNS stuff
 	Reconcile(ctx context.Context, namespace string, c client.Client, setOwner func(object metav1.Object) error) error
@@ -115,16 +115,16 @@ func (dns *boshDomainNameService) HeadlessServiceName(instanceGroupName string) 
 }
 
 // DNSSetting see interface
-func (dns *boshDomainNameService) DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig) {
+func (dns *boshDomainNameService) DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig, error) {
 	if dns.LocalDNSIP == "" {
-		panic("BoshDomainNameService: DNSSetting called before Reconcile")
+		return corev1.DNSNone, nil, errors.New("BoshDomainNameService: DNSSetting called before Reconcile")
 	}
 	ndots := "5"
 	return corev1.DNSNone, &corev1.PodDNSConfig{
 		Nameservers: []string{dns.LocalDNSIP},
 		Searches:    []string{"svc.cluster.local", "cluster.local", "service.cf.internal"},
 		Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: &ndots}},
-	}
+	}, nil
 }
 
 // Reconcile see interface
@@ -265,8 +265,8 @@ func (dns *simpleDomainNameService) HeadlessServiceName(instanceGroupName string
 }
 
 // DNSSetting see interface
-func (dns *simpleDomainNameService) DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig) {
-	return corev1.DNSClusterFirst, nil
+func (dns *simpleDomainNameService) DNSSetting() (corev1.DNSPolicy, *corev1.PodDNSConfig, error) {
+	return corev1.DNSClusterFirst, nil, nil
 }
 
 // Reconcile see interface

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -235,7 +235,7 @@ func (dns *boshDomainNameService) rootDNSIP() string {
 func GetNameserverFromResolveConfig(content []byte) string {
 	found := re.FindSubmatch(content)
 	if len(found) == 0 {
-		ctxlog.Errorf(context.TODO(), "No nameserver found in resolve.conf using 1.1.1.1")
+		ctxlog.Errorf(context.Background(), "No nameserver found in resolve.conf using 1.1.1.1")
 		return "1.1.1.1"
 	}
 	return string(found[1])

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -243,14 +243,6 @@ func serviceName(instanceGroupName string, deploymentName string, maxLength int)
 	return serviceName
 }
 
-const boshDomainSuffix = ".service.cf.internal"
-
-func boshAliasServiceName(domain string) string {
-	svc := strings.TrimSuffix(domain, boshDomainSuffix)
-	svc = strings.ReplaceAll(svc, ".", "-")
-	return svc
-}
-
 func configMapMutateFn(configMap *corev1.ConfigMap) controllerutil.MutateFn {
 	updated := configMap.DeepCopy()
 	return func() error {

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -1,0 +1,298 @@
+package manifest
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	v13 "k8s.io/api/apps/v1"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/mutate"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	v1 "k8s.io/api/core/v1"
+
+	"code.cloudfoundry.org/cf-operator/pkg/kube/util/names"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//DomainNameService abstraction
+type DomainNameService interface {
+	// FindServiceNames determines how a service should be named in accordance with the 'bosh-dns'-addon
+	FindServiceNames(instanceGroupName string, deploymentName string) []string
+
+	// HeadlessServiceName constructs the headless service name for the instance group.
+	HeadlessServiceName(instanceGroupName string, deploymentName string) string
+
+	// Configure DNS inside pod
+	ConfigurePod(podSpec *v1.PodSpec)
+
+	// Reconcile DNS stuff
+	Reconcile(ctx context.Context, c client.Client, setOwner func(object v12.Object) error) error
+}
+
+// Target of domain alias
+type Target struct {
+	Query         string `json:"query"`
+	InstanceGroup string `json:"instance_group"`
+	Deployment    string `json:"deployment"`
+	Network       string `json:"network"`
+	Domain        string `json:"domain"`
+}
+
+// Alias of domain alias
+type Alias struct {
+	Domain  string   `json:"domain"`
+	Targets []Target `json:"targets"`
+}
+
+// boshDomainNameService is used to emulate Bosh DNS
+type boshDomainNameService struct {
+	namespace  string
+	aliases    []Alias
+	localDNSIP string
+}
+
+var _ DomainNameService = &boshDomainNameService{}
+var simple DomainNameService = &simpleDomainNameService{}
+
+// BoshDNSAddOnName name of bosh dns add on
+const BoshDNSAddOnName = "bosh-dns-aliases"
+
+// NewSimpleDomainNameService emulates old behaviour without bosh dns
+func NewSimpleDomainNameService() DomainNameService {
+	return simple
+}
+
+// NewBoshDomainNameService create a new DomainNameService
+func NewBoshDomainNameService(namespace string, addOn *AddOn) (DomainNameService, error) {
+	dns := boshDomainNameService{namespace: namespace}
+	for _, job := range addOn.Jobs {
+		aliases := job.Properties.Properties["aliases"]
+		if aliases != nil {
+			aliasesBytes, err := json.Marshal(aliases)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Loading aliases from manifest")
+			}
+			var a = make([]Alias, 0)
+			err = json.Unmarshal(aliasesBytes, &a)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Loading aliases from manifest")
+			}
+			dns.aliases = append(dns.aliases, a...)
+		}
+	}
+	return &dns, nil
+}
+
+// FindServiceNames see interface
+func (dns *boshDomainNameService) FindServiceNames(instanceGroupName string, _ string) []string {
+	result := make([]string, 0)
+	for _, alias := range dns.aliases {
+		for _, target := range alias.Targets {
+			if target.InstanceGroup == instanceGroupName {
+				result = append(result, strings.Split(alias.Domain, ".")[0])
+			}
+		}
+	}
+	return result
+}
+
+// HeadlessServiceName see interface
+func (dns *boshDomainNameService) HeadlessServiceName(instanceGroupName string, deploymentName string) string {
+	return dns.FindServiceNames(instanceGroupName, deploymentName)[0]
+}
+
+// ConfigurePod see interface
+func (dns *boshDomainNameService) ConfigurePod(podSpec *v1.PodSpec) {
+	podSpec.DNSPolicy = v1.DNSNone
+	podSpec.DNSConfig = &v1.PodDNSConfig{Nameservers: []string{dns.localDNSIP}}
+}
+
+// Reconcile see interface
+func (dns *boshDomainNameService) Reconcile(ctx context.Context, c client.Client, setOwner func(object v12.Object) error) error {
+
+	metadata := v12.ObjectMeta{
+		Name:      "bosh-dns",
+		Namespace: dns.namespace,
+		Labels:    map[string]string{"app": "bosh-dns"},
+	}
+
+	configMap := v1.ConfigMap{
+		ObjectMeta: metadata,
+		Data:       map[string]string{"Corefile": fmt.Sprintf(corefile, dns.namespace, dns.rootDNSIP())},
+	}
+	service := v1.Service{
+		ObjectMeta: metadata,
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{Name: "dns", Port: 53, Protocol: "UDP", TargetPort: intstr.FromInt(8053)},
+				{Name: "dns-tcp", Port: 53, Protocol: "TCP", TargetPort: intstr.FromInt(8053)},
+				{Name: "metrics", Port: 9153, Protocol: "TCP", TargetPort: intstr.FromInt(9153)},
+			},
+			Selector: map[string]string{"app": "bosh-dns"},
+			Type:     "ClusterIP",
+		},
+	}
+
+	var mode int32 = 420
+	deployment := v13.Deployment{
+		ObjectMeta: metadata,
+		Spec: v13.DeploymentSpec{
+			Selector: &v12.LabelSelector{
+				MatchLabels: map[string]string{"app": "bosh-dns"},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: v12.ObjectMeta{
+					Labels: map[string]string{"app": "bosh-dns"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "coredns",
+							Args:  []string{"-conf", "/etc/coredns/Corefile"},
+							Image: "eu.gcr.io/gardener-project/3rd/coredns/coredns:1.4.0",
+							Ports: []v1.ContainerPort{
+								{ContainerPort: 8053, Name: "dns-udp", Protocol: "UDP"},
+								{ContainerPort: 8053, Name: "dns-tcp", Protocol: "TCP"},
+								{ContainerPort: 9153, Name: "metrics", Protocol: "TCP"},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/etc/coredns", Name: "bosh-dns-volume", ReadOnly: true},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "bosh-dns-volume",
+							VolumeSource: v1.VolumeSource{
+								ConfigMap: &v1.ConfigMapVolumeSource{
+									DefaultMode: &mode,
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: "bosh-dns",
+									},
+									Items: []v1.KeyToPath{
+										{Key: "Corefile", Path: "Corefile"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, obj := range []v12.Object{&configMap, &deployment, &service} {
+		err := setOwner(obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, c, &configMap, configMapMutateFn(&configMap))
+	if err != nil {
+		return err
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, c, &deployment, deploymentMapMutateFn(&deployment))
+	if err != nil {
+		return err
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, c, &service, mutate.ServiceMutateFn(&service))
+	if err != nil {
+		return err
+	}
+
+	dns.localDNSIP = service.Spec.ClusterIP
+	return err
+}
+
+var re = regexp.MustCompile(`nameserver\s+([\d\.]*)`)
+
+func (dns *boshDomainNameService) rootDNSIP() string {
+	content, err := ioutil.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		content = []byte{}
+	}
+	return GetNameserverFromResolveConfig(content)
+}
+
+// GetNameserverFromResolveConfig read nameserver from resolve.conf
+func GetNameserverFromResolveConfig(content []byte) string {
+	found := re.FindSubmatch(content)
+	if len(found) == 0 {
+		return "1.1.1.1"
+	}
+	return string(found[1])
+
+}
+
+type simpleDomainNameService struct {
+}
+
+// FindServiceNames see interface
+func (dns *simpleDomainNameService) FindServiceNames(instanceGroupName string, deploymentName string) []string {
+	return []string{serviceName(instanceGroupName, deploymentName, 63)}
+}
+
+// HeadlessServiceName see interface
+func (dns *simpleDomainNameService) HeadlessServiceName(instanceGroupName string, deploymentName string) string {
+	return serviceName(instanceGroupName, deploymentName, 63)
+}
+
+// ConfigurePod see interface
+func (dns *simpleDomainNameService) ConfigurePod(podSpec *v1.PodSpec) {
+}
+
+// Reconcile see interface
+func (dns *simpleDomainNameService) Reconcile(ctx context.Context, c client.Client, setOwner func(object v12.Object) error) error {
+	return nil
+}
+
+func serviceName(instanceGroupName string, deploymentName string, maxLength int) string {
+	serviceName := fmt.Sprintf("%s-%s", deploymentName, names.Sanitize(instanceGroupName))
+	if len(serviceName) > maxLength {
+		sumHex := md5.Sum([]byte(serviceName))
+		sum := hex.EncodeToString(sumHex[:])
+		serviceName = fmt.Sprintf("%s-%s", serviceName[:maxLength-len(sum)-1], sum)
+	}
+	return serviceName
+}
+
+func configMapMutateFn(configMap *v1.ConfigMap) controllerutil.MutateFn {
+	updated := configMap.DeepCopy()
+	return func() error {
+		configMap.Labels = updated.Labels
+		configMap.Annotations = updated.Annotations
+		configMap.Data = updated.Data
+		return nil
+	}
+}
+
+func deploymentMapMutateFn(deployment *v13.Deployment) controllerutil.MutateFn {
+	updated := deployment.DeepCopy()
+	return func() error {
+		deployment.Labels = updated.Labels
+		deployment.Annotations = updated.Annotations
+		deployment.Spec = updated.Spec
+		return nil
+	}
+}
+
+const corefile = `
+.:8053 {
+  health
+  rewrite name substring service.cf.internal %s.svc.cluster.local
+  forward . %s
+}
+`

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -66,15 +66,9 @@ type boshDomainNameService struct {
 }
 
 var _ DomainNameService = &boshDomainNameService{}
-var simple DomainNameService = &simpleDomainNameService{}
 
 // BoshDNSAddOnName name of bosh dns add on
 const BoshDNSAddOnName = "bosh-dns-aliases"
-
-// NewSimpleDomainNameService emulates old behaviour without bosh dns
-func NewSimpleDomainNameService() DomainNameService {
-	return simple
-}
 
 // NewBoshDomainNameService create a new DomainNameService
 func NewBoshDomainNameService(addOn *AddOn) (DomainNameService, error) {
@@ -252,6 +246,13 @@ func GetNameserverFromResolveConfig(content []byte) string {
 }
 
 type simpleDomainNameService struct {
+}
+
+var simple DomainNameService = &simpleDomainNameService{}
+
+// NewSimpleDomainNameService emulates old behaviour without bosh dns
+func NewSimpleDomainNameService() DomainNameService {
+	return simple
 }
 
 // FindServiceNames see interface

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -155,7 +155,7 @@ var _ = Describe("kube converter", func() {
 	Context("bosh-dns", func() {
 
 		It("loads dns from addons correct", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
+			dns, err := manifest.NewBoshDomainNameService(loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			services := dns.FindServiceNames("scheduler", "")
 			Expect(services).To(HaveLen(1))
@@ -163,7 +163,7 @@ var _ = Describe("kube converter", func() {
 			Expect(dns.HeadlessServiceName("scheduler", "")).To(Equal("auctioneer"))
 		})
 		It("returns the correct service names", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
+			dns, err := manifest.NewBoshDomainNameService(loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			diegoAPI := dns.FindServiceNames("diego-api", "cf")
 			Expect(diegoAPI).To(ConsistOf("bbs", "bbs1"))
@@ -171,7 +171,7 @@ var _ = Describe("kube converter", func() {
 			Expect(uaa).To(ConsistOf("uaa"))
 		})
 		It("returns the default name if there is no alias configured", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
+			dns, err := manifest.NewBoshDomainNameService(loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			invalid := dns.FindServiceNames("invalid", "cf")
 			Expect(invalid).To(ConsistOf("cf-invalid"))
@@ -186,7 +186,7 @@ var _ = Describe("kube converter", func() {
 			Expect(ip).To(Equal("1.1.1.1"))
 		})
 		It("reconciles dns stuff", func() {
-			d, err := manifest.NewBoshDomainNameService("default", loadAddOn())
+			d, err := manifest.NewBoshDomainNameService(loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
@@ -194,7 +194,7 @@ var _ = Describe("kube converter", func() {
 
 			client := fake.NewFakeClientWithScheme(scheme)
 			counter := 0
-			err = d.Reconcile(context.TODO(), client, func(object v1.Object) error {
+			err = d.Reconcile(context.TODO(), "default", "scf", client, func(object v1.Object) error {
 				counter++
 				return nil
 			})
@@ -223,7 +223,7 @@ var _ = Describe("kube converter", func() {
 
 			client := fake.NewFakeClientWithScheme(runtime.NewScheme())
 
-			err := dns.Reconcile(context.TODO(), client, func(object v1.Object) error {
+			err := dns.Reconcile(context.TODO(), "default", "scf", client, func(object v1.Object) error {
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -1,0 +1,228 @@
+package manifest_test
+
+import (
+	"context"
+	"encoding/json"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const boshDNSAddOn = `
+{
+  "jobs": [
+    {
+      "name": "bosh-dns-aliases",
+      "properties": {
+        "aliases": [
+          {
+            "domain": "_.cell.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "diego-cell",
+                "network": "default",
+                "query": "_"
+              },
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "windows2012R2-cell",
+                "network": "default",
+                "query": "_"
+              },
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "windows2016-cell",
+                "network": "default",
+                "query": "_"
+              },
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "windows1803-cell",
+                "network": "default",
+                "query": "_"
+              },
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "windows2019-cell",
+                "network": "default",
+                "query": "_"
+              },
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "isolated-diego-cell",
+                "network": "default",
+                "query": "_"
+              }
+            ]
+          },
+          {
+            "domain": "auctioneer.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "scheduler",
+                "network": "default",
+                "query": "q-s4"
+              }
+            ]
+          },
+           {
+            "domain": "bbs1.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "diego-api",
+                "network": "default",
+                "query": "q-s4"
+              }
+            ]
+          },
+         {
+            "domain": "bbs.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "diego-api",
+                "network": "default",
+                "query": "q-s4"
+              }
+            ]
+          },
+          {
+            "domain": "bits.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "bits",
+                "network": "default",
+                "query": "*"
+              }
+            ]
+          },
+          {
+            "domain": "uaa.service.cf.internal",
+            "targets": [
+              {
+                "deployment": "cf",
+                "domain": "bosh",
+                "instance_group": "uaa",
+                "network": "default",
+                "query": "*"
+              }
+            ]
+          }
+        ]
+      },
+      "release": "bosh-dns-aliases"
+    }
+  ],
+  "name": "bosh-dns-aliases"
+}
+`
+
+func loadAddOn(data string) *manifest.AddOn {
+	var addOn manifest.AddOn
+	err := json.Unmarshal([]byte(data), &addOn)
+	if err != nil {
+		panic("Loading yaml failed")
+	}
+	return &addOn
+}
+
+var _ = Describe("kube converter", func() {
+
+	Context("bosh-dns", func() {
+
+		It("loads dns from addons correct", func() {
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			Expect(err).NotTo(HaveOccurred())
+			services := dns.FindServiceNames("scheduler", "")
+			Expect(services).To(HaveLen(1))
+			Expect(services[0]).To(Equal("auctioneer"))
+			Expect(dns.HeadlessServiceName("scheduler", "")).To(Equal("auctioneer"))
+		})
+		It("returns the correct service names", func() {
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			Expect(err).NotTo(HaveOccurred())
+			diegoAPI := dns.FindServiceNames("diego-api", "cf")
+			Expect(diegoAPI).To(ConsistOf("bbs", "bbs1"))
+			uaa := dns.FindServiceNames("uaa", "cf")
+			Expect(uaa).To(ConsistOf("uaa"))
+			invalid := dns.FindServiceNames("invalid", "cf")
+			Expect(invalid).To(ConsistOf())
+
+		})
+		It("reads nameserver from resolve.conv", func() {
+			ip := manifest.GetNameserverFromResolveConfig([]byte("search wdf.sap.corp global.corp.sap\nnameserver 10.17.122.10\n"))
+			Expect(ip).To(Equal("10.17.122.10"))
+		})
+		It("reads default nameserver from resolve.conv", func() {
+			ip := manifest.GetNameserverFromResolveConfig([]byte(""))
+			Expect(ip).To(Equal("1.1.1.1"))
+		})
+		It("reconciles dns stuff", func() {
+			d, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			Expect(err).NotTo(HaveOccurred())
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+
+			client := fake.NewFakeClientWithScheme(scheme)
+			counter := 0
+			err = d.Reconcile(context.TODO(), client, func(object v1.Object) error {
+				counter++
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(counter).To(Equal(3))
+		})
+	})
+	Context("simple-dns", func() {
+
+		It("returns correct service names", func() {
+			dns := manifest.NewSimpleDomainNameService()
+			services := dns.FindServiceNames("scheduler", "sfc")
+			Expect(services).To(HaveLen(1))
+			Expect(services[0]).To(Equal("sfc-scheduler"))
+			Expect(dns.HeadlessServiceName("scheduler", "sfc")).To(Equal("sfc-scheduler"))
+		})
+		It("shorten long service names", func() {
+			dns := manifest.NewSimpleDomainNameService()
+			Expect(len(dns.HeadlessServiceName(
+				"scheduler-scheduler-scheduler-scheduler-scheduler-scheduler-scheduler-scheduler",
+				"sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-"))).
+				To(Equal(63))
+		})
+		It("reconciles does nothing", func() {
+			dns := manifest.NewSimpleDomainNameService()
+
+			client := fake.NewFakeClientWithScheme(runtime.NewScheme())
+
+			err := dns.Reconcile(context.TODO(), client, func(object v1.Object) error {
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -140,10 +140,11 @@ const boshDNSAddOn = `
 }
 `
 
-func loadAddOn(data string) *manifest.AddOn {
+func loadAddOn() *manifest.AddOn {
 	var addOn manifest.AddOn
-	err := json.Unmarshal([]byte(data), &addOn)
+	err := json.Unmarshal([]byte(boshDNSAddOn), &addOn)
 	if err != nil {
+		// This should never happen, because boshDNSAddOn is a constant
 		panic("Loading yaml failed")
 	}
 	return &addOn
@@ -154,7 +155,7 @@ var _ = Describe("kube converter", func() {
 	Context("bosh-dns", func() {
 
 		It("loads dns from addons correct", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			services := dns.FindServiceNames("scheduler", "")
 			Expect(services).To(HaveLen(1))
@@ -162,7 +163,7 @@ var _ = Describe("kube converter", func() {
 			Expect(dns.HeadlessServiceName("scheduler", "")).To(Equal("auctioneer"))
 		})
 		It("returns the correct service names", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			diegoAPI := dns.FindServiceNames("diego-api", "cf")
 			Expect(diegoAPI).To(ConsistOf("bbs", "bbs1"))
@@ -170,7 +171,7 @@ var _ = Describe("kube converter", func() {
 			Expect(uaa).To(ConsistOf("uaa"))
 		})
 		It("returns the default name if there is no alias configured", func() {
-			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			invalid := dns.FindServiceNames("invalid", "cf")
 			Expect(invalid).To(ConsistOf("cf-invalid"))
@@ -185,7 +186,7 @@ var _ = Describe("kube converter", func() {
 			Expect(ip).To(Equal("1.1.1.1"))
 		})
 		It("reconciles dns stuff", func() {
-			d, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			d, err := manifest.NewBoshDomainNameService("default", loadAddOn())
 			Expect(err).NotTo(HaveOccurred())
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -168,8 +168,12 @@ var _ = Describe("kube converter", func() {
 			Expect(diegoAPI).To(ConsistOf("bbs", "bbs1"))
 			uaa := dns.FindServiceNames("uaa", "cf")
 			Expect(uaa).To(ConsistOf("uaa"))
+		})
+		It("returns the default name if there is no alias configured", func() {
+			dns, err := manifest.NewBoshDomainNameService("default", loadAddOn(boshDNSAddOn))
+			Expect(err).NotTo(HaveOccurred())
 			invalid := dns.FindServiceNames("invalid", "cf")
-			Expect(invalid).To(ConsistOf())
+			Expect(invalid).To(ConsistOf("cf-invalid"))
 
 		})
 		It("reads nameserver from resolve.conv", func() {

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -154,29 +154,6 @@ var _ = Describe("kube converter", func() {
 
 	Context("bosh-dns", func() {
 
-		It("loads dns from addons correct", func() {
-			dns, err := manifest.NewBoshDomainNameService(loadAddOn(), "")
-			Expect(err).NotTo(HaveOccurred())
-			services := dns.FindServiceNames("scheduler")
-			Expect(services).To(HaveLen(1))
-			Expect(services[0]).To(Equal("auctioneer"))
-			Expect(dns.HeadlessServiceName("scheduler")).To(Equal("auctioneer"))
-		})
-		It("returns the correct service names", func() {
-			dns, err := manifest.NewBoshDomainNameService(loadAddOn(), "cf")
-			Expect(err).NotTo(HaveOccurred())
-			diegoAPI := dns.FindServiceNames("diego-api")
-			Expect(diegoAPI).To(ConsistOf("bbs", "bbs1"))
-			uaa := dns.FindServiceNames("uaa")
-			Expect(uaa).To(ConsistOf("uaa"))
-		})
-		It("returns the default name if there is no alias configured", func() {
-			dns, err := manifest.NewBoshDomainNameService(loadAddOn(), "cf")
-			Expect(err).NotTo(HaveOccurred())
-			invalid := dns.FindServiceNames("invalid")
-			Expect(invalid).To(ConsistOf("cf-invalid"))
-
-		})
 		It("reconciles dns stuff", func() {
 			d, err := manifest.NewBoshDomainNameService(loadAddOn(), "scf")
 			Expect(err).NotTo(HaveOccurred())
@@ -186,38 +163,33 @@ var _ = Describe("kube converter", func() {
 
 			client := fake.NewFakeClientWithScheme(scheme)
 			counter := 0
-			err = d.Reconcile(context.TODO(), "default", client, func(object v1.Object) error {
+			err = d.Reconcile(context.Background(), "default", client, func(object v1.Object) error {
 				counter++
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(counter).To(Equal(3))
 		})
+
 	})
+
 	Context("simple-dns", func() {
 
-		It("returns correct service names", func() {
-			dns := manifest.NewSimpleDomainNameService("sfc")
-			services := dns.FindServiceNames("scheduler")
-			Expect(services).To(HaveLen(1))
-			Expect(services[0]).To(Equal("sfc-scheduler"))
-			Expect(dns.HeadlessServiceName("scheduler")).To(Equal("sfc-scheduler"))
-		})
 		It("shorten long service names", func() {
 			dns := manifest.NewSimpleDomainNameService("sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-sfc-")
 			Expect(len(dns.HeadlessServiceName("scheduler-scheduler-scheduler-scheduler-scheduler-scheduler-scheduler-scheduler"))).
 				To(Equal(63))
 		})
+
 		It("reconciles does nothing", func() {
 			dns := manifest.NewSimpleDomainNameService("scf")
-
 			client := fake.NewFakeClientWithScheme(runtime.NewScheme())
-
-			err := dns.Reconcile(context.TODO(), "default", client, func(object v1.Object) error {
+			err := dns.Reconcile(context.Background(), "default", client, func(object v1.Object) error {
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 	})
 
 })

--- a/pkg/bosh/manifest/dns_test.go
+++ b/pkg/bosh/manifest/dns_test.go
@@ -177,14 +177,6 @@ var _ = Describe("kube converter", func() {
 			Expect(invalid).To(ConsistOf("cf-invalid"))
 
 		})
-		It("reads nameserver from resolve.conv", func() {
-			ip := manifest.GetNameserverFromResolveConfig([]byte("search wdf.sap.corp global.corp.sap\nnameserver 10.17.122.10\n"))
-			Expect(ip).To(Equal("10.17.122.10"))
-		})
-		It("reads default nameserver from resolve.conv", func() {
-			ip := manifest.GetNameserverFromResolveConfig([]byte(""))
-			Expect(ip).To(Equal("1.1.1.1"))
-		})
 		It("reconciles dns stuff", func() {
 			d, err := manifest.NewBoshDomainNameService(loadAddOn(), "scf")
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -1,8 +1,6 @@
 package manifest
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,26 +40,11 @@ func (ig *InstanceGroup) ExtendedStatefulsetName(deploymentName string) string {
 	return fmt.Sprintf("%s-%s", deploymentName, ign)
 }
 
-// HeadlessServiceName constructs the headless service name for the instance group.
-func (ig *InstanceGroup) HeadlessServiceName(deploymentName string) string {
-	return ig.serviceName(deploymentName, 63)
-}
-
 // IndexedServiceName constructs an indexed service name. It's used to construct the other service
 // names other than the headless service.
 func (ig *InstanceGroup) IndexedServiceName(deploymentName string, index int) string {
-	sn := ig.serviceName(deploymentName, 53)
+	sn := serviceName(ig.Name, deploymentName, 53)
 	return fmt.Sprintf("%s-%d", sn, index)
-}
-
-func (ig *InstanceGroup) serviceName(deploymentName string, maxLength int) string {
-	estsn := ig.ExtendedStatefulsetName(deploymentName)
-	if len(estsn) > maxLength {
-		sumHex := md5.Sum([]byte(estsn))
-		sum := hex.EncodeToString(sumHex[:])
-		estsn = fmt.Sprintf("%s-%s", estsn[:maxLength-len(sum)-1], sum)
-	}
-	return estsn
 }
 
 func (ig *InstanceGroup) jobInstances(

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -177,7 +177,7 @@ func (m *Manifest) loadDNS() {
 	for _, addon := range m.AddOns {
 		if addon.Name == BoshDNSAddOnName {
 			var err error
-			dns, err := NewBoshDomainNameService(addon)
+			dns, err := NewBoshDomainNameService(addon, m.Name)
 			if err != nil {
 				ctxlog.Errorf(context.TODO(), "Error loading bosh dns configuration: %s", err.Error())
 				continue
@@ -186,7 +186,7 @@ func (m *Manifest) loadDNS() {
 			return
 		}
 	}
-	m.DNS = NewSimpleDomainNameService()
+	m.DNS = NewSimpleDomainNameService(m.Name)
 }
 
 // Marshal serializes a BOSH manifest into yaml

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -170,11 +170,11 @@ func LoadYAML(data []byte) (*Manifest, error) {
 }
 
 // DNS returns the DNS service
-func (m *Manifest) DNS(namespace string) DomainNameService {
+func (m *Manifest) DNS() DomainNameService {
 	for _, addon := range m.AddOns {
 		if addon.Name == BoshDNSAddOnName {
 			var err error
-			dns, err := NewBoshDomainNameService(namespace, addon)
+			dns, err := NewBoshDomainNameService(addon)
 			if err != nil {
 				ctxlog.Errorf(context.TODO(), "Error loading bosh dns configuration: %s", err.Error())
 				continue

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -131,7 +131,7 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 			log.WithEvent(bpmSecret, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s': %v", instanceName, err)
 	}
 
-	err = manifest.DNS.Reconcile(ctx, request.Namespace, manifest.Name, r.client, func(object v1.Object) error {
+	err = manifest.DNS.Reconcile(ctx, request.Namespace, r.client, func(object v1.Object) error {
 		return r.setReference(instance, object, r.scheme)
 	})
 

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +19,7 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	ejv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/extendedjob/v1alpha1"
@@ -35,7 +38,7 @@ type DesiredManifest interface {
 
 // KubeConverter converts k8s resources from single BOSH manifest
 type KubeConverter interface {
-	BPMResources(manifestName string, version string, instanceGroup *bdm.InstanceGroup, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs) (*converter.BPMResources, error)
+	BPMResources(manifestName string, dns manifest.DomainNameService, version string, instanceGroup *bdm.InstanceGroup, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs) (*converter.BPMResources, error)
 	Variables(manifestName string, variables []bdm.Variable) ([]esv1.ExtendedSecret, error)
 }
 
@@ -114,7 +117,32 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 			log.WithEvent(bpmSecret, "LabelMissingError").Errorf(ctx, "Missing container label for bpm information bpmSecret '%s'", request.NamespacedName)
 	}
 
-	resources, err := r.applyBPMResources(bpmSecret, manifest)
+	// Start the instance groups referenced by this BPM secret
+	instanceName, ok := bpmSecret.Labels[bdv1.LabelDeploymentName]
+	if !ok {
+		return reconcile.Result{},
+			log.WithEvent(bpmSecret, "LabelMissingError").Errorf(ctx, "Missing deployment mame label for bpm information bpmSecret '%s'", request.NamespacedName)
+	}
+
+	instance := &bdv1.BOSHDeployment{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: instanceName}, instance)
+	if err != nil {
+		return reconcile.Result{},
+			log.WithEvent(bpmSecret, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s': %v", instanceName, err)
+	}
+
+	dns := manifest.DNS(request.Namespace)
+
+	err = dns.Reconcile(ctx, r.client, func(object v1.Object) error {
+		return r.setReference(instance, object, r.scheme)
+	})
+
+	if err != nil {
+		return reconcile.Result{},
+			log.WithEvent(bpmSecret, "DnsReconcileError").Errorf(ctx, "Failed to reconcile dns: %v", err)
+	}
+
+	resources, err := r.applyBPMResources(bpmSecret, manifest, dns)
 	if err != nil {
 		return reconcile.Result{},
 			log.WithEvent(bpmSecret, "BPMApplyingError").Errorf(ctx, "Failed to apply BPM information: %v", err)
@@ -125,21 +153,7 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 		return reconcile.Result{}, nil
 	}
 
-	// Start the instance groups referenced by this BPM secret
-	instanceName, ok := bpmSecret.Labels[bdv1.LabelDeploymentName]
-	if !ok {
-		return reconcile.Result{},
-			log.WithEvent(bpmSecret, "LabelMissingError").Errorf(ctx, "Missing deployment mame label for bpm information bpmSecret '%s'", request.NamespacedName)
-	}
-
 	// Deploy instance groups
-	instance := &bdv1.BOSHDeployment{}
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: instanceName}, instance)
-	if err != nil {
-		return reconcile.Result{},
-			log.WithEvent(bpmSecret, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s': %v", instanceName, err)
-	}
-
 	err = r.deployInstanceGroups(ctx, instance, instanceGroupName, resources)
 	if err != nil {
 		return reconcile.Result{},
@@ -156,7 +170,7 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileBPM) applyBPMResources(bpmSecret *corev1.Secret, manifest *bdm.Manifest) (*converter.BPMResources, error) {
+func (r *ReconcileBPM) applyBPMResources(bpmSecret *corev1.Secret, manifest *bdm.Manifest, dns manifest.DomainNameService) (*converter.BPMResources, error) {
 
 	instanceGroupName, ok := bpmSecret.Labels[ejv1.LabelInstanceGroup]
 	if !ok {
@@ -183,7 +197,7 @@ func (r *ReconcileBPM) applyBPMResources(bpmSecret *corev1.Secret, manifest *bdm
 		return nil, err
 	}
 
-	resources, err := r.kubeConverter.BPMResources(manifest.Name, version, instanceGroup, manifest, bpmConfigs)
+	resources, err := r.kubeConverter.BPMResources(manifest.Name, dns, version, instanceGroup, manifest, bpmConfigs)
 	if err != nil {
 		return resources, err
 	}

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -131,9 +131,9 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 			log.WithEvent(bpmSecret, "GetBOSHDeployment").Errorf(ctx, "Failed to get BoshDeployment instance '%s': %v", instanceName, err)
 	}
 
-	dns := manifest.DNS(request.Namespace)
+	dns := manifest.DNS()
 
-	err = dns.Reconcile(ctx, r.client, func(object v1.Object) error {
+	err = dns.Reconcile(ctx, request.Namespace, manifest.Name, r.client, func(object v1.Object) error {
 		return r.setReference(instance, object, r.scheme)
 	})
 

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ReconcileBPM", func() {
 					Type: "password",
 				},
 			},
-			DNS: bdm.NewSimpleDomainNameService(),
+			DNS: bdm.NewSimpleDomainNameService("fake-manifest"),
 		}
 		config = &cfcfg.Config{CtxTimeOut: 10 * time.Second}
 		logs, log = helper.NewTestLogger()

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -115,6 +115,7 @@ var _ = Describe("ReconcileBPM", func() {
 					Type: "password",
 				},
 			},
+			DNS: bdm.NewSimpleDomainNameService(),
 		}
 		config = &cfcfg.Config{CtxTimeOut: 10 * time.Second}
 		logs, log = helper.NewTestLogger()

--- a/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
+++ b/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
+++ b/pkg/kube/controllers/boshdeployment/generated_variable_controller.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
-
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -476,7 +476,7 @@ instance_groups:
         pre_render_scripts:
           jobs:
           - |
-            touch /tmp
+            echo "Hello BOSH container"
         bpm:
           processes:
           - name: redis

--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -41,7 +41,22 @@ func NewKubectl() *Kubectl {
 	}
 }
 
-// RunCommandWithCheckString runs the command specified helperin the container
+// RunCommandOnceWithCheckString runs the command specified helper in the container once
+func (k *Kubectl) RunCommandOnceWithCheckString(namespace string, podName string, commandInPod string, result string) error {
+	found, err := k.checkString(namespace, podName, commandInPod, result)
+
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return errors.Errorf("'%s' not found in output of command '%s'", result, commandInPod)
+	}
+
+	return nil
+}
+
+// RunCommandWithCheckString runs the command specified helper in the container
 func (k *Kubectl) RunCommandWithCheckString(namespace string, podName string, commandInPod string, result string) error {
 	return wait.PollImmediate(k.pollInterval, k.PollTimeout, func() (bool, error) {
 		return k.checkString(namespace, podName, commandInPod, result)

--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -41,32 +41,17 @@ func NewKubectl() *Kubectl {
 	}
 }
 
-// RunCommandOnceWithCheckString runs the command specified helper in the container once
-func (k *Kubectl) RunCommandOnceWithCheckString(namespace string, podName string, commandInPod string, result string) error {
-	found, err := k.checkString(namespace, podName, commandInPod, result)
-
-	if err != nil {
-		return err
-	}
-
-	if !found {
-		return errors.Errorf("'%s' not found in output of command '%s'", result, commandInPod)
-	}
-
-	return nil
-}
-
 // RunCommandWithCheckString runs the command specified helper in the container
-func (k *Kubectl) RunCommandWithCheckString(namespace string, podName string, commandInPod string, result string) error {
+func (k *Kubectl) RunCommandWithCheckString(namespace string, podName string, commandInPod []string, result string) error {
 	return wait.PollImmediate(k.pollInterval, k.PollTimeout, func() (bool, error) {
 		return k.checkString(namespace, podName, commandInPod, result)
 	})
 }
 
 // checkString checks is the string is present in the output of the kubectl command
-func (k *Kubectl) checkString(namespace string, podName string, commandInPod string, result string) (bool, error) {
+func (k *Kubectl) checkString(namespace string, podName string, commandInPod []string, result string) (bool, error) {
 	args := []string{"--namespace", namespace, "exec", "-it", podName, "--"}
-	args = append(args, strings.Split(commandInPod, " ")...)
+	args = append(args, commandInPod...)
 
 	out, err := runBinary(kubeCtlCmd, args...)
 	if err != nil {

--- a/testing/command_helper.go
+++ b/testing/command_helper.go
@@ -42,25 +42,15 @@ func NewKubectl() *Kubectl {
 }
 
 // RunCommandWithCheckString runs the command specified helper in the container
-func (k *Kubectl) RunCommandWithCheckString(namespace string, podName string, commandInPod []string, result string) error {
-	return wait.PollImmediate(k.pollInterval, k.PollTimeout, func() (bool, error) {
-		return k.checkString(namespace, podName, commandInPod, result)
-	})
-}
-
-// checkString checks is the string is present in the output of the kubectl command
-func (k *Kubectl) checkString(namespace string, podName string, commandInPod []string, result string) (bool, error) {
-	args := []string{"--namespace", namespace, "exec", "-it", podName, "--"}
-	args = append(args, commandInPod...)
-
-	out, err := runBinary(kubeCtlCmd, args...)
+func (k *Kubectl) RunCommandWithCheckString(namespace string, podName string, commandInPod string, result string) error {
+	out, err := runBinary(kubeCtlCmd, "--namespace", namespace, "exec", podName, "--", "sh", "-c", commandInPod)
 	if err != nil {
-		return false, nil
+		return err
 	}
 	if strings.Contains(string(out), result) {
-		return true, nil
+		return nil
 	}
-	return false, nil
+	return errors.Errorf("'%s' not found in output '%s'", result, string(out))
 }
 
 // WaitForPod blocks until the pod is available. It fails after the timeout.


### PR DESCRIPTION
We implemented [BOSH-compatible hostname aliases](https://github.com/SUSE/scf/issues/2780)

* We use a second DNS server
* k8s headless services are created based on the alias configuration
* The _old_ headless service names are resolved by the second DNS server.

All these features are only enabled if the bosh dns addon is configured inside the manifest.

It can be tested using `docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml`.

It's also working with the [SUSE cloudfoundry v3-release](https://github.com/SUSE/scf) after changing the file `scripts/scf/bazel-scf/deploy/helm/scf/assets/operations/addons.yaml`
* Remove 
```yaml
- type: remove
  path: /addons/name=bosh-dns-aliases
```

* Add*

```yaml
- type: replace
  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=nats?
  value:
    domain: nats.service.cf.internal
    targets:
      - deployment: cf
        domain: bosh
        instance_group: nats
        network: default
        query: '*'
- type: replace
  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=eirini?
  value:
    domain: eirini.service.cf.internal
    targets:
      - deployment: cf
        domain: bosh
        instance_group: eirini
        network: default
        query: '*'
```

