### PR TITLE
Fix shellcheck warning in dump_env.sh

### DIFF
--- a/testing/dump_env.sh
+++ b/testing/dump_env.sh
@@ -7,7 +7,7 @@ NS="$1"
 echo "Collecting environment information for namespace ${NS}"
 
 function get_resources() {
-  kubectl get $1 --namespace "${NS}" --output=jsonpath='{.items[*].metadata.name}'
+  kubectl get "$1" --namespace "${NS}" --output=jsonpath='{.items[*].metadata.name}'
 }
 
 function describe_resource() {


### PR DESCRIPTION
The main intent of this PR is checking the new CFF CLA bot.