### PR TITLE
Respect update serial in bosh manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ tags
 /tmp/
 *.coverprofile
 .envrc
+testing/assets/output.json

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ webhooks:
 
 The `cf-operator` watches four different types of custom resources:
 
-- BoshDeployment
-- ExtendedJob
-- ExtendedSecret
-- ExtendedStatefulset
+- [BoshDeployment](docs/controllers/boshdeployment.md)
+- [ExtendedJob](https://github.com/cloudfoundry-incubator/quarks-job/blob/master/docs/extendedjob.md)
+- [ExtendedSecret](docs/controllers/extendedsecret.md)
+- [ExtendedStatefulset](docs/controllers/extendedstatefulset.md)
 
 The `cf-operator` requires the according CRDs to be installed in the cluster in order to work as expected. By default, the `cf-operator` applies CRDs in your cluster automatically.
 

--- a/cmd/internal/wait.go
+++ b/cmd/internal/wait.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(waitCmd)
+}
+
+var waitCmd = &cobra.Command{
+	Use:   "wait",
+	Short: "Wait for required service",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		for {
+			if _, err := net.LookupIP(args[0]); err == nil {
+				break
+			}
+			fmt.Printf("Waiting for %s to be reachable\n", args[0])
+			time.Sleep(time.Second * 5)
+		}
+	},
+}

--- a/cmd/internal/wait.go
+++ b/cmd/internal/wait.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(waitCmd)
+	utilCmd.AddCommand(waitCmd)
 }
 
 var waitCmd = &cobra.Command{

--- a/cmd/internal/wait.go
+++ b/cmd/internal/wait.go
@@ -5,21 +5,31 @@ import (
 	"net"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	utilCmd.AddCommand(waitCmd)
+	waitCmd.Flags().IntP("timeout", "", 30*60, "timeout in seconds after the required service must be available")
+	viper.BindPFlag("timeout", waitCmd.Flags().Lookup("timeout"))
 }
 
+// waitCmd is used to wait for a service (e.g. database), which is required for the calling job (e.g. cloud-controller).
+// This command is used to implement the update.serial flag in the BOSH manifest
 var waitCmd = &cobra.Command{
 	Use:   "wait",
 	Short: "Wait for required service",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		expiry := time.Now().Add(time.Duration(viper.GetInt("timeout")) * time.Second)
 		for {
+			if time.Now().After(expiry) {
+				return fmt.Errorf("timeout during waiting for %s to be reachable", args[0])
+			}
 			if _, err := net.LookupIP(args[0]); err == nil {
-				break
+				return nil
 			}
 			fmt.Printf("Waiting for %s to be reachable\n", args[0])
 			time.Sleep(time.Second * 5)

--- a/docs/controllers/boshdeployment.md
+++ b/docs/controllers/boshdeployment.md
@@ -28,6 +28,8 @@ The ops files modify the deployment manifest. For example, ops files can be used
 A deployment is represented by the `boshdeployments.fissile.cloudfoundry.org` (`bdpl`) custom resource, defined in [`boshdeployment_crd.yaml`](https://github.com/cloudfoundry-incubator/cf-operator/tree/master/deploy/helm/cf-operator/templates/fissile_v1alpha1_boshdeployment_crd.yaml).
 This [bdpl custom resource](https://github.com/cloudfoundry-incubator/cf-operator/tree/master/docs/examples/bosh-deployment/boshdeployment.yaml) contains references to config maps or secrets containing the actual manifests content.
 
+The name of the `bdpl` resource has to match the [deployment name](https://bosh.io/docs/manifest-v2/#deployment) in the BOSH manifest.
+
 After creating the `bdpl` resource on Kubernetes, i.e. via `kubectl apply`, the CF operator will start reconciliation, which will eventually result in the deployment
 of the BOSH release on Kubernetes.
 

--- a/e2e/cli/util_variable_interpolation_test.go
+++ b/e2e/cli/util_variable_interpolation_test.go
@@ -41,7 +41,7 @@ var _ = Describe("variable-interpolation", func() {
 			dataBytes, err := ioutil.ReadFile(filepath.Join(assetPath, "output.json"))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(string(dataBytes)).To(Equal(`{"manifest.yaml":"director_uuid: \"\"\ninstance_groups:\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    baz\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    foo\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    bar\n  stemcell: \"\"\n  vm_resources: null\nname: |\n  fake-password\n"}`))
+			Expect(string(dataBytes)).To(Equal(`{"manifest.yaml":"director_uuid: \"\"\ninstance_groups:\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    baz\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    foo\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    bar\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\nname: |\n  fake-password\n"}`))
 		})
 	})
 })

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -122,12 +122,12 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, env.DefaultBOSHDeployment("test-bdpl", "diego-manifest"))
+			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, env.DefaultBOSHDeployment("diego", "diego-manifest"))
 			Expect(err).NotTo(HaveOccurred())
 			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
 			By("checking for instance group pods")
-			err = env.WaitForInstanceGroup(env.Namespace, "test-bdpl", "file_server", "1", 2)
+			err = env.WaitForInstanceGroup(env.Namespace, "diego", "file_server", "1", 2)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for instance group pods from deployment")
 
 			By("checking for containers")
@@ -186,12 +186,12 @@ var _ = Describe("Deploy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			tearDowns = append(tearDowns, tearDown)
 
-			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, env.DefaultBOSHDeployment("test-bdpl", "router-manifest"))
+			_, tearDown, err = env.CreateBOSHDeployment(env.Namespace, env.DefaultBOSHDeployment("routing", "router-manifest"))
 			Expect(err).NotTo(HaveOccurred())
 			tearDowns = append(tearDowns, tearDown)
 
 			By("checking for instance group pods")
-			err = env.WaitForInstanceGroup(env.Namespace, "test-bdpl", "route_registrar", "1", 2)
+			err = env.WaitForInstanceGroup(env.Namespace, "routing", "route_registrar", "1", 2)
 			Expect(err).NotTo(HaveOccurred(), "error waiting for instance group pods from deployment")
 
 			By("checking for containers")

--- a/integration/storage/deploy_with_storage_test.go
+++ b/integration/storage/deploy_with_storage_test.go
@@ -14,10 +14,8 @@ import (
 )
 
 var _ = Describe("DeployWithStorage", func() {
-
 	Context("when using multiple processes in BPM", func() {
 		It("should add multiple containers to a pod", func() {
-
 			By("Creating a secret for implicit variable")
 			storageClass, ok := os.LookupEnv("OPERATOR_TEST_STORAGE_CLASS")
 			Expect(ok).To(Equal(true))

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -100,7 +100,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 	bpmDisks disk.BPMResourceDisks,
 ) (essv1.ExtendedStatefulSet, error) {
 	defaultVolumeMounts := defaultDisks.VolumeMounts()
-	initContainers, err := cfac.JobsToInitContainers(instanceGroup.Jobs, defaultVolumeMounts, bpmDisks)
+	initContainers, err := cfac.JobsToInitContainers(instanceGroup.Jobs, defaultVolumeMounts, bpmDisks, instanceGroup.Properties.Quarks.RequiredService)
 	if err != nil {
 		return essv1.ExtendedStatefulSet{}, errors.Wrapf(err, "building initContainers failed for instance group %s", instanceGroup.Name)
 	}
@@ -181,17 +181,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 func (kc *KubeConverter) serviceToKubeServices(manifestName string, dns manifest.DomainNameService, instanceGroup *bdm.InstanceGroup, eSts *essv1.ExtendedStatefulSet) []corev1.Service {
 	var services []corev1.Service
 	// Collect ports to be exposed for each job
-	ports := []corev1.ServicePort{}
-	for _, job := range instanceGroup.Jobs {
-		for _, port := range job.Properties.Quarks.Ports {
-			ports = append(ports, corev1.ServicePort{
-				Name:     port.Name,
-				Protocol: corev1.Protocol(port.Protocol),
-				Port:     int32(port.Internal),
-			})
-		}
-	}
-
+	ports := instanceGroup.ServicePorts()
 	if len(ports) == 0 {
 		return services
 	}
@@ -277,7 +267,7 @@ func (kc *KubeConverter) errandToExtendedJob(
 	bpmDisks disk.BPMResourceDisks,
 ) (ejv1.ExtendedJob, error) {
 	defaultVolumeMounts := defaultDisks.VolumeMounts()
-	initContainers, err := cfac.JobsToInitContainers(instanceGroup.Jobs, defaultVolumeMounts, bpmDisks)
+	initContainers, err := cfac.JobsToInitContainers(instanceGroup.Jobs, defaultVolumeMounts, bpmDisks, instanceGroup.Properties.Quarks.RequiredService)
 	if err != nil {
 		return ejv1.ExtendedJob{}, errors.Wrapf(err, "building initContainers failed for instance group %s", instanceGroup.Name)
 	}

--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -164,7 +164,7 @@ func createWaitContainer(requiredService *string) []corev1.Container {
 		Args: []string{
 			"/bin/sh",
 			"-xc",
-			fmt.Sprintf("cf-operator wait %s", *requiredService),
+			fmt.Sprintf("cf-operator util wait %s", *requiredService),
 		},
 	}}
 

--- a/pkg/bosh/converter/container_factory_test.go
+++ b/pkg/bosh/converter/container_factory_test.go
@@ -547,7 +547,7 @@ var _ = Describe("ContainerFactory", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(containers).To(HaveLen(7))
 				Expect(containers[4].Name).To(Equal("wait-for"))
-				Expect(containers[4].Args).To(ContainElement(`cf-operator wait required-service`))
+				Expect(containers[4].Args).To(ContainElement(`cf-operator util wait required-service`))
 			})
 
 			It("generates per job directories", func() {

--- a/pkg/bosh/converter/container_factory_test.go
+++ b/pkg/bosh/converter/container_factory_test.go
@@ -530,7 +530,7 @@ var _ = Describe("ContainerFactory", func() {
 
 	Context("JobsToInitContainers", func() {
 		act := func() ([]corev1.Container, error) {
-			return containerFactory.JobsToInitContainers(jobs, defaultVolumeMounts, bpmDisks)
+			return containerFactory.JobsToInitContainers(jobs, defaultVolumeMounts, bpmDisks, nil)
 		}
 
 		Context("when multiple jobs are configured", func() {
@@ -539,6 +539,15 @@ var _ = Describe("ContainerFactory", func() {
 					"fake-job":  bpm.Config{},
 					"other-job": bpm.Config{},
 				}
+			})
+
+			It("respects required services", func() {
+				requiredService := "required-service"
+				containers, err := containerFactory.JobsToInitContainers(jobs, defaultVolumeMounts, bpmDisks, &requiredService)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(containers).To(HaveLen(7))
+				Expect(containers[4].Name).To(Equal("wait-for"))
+				Expect(containers[4].Args).To(ContainElement(`cf-operator wait required-service`))
 			})
 
 			It("generates per job directories", func() {

--- a/pkg/bosh/converter/fakes/container_factory.go
+++ b/pkg/bosh/converter/fakes/container_factory.go
@@ -26,12 +26,13 @@ type FakeContainerFactory struct {
 		result1 []v1.Container
 		result2 error
 	}
-	JobsToInitContainersStub        func([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks) ([]v1.Container, error)
+	JobsToInitContainersStub        func([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks, *string) ([]v1.Container, error)
 	jobsToInitContainersMutex       sync.RWMutex
 	jobsToInitContainersArgsForCall []struct {
 		arg1 []manifest.Job
 		arg2 []v1.VolumeMount
 		arg3 disk.BPMResourceDisks
+		arg4 *string
 	}
 	jobsToInitContainersReturns struct {
 		result1 []v1.Container
@@ -120,7 +121,7 @@ func (fake *FakeContainerFactory) JobsToContainersReturnsOnCall(i int, result1 [
 	}{result1, result2}
 }
 
-func (fake *FakeContainerFactory) JobsToInitContainers(arg1 []manifest.Job, arg2 []v1.VolumeMount, arg3 disk.BPMResourceDisks) ([]v1.Container, error) {
+func (fake *FakeContainerFactory) JobsToInitContainers(arg1 []manifest.Job, arg2 []v1.VolumeMount, arg3 disk.BPMResourceDisks, arg4 *string) ([]v1.Container, error) {
 	var arg1Copy []manifest.Job
 	if arg1 != nil {
 		arg1Copy = make([]manifest.Job, len(arg1))
@@ -137,11 +138,12 @@ func (fake *FakeContainerFactory) JobsToInitContainers(arg1 []manifest.Job, arg2
 		arg1 []manifest.Job
 		arg2 []v1.VolumeMount
 		arg3 disk.BPMResourceDisks
-	}{arg1Copy, arg2Copy, arg3})
-	fake.recordInvocation("JobsToInitContainers", []interface{}{arg1Copy, arg2Copy, arg3})
+		arg4 *string
+	}{arg1Copy, arg2Copy, arg3, arg4})
+	fake.recordInvocation("JobsToInitContainers", []interface{}{arg1Copy, arg2Copy, arg3, arg4})
 	fake.jobsToInitContainersMutex.Unlock()
 	if fake.JobsToInitContainersStub != nil {
-		return fake.JobsToInitContainersStub(arg1, arg2, arg3)
+		return fake.JobsToInitContainersStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -156,17 +158,17 @@ func (fake *FakeContainerFactory) JobsToInitContainersCallCount() int {
 	return len(fake.jobsToInitContainersArgsForCall)
 }
 
-func (fake *FakeContainerFactory) JobsToInitContainersCalls(stub func([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks) ([]v1.Container, error)) {
+func (fake *FakeContainerFactory) JobsToInitContainersCalls(stub func([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks, *string) ([]v1.Container, error)) {
 	fake.jobsToInitContainersMutex.Lock()
 	defer fake.jobsToInitContainersMutex.Unlock()
 	fake.JobsToInitContainersStub = stub
 }
 
-func (fake *FakeContainerFactory) JobsToInitContainersArgsForCall(i int) ([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks) {
+func (fake *FakeContainerFactory) JobsToInitContainersArgsForCall(i int) ([]manifest.Job, []v1.VolumeMount, disk.BPMResourceDisks, *string) {
 	fake.jobsToInitContainersMutex.RLock()
 	defer fake.jobsToInitContainersMutex.RUnlock()
 	argsForCall := fake.jobsToInitContainersArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeContainerFactory) JobsToInitContainersReturns(result1 []v1.Container, result2 error) {

--- a/pkg/bosh/converter/kube_converter.go
+++ b/pkg/bosh/converter/kube_converter.go
@@ -23,7 +23,7 @@ type KubeConverter struct {
 
 // ContainerFactory builds Kubernetes containers from BOSH jobs.
 type ContainerFactory interface {
-	JobsToInitContainers(jobs []bdm.Job, defaultVolumeMounts []corev1.VolumeMount, bpmDisks disk.BPMResourceDisks) ([]corev1.Container, error)
+	JobsToInitContainers(jobs []bdm.Job, defaultVolumeMounts []corev1.VolumeMount, bpmDisks disk.BPMResourceDisks, requiredService *string) ([]corev1.Container, error)
 	JobsToContainers(jobs []bdm.Job, defaultVolumeMounts []corev1.VolumeMount, bpmDisks disk.BPMResourceDisks) ([]corev1.Container, error)
 }
 

--- a/pkg/bosh/converter/resolver.go
+++ b/pkg/bosh/converter/resolver.go
@@ -106,8 +106,9 @@ func (r *ResolverImpl) WithOpsManifest(ctx context.Context, instance *bdv1.BOSHD
 		}
 	}
 
+	instanceName := instance.GetName()
 	// Reload the manifest after interpolation, and apply implicit variables
-	manifest, err := bdm.LoadYAML(bytes)
+	manifest, err := bdm.LoadYAMLWithName(bytes, &instanceName)
 	if err != nil {
 		return nil, []string{}, errors.Wrapf(err, "Loading yaml failed in interpolation task after applying ops %#v", m)
 	}
@@ -135,6 +136,8 @@ func (r *ResolverImpl) WithOpsManifest(ctx context.Context, instance *bdv1.BOSHD
 	if err != nil {
 		return nil, varSecrets, errors.Wrapf(err, "failed to apply addons")
 	}
+
+	manifest.CalculateRequiredServices()
 
 	return manifest, varSecrets, err
 }
@@ -181,8 +184,9 @@ func (r *ResolverImpl) WithOpsManifestDetailed(ctx context.Context, instance *bd
 		log.Debugf(ctx, "Applied ops file '%s' for deployment '%s'", op.Name, instance.Name)
 	}
 
+	instanceName := instance.GetName()
 	// Reload the manifest after interpolation, and apply implicit variables
-	manifest, err := bdm.LoadYAML(bytes)
+	manifest, err := bdm.LoadYAMLWithName(bytes, &instanceName)
 	if err != nil {
 		return nil, []string{}, errors.Wrapf(err, "Loading yaml failed in interpolation task after applying ops %#v", m)
 	}
@@ -210,6 +214,8 @@ func (r *ResolverImpl) WithOpsManifestDetailed(ctx context.Context, instance *bd
 	if err != nil {
 		return nil, varSecrets, errors.Wrapf(err, "failed to apply addons")
 	}
+
+	manifest.CalculateRequiredServices()
 
 	return manifest, varSecrets, err
 }

--- a/pkg/bosh/converter/resolver.go
+++ b/pkg/bosh/converter/resolver.go
@@ -106,9 +106,8 @@ func (r *ResolverImpl) WithOpsManifest(ctx context.Context, instance *bdv1.BOSHD
 		}
 	}
 
-	instanceName := instance.GetName()
 	// Reload the manifest after interpolation, and apply implicit variables
-	manifest, err := bdm.LoadYAMLWithName(bytes, &instanceName)
+	manifest, err := bdm.LoadYAML(bytes)
 	if err != nil {
 		return nil, []string{}, errors.Wrapf(err, "Loading yaml failed in interpolation task after applying ops %#v", m)
 	}
@@ -184,9 +183,8 @@ func (r *ResolverImpl) WithOpsManifestDetailed(ctx context.Context, instance *bd
 		log.Debugf(ctx, "Applied ops file '%s' for deployment '%s'", op.Name, instance.Name)
 	}
 
-	instanceName := instance.GetName()
 	// Reload the manifest after interpolation, and apply implicit variables
-	manifest, err := bdm.LoadYAMLWithName(bytes, &instanceName)
+	manifest, err := bdm.LoadYAML(bytes)
 	if err != nil {
 		return nil, []string{}, errors.Wrapf(err, "Loading yaml failed in interpolation task after applying ops %#v", m)
 	}

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -815,7 +815,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			dns := m.DNS
 			Expect(dns).NotTo(BeNil())
-			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("foo-singleton-uaa"))
+			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("scf-singleton-uaa"))
 		})
 
 		It("handles multi-line implicit vars", func() {
@@ -836,7 +836,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(implicitVars)).To(Equal(1))
 			Expect(implicitVars[0]).To(Equal("foo-deployment.var-implicit-ca"))
-			Expect(m.InstanceGroups[0].Properties["ca"]).To(Equal("complicated\n'multiline'\nstring"))
+			Expect(m.InstanceGroups[0].Properties.Properties["ca"]).To(Equal("complicated\n'multiline'\nstring"))
 		})
 
 		It("handles embedded variables", func() {
@@ -857,7 +857,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(implicitVars)).To(Equal(1))
 			Expect(implicitVars[0]).To(Equal("foo-deployment.var-system-domain"))
-			Expect(m.InstanceGroups[0].Properties["host"]).To(Equal("foo.example.com"))
+			Expect(m.InstanceGroups[0].Properties.Properties["host"]).To(Equal("foo.example.com"))
 		})
 	})
 })

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -133,7 +133,7 @@ variables:
 					Namespace: "default",
 				},
 				Data: map[string]string{bdc.ManifestSpecName: `---
-name: foo
+name: manifest-with-dns
 addons:
 - name: bosh-dns-aliases
   jobs:
@@ -815,7 +815,7 @@ instance_groups:
 			Expect(err).ToNot(HaveOccurred())
 			dns := m.DNS
 			Expect(dns).NotTo(BeNil())
-			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("scf-singleton-uaa"))
+			Expect(dns.HeadlessServiceName("singleton-uaa")).To(Equal("manifest-with-dns-singleton-uaa"))
 		})
 
 		It("handles multi-line implicit vars", func() {

--- a/pkg/bosh/manifest/cmd_interpolate_test.go
+++ b/pkg/bosh/manifest/cmd_interpolate_test.go
@@ -44,7 +44,7 @@ instance_groups:
 		Expect(err).ToNot(HaveOccurred())
 		Expect(err).To(BeNil())
 
-		Expect(string(dataBytes)).To(Equal(`{"manifest.yaml":"director_uuid: \"\"\ninstance_groups:\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    baz\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    foo\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    bar\n  stemcell: \"\"\n  vm_resources: null\nname: |\n  fake-password\n"}`))
+		Expect(string(dataBytes)).To(Equal(`{"manifest.yaml":"director_uuid: \"\"\ninstance_groups:\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    baz\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    foo\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\n- azs: null\n  env:\n    bosh:\n      agent:\n        settings: {}\n      ipv6:\n        enable: false\n  instances: 0\n  jobs: null\n  name: |\n    bar\n  properties:\n    quarks: {}\n  stemcell: \"\"\n  vm_resources: null\nname: |\n  fake-password\n"}`))
 	})
 
 	It("raises error when variablesDir is not directory", func() {

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -202,8 +202,8 @@ func (m *Manifest) loadDNS() error {
 
 // CalculateRequiredServices calculates the required services using the update.serial property
 func (m *Manifest) CalculateRequiredServices() {
-	var requiredService *string = nil
-	var requiredSerialService *string = nil
+	var requiredService *string
+	var requiredSerialService *string
 
 	for _, ig := range m.InstanceGroups {
 		serial := true
@@ -212,14 +212,6 @@ func (m *Manifest) CalculateRequiredServices() {
 		}
 		if ig.Update != nil && ig.Update.Serial != nil {
 			serial = *ig.Update.Serial
-		}
-
-		//FIXME This is required because eirini is inserted as last instance group in https://github.com/SUSE/scf
-		// Without this condition, eirini would wait for all other instance groups. On the other hand, there are
-		// instance groups, which require eirini. Therefore, without this condition there will be a deadlock
-		// This can be removed, if the position of eirini in scf is fixed.
-		if strings.Contains(ig.Name, "eirini") {
-			continue
 		}
 
 		if serial {

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -158,11 +158,6 @@ type duplicateYamlValue struct {
 
 // LoadYAML returns a new BOSH deployment manifest from a yaml representation
 func LoadYAML(data []byte) (*Manifest, error) {
-	return LoadYAMLWithName(data, nil)
-}
-
-// LoadYAMLWithName returns a new BOSH deployment manifest from a yaml representation with the given name
-func LoadYAMLWithName(data []byte, name *string) (*Manifest, error) {
 	m := &Manifest{}
 	err := yaml.Unmarshal(data, m, func(opt *json.Decoder) *json.Decoder {
 		opt.UseNumber()
@@ -170,9 +165,6 @@ func LoadYAMLWithName(data []byte, name *string) (*Manifest, error) {
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal BOSH deployment manifest %s", string(data))
-	}
-	if name != nil {
-		m.Name = *name
 	}
 
 	if err := m.loadDNS(); err != nil {

--- a/pkg/bosh/manifest/manifest_test.go
+++ b/pkg/bosh/manifest/manifest_test.go
@@ -1084,7 +1084,7 @@ var _ = Describe("Manifest", func() {
 				manifest, err := LoadYAML([]byte(boshmanifest.BPMReleaseWithAffinity))
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(manifest.Name).To(Equal("bpm"))
+				Expect(manifest.Name).To(Equal("bpm-affinity"))
 
 				ig := manifest.InstanceGroups[0]
 				Expect(ig.Name).To(Equal("bpm1"))
@@ -1265,6 +1265,7 @@ var _ = Describe("Manifest", func() {
 					Expect(hc).ToNot(BeNil())
 					Expect(hc["test-server"].ReadinessProbe.Handler.Exec.Command).To(ContainElement("curl --silent --fail --head http://${HOSTNAME}:8080/health"))
 				})
+
 				It("serializes instancegroup quarks", func() {
 					m1.CalculateRequiredServices()
 					text, err := m1.Marshal()
@@ -1274,9 +1275,9 @@ var _ = Describe("Manifest", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(manifest.InstanceGroups).To(HaveLen(3))
 					Expect(manifest.InstanceGroups[0].Properties.Quarks.RequiredService).To(BeNil())
-					expectedRequireService := "bpm-bpm1"
+					expectedRequireService := "bpm-affinity-bpm1"
 					Expect(manifest.InstanceGroups[1].Properties.Quarks.RequiredService).To(Equal(&expectedRequireService))
-					expectedRequireService = "bpm-bpm2"
+					expectedRequireService = "bpm-affinity-bpm2"
 					Expect(manifest.InstanceGroups[2].Properties.Quarks.RequiredService).To(Equal(&expectedRequireService))
 
 				})

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -221,7 +221,7 @@ releases:
 
 // NatsSmall is a small manifest to start nats
 const NatsSmall = `---
-name: my-manifest
+name: test
 releases:
 - name: nats
   version: "26"
@@ -252,7 +252,7 @@ instance_groups:
 
 // NatsSmallWithPatch is a manifest that patches the prestart hook to loop forever
 const NatsSmallWithPatch = `---
-name: my-manifest
+name: test
 releases:
 - name: nats
   version: "26"
@@ -725,7 +725,7 @@ instance_groups:
 
 // BPMRelease utilizing the test server to open two tcp ports
 const BPMRelease = `
-name: bpm
+name: test-bdpl
 
 releases:
 - name: bpm
@@ -906,7 +906,7 @@ instance_groups:
 
 // BPMReleaseWithAffinity contains affinity information
 const BPMReleaseWithAffinity = `
-name: bpm
+name: bpm-affinity
 
 releases:
 - name: bpm

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -2644,3 +2644,152 @@ instance_groups:
   name: log-api
 name: scf-dev
 variables: []`
+
+// BPMReleaseWithUpdateSerial contains a manifest with some dependent instance groups
+const BPMReleaseWithUpdateSerial = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+update:
+  serial: false
+instance_groups:
+- name: bpm1
+  update:
+    serial: true
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+- name: bpm2
+  update:
+    serial: false
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+- name: bpm3
+  update:
+    serial: false
+  jobs:
+  - name: test-server3
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+- name: bpm4
+  update:
+    serial: true
+  jobs:
+  - name: test-server4
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+
+`
+
+// BPMReleaseWithUpdateSerialInManifest contains a manifest with bosh serial on manifest level
+const BPMReleaseWithUpdateSerialInManifest = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+update:
+  serial: false
+instance_groups:
+- name: bpm1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+- name: bpm2
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+`
+
+// BPMReleaseWithUpdateSerialAndWithoutPorts contains a manifest with serial but without ports
+const BPMReleaseWithUpdateSerialAndWithoutPorts = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+update:
+  serial: true
+instance_groups:
+- name: bpm1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+- name: bpm2
+  jobs:
+  - name: test-server
+    release: bpm
+- name: bpm3
+  update:
+    serial: true
+  jobs:
+  - name: test-server
+    release: bpm
+`

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -648,3 +648,30 @@ func (c *Catalog) NodePortService(name, ig string, targetPort int32) corev1.Serv
 		},
 	}
 }
+
+// BOSHManifestWithUpdateSerial returns a manifest with update serial
+func (c *Catalog) BOSHManifestWithUpdateSerial() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithUpdateSerial))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}
+
+// BOSHManifestWithUpdateSerialInManifest returns a manifest with update serial in manifest
+func (c *Catalog) BOSHManifestWithUpdateSerialInManifest() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithUpdateSerialInManifest))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}
+
+// BOSHManifestWithUpdateSerialAndWithoutPorts returns a manifest with update serial and without ports
+func (c *Catalog) BOSHManifestWithUpdateSerialAndWithoutPorts() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithUpdateSerialAndWithoutPorts))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}


### PR DESCRIPTION
Fixes #636 

This introduces an initContainer waiting for another instance group to be reachable via service if the `update: serial` is set accordingly in the manifest.

This results in faster startup times since there are fewer crashes and `CrashLoopBackOff`s. Also the startup phase looks a bit smoother.

There are still some crashes left (e.g. one container of `api` crashes if the database is not migrated yet, this is done by another container)

There is a special handling of the eirini instance group inside `manifest.go`, because eirini is patched at the wrong position inside the manifest. We will prepare a PR for scf to fix this (https://github.com/SUSE/scf/pull/2980). Afterward, this special handling can be removed.

We tried to write an e2e test. But we had several problems to run e2e tests with multiple instance groups (#645 ). 