### PR TITLE
Propagate image-pull policy into generated pods

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -157,7 +157,7 @@ func init() {
 	pf.StringP("docker-image-org", "o", "cfcontainerization", "Dockerhub organization that provides the operator docker image")
 	pf.StringP("docker-image-repository", "r", "cf-operator", "Dockerhub repository that provides the operator docker image")
 	pf.StringP("docker-image-tag", "t", version.Version, "Tag of the operator docker image")
-	pf.StringP("docker-image-pull-policy", "", string(corev1.PullAlways), "Image pull policy")
+	pf.StringP("docker-image-pull-policy", "", string(corev1.PullIfNotPresent), "Image pull policy")
 	pf.StringP("bosh-dns-docker-image", "", "coredns/coredns:1.6.3", "The docker image used for emulating bosh DNS (a CoreDNS image)")
 	pf.StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
 	pf.StringP("log-level", "l", "debug", "Only print log messages from this level onward")

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 
 	"github.com/go-logr/zapr"
@@ -68,6 +70,7 @@ var rootCmd = &cobra.Command{
 			viper.GetString("docker-image-org"),
 			viper.GetString("docker-image-repository"),
 			viper.GetString("docker-image-tag"),
+			viper.GetString("docker-image-pull-policy"),
 		)
 		if err != nil {
 			return wrapError(err, "Couldn't parse cf-operator docker image reference.")
@@ -154,6 +157,7 @@ func init() {
 	pf.StringP("docker-image-org", "o", "cfcontainerization", "Dockerhub organization that provides the operator docker image")
 	pf.StringP("docker-image-repository", "r", "cf-operator", "Dockerhub repository that provides the operator docker image")
 	pf.StringP("docker-image-tag", "t", version.Version, "Tag of the operator docker image")
+	pf.StringP("docker-image-pull-policy", "", string(corev1.PullAlways), "Image pull policy")
 	pf.StringP("bosh-dns-docker-image", "", "coredns/coredns:1.6.3", "The docker image used for emulating bosh DNS (a CoreDNS image)")
 	pf.StringP("kubeconfig", "c", "", "Path to a kubeconfig, not required in-cluster")
 	pf.StringP("log-level", "l", "debug", "Only print log messages from this level onward")
@@ -172,6 +176,7 @@ func init() {
 	viper.BindPFlag("docker-image-org", pf.Lookup("docker-image-org"))
 	viper.BindPFlag("docker-image-repository", pf.Lookup("docker-image-repository"))
 	viper.BindPFlag("docker-image-tag", rootCmd.PersistentFlags().Lookup("docker-image-tag"))
+	viper.BindPFlag("docker-image-pull-policy", rootCmd.PersistentFlags().Lookup("docker-image-pull-policy"))
 	viper.BindPFlag("bosh-dns-docker-image", rootCmd.PersistentFlags().Lookup("bosh-dns-docker-image"))
 	viper.BindPFlag("kubeconfig", pf.Lookup("kubeconfig"))
 	viper.BindPFlag("log-level", pf.Lookup("log-level"))
@@ -191,6 +196,7 @@ func init() {
 		"docker-image-org":                       "DOCKER_IMAGE_ORG",
 		"docker-image-repository":                "DOCKER_IMAGE_REPOSITORY",
 		"docker-image-tag":                       "DOCKER_IMAGE_TAG",
+		"docker-image-pull-policy":               "DOCKER_IMAGE_PULL_POLICY",
 		"bosh-dns-docker-image":                  "BOSH_DNS_DOCKER_IMAGE",
 		"kubeconfig":                             "KUBECONFIG",
 		"log-level":                              "LOG_LEVEL",

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -45,6 +45,8 @@ spec:
               value: "{{ .Values.image.repository }}"
             - name: DOCKER_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
+            - name: DOCKER_IMAGE_PULL_POLICY
+              value: "{{ .Values.image.pullPolicy }}"
             - name: CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE
               value: "{{ .Values.operator.webhookUseServiceReference }}"
           readinessProbe:

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -33,6 +33,7 @@ var _ = Describe("CLI", func() {
   -n, --cf-operator-namespace string             \(CF_OPERATOR_NAMESPACE\) The operator namespace \(default "default"\)
       --ctx-timeout int                          \(CTX_TIMEOUT\) context timeout for each k8s API request in seconds \(default 30\)
   -o, --docker-image-org string                  \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
+      --docker-image-pull-policy string          \(DOCKER_IMAGE_PULL_POLICY\) Image pull policy \(default "IfNotPresent"\)
   -r, --docker-image-repository string           \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)
   -t, --docker-image-tag string                  \(DOCKER_IMAGE_TAG\) Tag of the operator docker image \(default "\d+.\d+.\d+"\)
   -h, --help                                     help for cf-operator

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/cf-operator
 
 require (
-	code.cloudfoundry.org/quarks-job v0.0.0-20191011125438-1091c831c0e7
+	code.cloudfoundry.org/quarks-job v0.0.0-20191014152407-a2cfdb4e1f5c
 	code.cloudfoundry.org/quarks-utils v0.0.0-20191011134804-e632c6624b94
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ code.cloudfoundry.org/quarks-job v0.0.0-20191011100414-973318584d67 h1:3ff6rvSYK
 code.cloudfoundry.org/quarks-job v0.0.0-20191011100414-973318584d67/go.mod h1:m0oYwyebyY1B1Frlb3f196NUIGqcOml36A2dPzJWxBo=
 code.cloudfoundry.org/quarks-job v0.0.0-20191011125438-1091c831c0e7 h1:U2B5ghl4VSeZK+6BEw4vSfbyQPTofyrvt+qSm1Afyl4=
 code.cloudfoundry.org/quarks-job v0.0.0-20191011125438-1091c831c0e7/go.mod h1:vr9ZuQ16kAXjcShhs0HNH+piDxZDYw39FuzmC6mpQQw=
+code.cloudfoundry.org/quarks-job v0.0.0-20191014152407-a2cfdb4e1f5c h1:iblrAmZteo+1+wFupdQsC4kJ1pyCOZ2Wkxkbcytm1Xc=
+code.cloudfoundry.org/quarks-job v0.0.0-20191014152407-a2cfdb4e1f5c/go.mod h1:vr9ZuQ16kAXjcShhs0HNH+piDxZDYw39FuzmC6mpQQw=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191011093601-6222c5e935d6 h1:K9XDIALNuhG9FlUf3vhpzjyJ3sSxnb3vmwBxcbIbjYg=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191011093601-6222c5e935d6/go.mod h1:pz+JWJd3D4wfK2xPImLwPL7x+n17NpBp6vdpZ68iINI=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191011123930-d0e4a67beeac h1:a7V6vTdhVdFi6cdYQVUM9FxyB/1m6st41Y62itsyoUY=

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -84,7 +86,7 @@ func (e *Environment) setupCFOperator() (manager.Manager, error) {
 		return nil, errors.Errorf("required environment variable DOCKER_IMAGE_TAG not set")
 	}
 
-	err = converter.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag)
+	err = converter.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag, string(corev1.PullAlways))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -246,9 +246,10 @@ func (c *ContainerFactoryImpl) JobsToContainers(
 // logsTailerContainer is a container that tails all logs in /var/vcap/sys/log.
 func logsTailerContainer(instanceGroupName string) corev1.Container {
 	return corev1.Container{
-		Name:         "logs",
-		Image:        GetOperatorDockerImage(),
-		VolumeMounts: []corev1.VolumeMount{*sysDirVolumeMount()},
+		Name:            "logs",
+		Image:           GetOperatorDockerImage(),
+		ImagePullPolicy: GetOperatorImagePullPolicy(),
+		VolumeMounts:    []corev1.VolumeMount{*sysDirVolumeMount()},
 		Args: []string{
 			"util",
 			"tail-logs",
@@ -268,8 +269,9 @@ func logsTailerContainer(instanceGroupName string) corev1.Container {
 func containerRunCopier() corev1.Container {
 	dstDir := fmt.Sprintf("%s/container-run", VolumeRenderingDataMountPath)
 	return corev1.Container{
-		Name:  "container-run-copier",
-		Image: GetOperatorDockerImage(),
+		Name:            "container-run-copier",
+		Image:           GetOperatorDockerImage(),
+		ImagePullPolicy: GetOperatorImagePullPolicy(),
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      VolumeRenderingDataName,
@@ -312,8 +314,9 @@ func jobSpecCopierContainer(releaseName string, jobImage string, volumeMountName
 
 func templateRenderingContainer(instanceGroupName string, secretName string) corev1.Container {
 	return corev1.Container{
-		Name:  "template-render",
-		Image: GetOperatorDockerImage(),
+		Name:            "template-render",
+		Image:           GetOperatorDockerImage(),
+		ImagePullPolicy: GetOperatorImagePullPolicy(),
 		VolumeMounts: []corev1.VolumeMount{
 			*renderingVolumeMount(),
 			*jobsDirVolumeMount(),
@@ -366,10 +369,11 @@ func createDirContainer(jobs []bdm.Job) corev1.Container {
 	}
 
 	return corev1.Container{
-		Name:         "create-dirs",
-		Image:        GetOperatorDockerImage(),
-		VolumeMounts: []corev1.VolumeMount{*dataDirVolumeMount(), *sysDirVolumeMount()},
-		Command:      []string{"/usr/bin/dumb-init", "--"},
+		Name:            "create-dirs",
+		Image:           GetOperatorDockerImage(),
+		ImagePullPolicy: GetOperatorImagePullPolicy(),
+		VolumeMounts:    []corev1.VolumeMount{*dataDirVolumeMount(), *sysDirVolumeMount()},
+		Command:         []string{"/usr/bin/dumb-init", "--"},
 		Args: []string{
 			"/bin/sh",
 			"-xc",

--- a/pkg/bosh/converter/docker_image.go
+++ b/pkg/bosh/converter/docker_image.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"code.cloudfoundry.org/quarks-job/pkg/kube/controllers/extendedjob"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
@@ -9,7 +11,7 @@ import (
 var operatorDockerImage = ""
 
 // SetupOperatorDockerImage initializes the package scoped variable
-func SetupOperatorDockerImage(org, repo, tag string) error {
+func SetupOperatorDockerImage(org, repo, tag, pullPolicy string) error {
 	var err error
 	operatorDockerImage, err = names.GetDockerSourceName(org, repo, tag)
 	if err != nil {
@@ -18,10 +20,19 @@ func SetupOperatorDockerImage(org, repo, tag string) error {
 
 	// setup quarks job docker image, too.
 	// will have to change this once the persist command is moved to quarks-job
-	return extendedjob.SetupOperatorDockerImage(org, repo, tag)
+	err = extendedjob.SetupOperatorDockerImage(org, repo, tag)
+	if err != nil {
+		return err
+	}
+	return extendedjob.SetupOperatorImagePullPolicy(pullPolicy)
 }
 
 // GetOperatorDockerImage returns the image name of the operator docker image
 func GetOperatorDockerImage() string {
 	return operatorDockerImage
+}
+
+// GetOperatorImagePullPolicy returns the image pull policy to be used for generated pods
+func GetOperatorImagePullPolicy() corev1.PullPolicy {
+	return extendedjob.GetOperatorImagePullPolicy()
 }

--- a/pkg/bosh/converter/job_factory.go
+++ b/pkg/bosh/converter/job_factory.go
@@ -116,10 +116,11 @@ func (f *JobFactory) VariableInterpolationJob(manifest bdm.Manifest) (*ejv1.Exte
 					RestartPolicy: corev1.RestartPolicyOnFailure,
 					Containers: []corev1.Container{
 						{
-							Name:         VarInterpolationContainerName,
-							Image:        GetOperatorDockerImage(),
-							Args:         args,
-							VolumeMounts: volumeMounts,
+							Name:            VarInterpolationContainerName,
+							Image:           GetOperatorDockerImage(),
+							ImagePullPolicy: GetOperatorImagePullPolicy(),
+							Args:            args,
+							VolumeMounts:    volumeMounts,
 							Env: []corev1.EnvVar{
 								{
 									Name:  EnvBOSHManifestPath,
@@ -178,9 +179,10 @@ func (f *JobFactory) BPMConfigsJob(manifest bdm.Manifest) (*ejv1.ExtendedJob, er
 
 func (f *JobFactory) gatheringContainer(cmd, desiredManifestName string, instanceGroupName string) corev1.Container {
 	return corev1.Container{
-		Name:  names.Sanitize(instanceGroupName),
-		Image: GetOperatorDockerImage(),
-		Args:  []string{"util", cmd},
+		Name:            names.Sanitize(instanceGroupName),
+		Image:           GetOperatorDockerImage(),
+		ImagePullPolicy: GetOperatorImagePullPolicy(),
+		Args:            []string{"util", cmd},
 		VolumeMounts: []corev1.VolumeMount{
 			withOpsVolumeMount(desiredManifestName),
 			releaseSourceVolumeMount(),

--- a/pkg/kube/operator/operator_test.go
+++ b/pkg/kube/operator/operator_test.go
@@ -4,14 +4,16 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("operator", func() {
 	Describe("GetOperatorDockerImage", func() {
 		It("returns the location of the docker image", func() {
-			err := converter.SetupOperatorDockerImage("foo", "bar", "1.2.3")
+			err := converter.SetupOperatorDockerImage("foo", "bar", "1.2.3", "Always")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(converter.GetOperatorDockerImage()).To(Equal("foo/bar:1.2.3"))
+			Expect(converter.GetOperatorImagePullPolicy()).To(Equal(corev1.PullAlways))
 		})
 	})
 })


### PR DESCRIPTION
With this change we propagate the helm value `image.pullPolicy` into the generated pods (which use the cf-operator image).
This mitigates #634