### PR TITLE
Make kube API request context deadline configurable for the user

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -80,6 +80,7 @@ var rootCmd = &cobra.Command{
 
 		config := config.NewConfig(
 			cfOperatorNamespace,
+			viper.GetInt("ctx-timeout"),
 			provider,
 			serviceHost,
 			servicePort,
@@ -138,50 +139,54 @@ func Execute() {
 func init() {
 	pf := rootCmd.PersistentFlags()
 
-	pf.StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
-	pf.StringP("log-level", "l", "debug", "Only print log messages from this level onward")
+	pf.Bool("apply-crd", true, "If true, apply CRDs on start")
+	pf.Int("ctx-timeout", 30, "context timeout for each k8s API request in seconds")
 	pf.StringP("cf-operator-namespace", "n", "default", "Namespace to watch for BOSH deployments")
 	pf.StringP("docker-image-org", "o", "cfcontainerization", "Dockerhub organization that provides the operator docker image")
 	pf.StringP("docker-image-repository", "r", "cf-operator", "Dockerhub repository that provides the operator docker image")
-	pf.StringP("operator-webhook-service-host", "w", "", "Hostname/IP under which the webhook server can be reached from the cluster")
-	pf.StringP("operator-webhook-service-port", "p", "2999", "Port the webhook server listens on")
 	pf.StringP("docker-image-tag", "t", version.Version, "Tag of the operator docker image")
-	pf.StringP("provider", "x", "", "Cloud Provider where cf-operator is being deployed")
+	pf.StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
+	pf.StringP("log-level", "l", "debug", "Only print log messages from this level onward")
 	pf.Int("max-boshdeployment-workers", 1, "Maximum number of workers concurrently running BOSHDeployment controller")
 	pf.Int("max-extendedjob-workers", 1, "Maximum number of workers concurrently running ExtendedJob controller")
 	pf.Int("max-extendedsecret-workers", 5, "Maximum number of workers concurrently running ExtendedSecret controller")
 	pf.Int("max-extendedstatefulset-workers", 1, "Maximum number of workers concurrently running ExtendedStatefulSet controller")
-	pf.Bool("apply-crd", true, "If true, apply CRDs on start")
-	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
-	viper.BindPFlag("log-level", pf.Lookup("log-level"))
+	pf.StringP("operator-webhook-service-host", "w", "", "Hostname/IP under which the webhook server can be reached from the cluster")
+	pf.StringP("operator-webhook-service-port", "p", "2999", "Port the webhook server listens on")
+	pf.StringP("provider", "x", "", "Cloud Provider where cf-operator is being deployed")
+
+	viper.BindPFlag("apply-crd", rootCmd.PersistentFlags().Lookup("apply-crd"))
+	viper.BindPFlag("ctx-timeout", pf.Lookup("ctx-timeout"))
 	viper.BindPFlag("cf-operator-namespace", pf.Lookup("cf-operator-namespace"))
 	viper.BindPFlag("docker-image-org", pf.Lookup("docker-image-org"))
 	viper.BindPFlag("docker-image-repository", pf.Lookup("docker-image-repository"))
-	viper.BindPFlag("operator-webhook-service-host", pf.Lookup("operator-webhook-service-host"))
-	viper.BindPFlag("operator-webhook-service-port", pf.Lookup("operator-webhook-service-port"))
-	viper.BindPFlag("provider", pf.Lookup("provider"))
 	viper.BindPFlag("docker-image-tag", rootCmd.PersistentFlags().Lookup("docker-image-tag"))
+	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
+	viper.BindPFlag("log-level", pf.Lookup("log-level"))
 	viper.BindPFlag("max-boshdeployment-workers", pf.Lookup("max-boshdeployment-workers"))
 	viper.BindPFlag("max-extendedjob-workers", pf.Lookup("max-extendedjob-workers"))
 	viper.BindPFlag("max-extendedsecret-workers", pf.Lookup("max-extendedsecret-workers"))
 	viper.BindPFlag("max-extendedstatefulset-workers", rootCmd.PersistentFlags().Lookup("max-extendedstatefulset-workers"))
-	viper.BindPFlag("apply-crd", rootCmd.PersistentFlags().Lookup("apply-crd"))
+	viper.BindPFlag("operator-webhook-service-host", pf.Lookup("operator-webhook-service-host"))
+	viper.BindPFlag("operator-webhook-service-port", pf.Lookup("operator-webhook-service-port"))
+	viper.BindPFlag("provider", pf.Lookup("provider"))
 
 	argToEnv := map[string]string{
-		"kubeconfig":                      "KUBECONFIG",
-		"log-level":                       "LOG_LEVEL",
+		"apply-crd":                       "APPLY_CRD",
+		"ctx-timeout":                     "CTX_TIMEOUT",
 		"cf-operator-namespace":           "CF_OPERATOR_NAMESPACE",
 		"docker-image-org":                "DOCKER_IMAGE_ORG",
 		"docker-image-repository":         "DOCKER_IMAGE_REPOSITORY",
-		"operator-webhook-service-host":   "CF_OPERATOR_WEBHOOK_SERVICE_HOST",
-		"operator-webhook-service-port":   "CF_OPERATOR_WEBHOOK_SERVICE_PORT",
-		"provider":                        "PROVIDER",
 		"docker-image-tag":                "DOCKER_IMAGE_TAG",
+		"kubeconfig":                      "KUBECONFIG",
+		"log-level":                       "LOG_LEVEL",
 		"max-boshdeployment-workers":      "MAX_BOSHDEPLOYMENT_WORKERS",
 		"max-extendedjob-workers":         "MAX_EXTENDEDJOB_WORKERS",
 		"max-extendedsecret-workers":      "MAX_EXTENDEDSECRET_WORKERS",
 		"max-extendedstatefulset-workers": "MAX_EXTENDEDSTATEFULSET_WORKERS",
-		"apply-crd":                       "APPLY_CRD",
+		"operator-webhook-service-host":   "CF_OPERATOR_WEBHOOK_SERVICE_HOST",
+		"operator-webhook-service-port":   "CF_OPERATOR_WEBHOOK_SERVICE_PORT",
+		"provider":                        "PROVIDER",
 	}
 
 	// Add env variables to help

--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -65,6 +65,7 @@ helm delete cf-operator --purge
 | `rbacEnable`                                      | install required RBAC service account, roles and rolebindings                     | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name  | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`         |                                                |
+| `contextTimeout`                                  | Will set the context timeout in seconds, for future K8S API requests              | `30`                                           |
 
 ## RBAC
 

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -27,6 +27,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CTX_TIMEOUT
+              value: "{{ .Values.contextTimeout }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -30,6 +30,7 @@ var _ = Describe("CLI", func() {
 			Eventually(session.Out).Should(Say(`Flags:
       --apply-crd                              \(APPLY_CRD\) If true, apply CRDs on start \(default true\)
   -n, --cf-operator-namespace string           \(CF_OPERATOR_NAMESPACE\) Namespace to watch for BOSH deployments \(default "default"\)
+      --ctx-timeout int                        \(CTX_TIMEOUT\) context timeout for each k8s API request in seconds \(default 30\)
   -o, --docker-image-org string                \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
   -r, --docker-image-repository string         \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)
   -t, --docker-image-tag string                \(DOCKER_IMAGE_TAG\) Tag of the operator docker image \(default "\d+.\d+.\d+"\)
@@ -41,7 +42,8 @@ var _ = Describe("CLI", func() {
       --max-extendedsecret-workers int         \(MAX_EXTENDEDSECRET_WORKERS\) Maximum number of workers concurrently running ExtendedSecret controller \(default 5\)
       --max-extendedstatefulset-workers int    \(MAX_EXTENDEDSTATEFULSET_WORKERS\) Maximum number of workers concurrently running ExtendedStatefulSet controller \(default 1\)
   -w, --operator-webhook-service-host string   \(CF_OPERATOR_WEBHOOK_SERVICE_HOST\) Hostname/IP under which the webhook server can be reached from the cluster
-  -p, --operator-webhook-service-port string   \(CF_OPERATOR_WEBHOOK_SERVICE_PORT\) Port the webhook server listens on \(default "2999"\)`))
+  -p, --operator-webhook-service-port string   \(CF_OPERATOR_WEBHOOK_SERVICE_PORT\) Port the webhook server listens on \(default "2999"\)
+  -x, --provider string                        \(PROVIDER\) Cloud Provider where cf-operator is being deployed`))
 		})
 
 		It("shows all available commands", func() {

--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -7,8 +7,6 @@ import (
 )
 
 const (
-	// CtxTimeOut is the default context.Context timeout
-	CtxTimeOut = 30 * time.Second
 	// MeltdownDuration is the duration of the meltdown period, in which we
 	// postpone further reconciles for the same resource
 	MeltdownDuration = 10 * time.Second
@@ -34,9 +32,9 @@ type Config struct {
 }
 
 // NewConfig returns a new Config for a Manager of Controllers
-func NewConfig(namespace string, provider string, host string, port int32, fs afero.Fs, maxBoshDeploymentWorkers, maxExtendedJobWorkers, maxExtendedSecretWorkers, maxExtendedStatefulSetWorkers int, applyCRD bool) *Config {
+func NewConfig(namespace string, ctxTimeOut int, provider string, host string, port int32, fs afero.Fs, maxBoshDeploymentWorkers, maxExtendedJobWorkers, maxExtendedSecretWorkers, maxExtendedStatefulSetWorkers int, applyCRD bool) *Config {
 	return &Config{
-		CtxTimeOut:                    CtxTimeOut,
+		CtxTimeOut:                    time.Duration(ctxTimeOut) * time.Second,
 		MeltdownDuration:              MeltdownDuration,
 		MeltdownRequeueAfter:          MeltdownRequeueAfter,
 		Namespace:                     namespace,


### PR DESCRIPTION
This includes
- a new cf-operator persistent flag `ctx-timeout`, default to 30 seconds
- a new ENV variable, that can set the above flag from the helm charts, via a variable in the `values.yml`.
  This is the `contextTimeout` variable.
- Alphabetically order all cobra/viper flags, so that in the future, is more clear which flags we have,
  before adding a new one.
- Remove hardcoded default context deadline timeout.
- Fix missing flag, inside the `cli_test.go` specs.


 [#168535029](https://www.pivotaltracker.com/n/projects/2192232/stories/168535029)