### PR TITLE
Support external endpoint

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -153,7 +153,7 @@ func init() {
 	pf.Int("max-extendedstatefulset-workers", 1, "Maximum number of workers concurrently running ExtendedStatefulSet controller")
 	pf.StringP("operator-webhook-service-host", "w", "", "Hostname/IP under which the webhook server can be reached from the cluster")
 	pf.StringP("operator-webhook-service-port", "p", "2999", "Port the webhook server listens on")
-	pf.BoolP("operator-webhook-use-service-reference", "x", false, "If true the webhook service is targetted using a service reference instead of a URL")
+	pf.BoolP("operator-webhook-use-service-reference", "x", false, "If true the webhook service is targeted using a service reference instead of a URL")
 
 	for _, name := range []string{
 		"bosh-dns-docker-image",

--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -59,9 +59,9 @@ helm delete cf-operator --purge
 | Parameter                                         | Description                                                                          | Default                                        |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------- |
 | `operator.watchNamespace`                         | namespace the operator will watch for BOSH deployments                               | the release namespace                          |
-| `operator.webhook.host`                           | Hostname/IP under which the webhook server can be reached from the cluster           | the IP of service `cf-operator-webhook `       |
+| `operator.webhook.endpoint`                       | Hostname/IP under which the webhook server can be reached from the cluster           | the IP of service `cf-operator-webhook `       |
 | `operator.webhook.port`                           | Port the webhook server listens on                                                   | 2999                                           |
-| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | false                                          |
+| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | `true`                                          |
 | `image.repository`                                | docker hub repository for the cf-operator image                                      | `cf-operator`                                  |
 | `image.org`                                       | docker hub organization for the cf-operator image                                    | `cfcontainerization`                           |
 | `image.tag`                                       | docker image tag                                                                     | `foobar`                                       |
@@ -73,7 +73,7 @@ helm delete cf-operator --purge
 
 > **Note:**
 >
-> `operator.webhook.useServiceReference` will override `operator.webhook.host` configuration
+> `operator.webhook.useServiceReference` will override `operator.webhook.endpoint` configuration
 >
 
 ## Watched namespace

--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -56,18 +56,25 @@ helm delete cf-operator --purge
 
 ## Configuration
 
-| Parameter                                         | Description                                                                       | Default                                        |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `operator.watchNamespace`                         | namespace the operator will watch for BOSH deployments                            | the release namespace                          |
-| `operator.webhookUseServiceReference`             | If true, the webhook server is addressed using a service reference instead of the IP | false                                       |
-| `image.repository`                                | docker hub repository for the cf-operator image                                   | `cf-operator`                                  |
-| `image.org`                                       | docker hub organization for the cf-operator image                                 | `cfcontainerization`                           |
-| `image.tag`                                       | docker image tag                                                                  | `foobar`                                       |
-| `image.pullPolicy`                                | Kubernetes image pullPolicy                                                       | `IfNotPresent`                                 |
-| `rbacEnable`                                      | install required RBAC service account, roles and rolebindings                     | `true`                                         |
-| `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name  | `true`                                         |
-| `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`         |                                                |
-| `contextTimeout`                                  | Will set the context timeout in seconds, for future K8S API requests              | `30`                                           |
+| Parameter                                         | Description                                                                          | Default                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `operator.watchNamespace`                         | namespace the operator will watch for BOSH deployments                               | the release namespace                          |
+| `operator.webhook.host`                           | Hostname/IP under which the webhook server can be reached from the cluster           | the IP of service `cf-operator-webhook `       |
+| `operator.webhook.port`                           | Port the webhook server listens on                                                   | 2999                                           |
+| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | false                                          |
+| `image.repository`                                | docker hub repository for the cf-operator image                                      | `cf-operator`                                  |
+| `image.org`                                       | docker hub organization for the cf-operator image                                    | `cfcontainerization`                           |
+| `image.tag`                                       | docker image tag                                                                     | `foobar`                                       |
+| `image.pullPolicy`                                | Kubernetes image pullPolicy                                                          | `IfNotPresent`                                 |
+| `rbacEnable`                                      | install required RBAC service account, roles and rolebindings                        | `true`                                         |
+| `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name     | `true`                                         |
+| `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`            |                                                |
+| `contextTimeout`                                  | Will set the context timeout in seconds, for future K8S API requests                 | `30`                                           |
+
+> **Note:**
+>
+> `operator.webhook.useServiceReference` will override `operator.webhook.host` configuration
+>
 
 ## Watched namespace
 

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -20,7 +20,7 @@ spec:
           - containerPort: 60000
             name: metrics
           - containerPort: 2999
-            name: operator-webhook
+            name: webhook
           command:
           - cf-operator
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -53,13 +53,12 @@ spec:
               value: "{{ .Values.image.tag }}"
             - name: DOCKER_IMAGE_PULL_POLICY
               value: "{{ .Values.image.pullPolicy }}"
-            {{- if .Values.operator.webhook.host }}
+            {{- if and .Values.operator.webhook.endpoint (not .Values.operator.webhook.useServiceReference) }}
             - name: CF_OPERATOR_WEBHOOK_SERVICE_HOST
-              value: {{ .Values.operator.webhook.host | quote }}
+              value: {{ .Values.operator.webhook.endpoint | quote }}
             {{- end }}
-              value: {{ .Release.Name }}-webhook
             - name: CF_OPERATOR_WEBHOOK_SERVICE_PORT
-              value: {{ .Values.operator.webhook.host | quote }}
+              value: {{ .Values.operator.webhook.port | quote }}
             {{- if .Values.operator.webhook.useServiceReference  }}
             - name: CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE
               value: "{{ .Values.operator.webhook.useServiceReference }}"

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -19,6 +19,8 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
+          - containerPort: 2999
+            name: operator-webhook
           command:
           - cf-operator
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -51,8 +53,17 @@ spec:
               value: "{{ .Values.image.tag }}"
             - name: DOCKER_IMAGE_PULL_POLICY
               value: "{{ .Values.image.pullPolicy }}"
+            {{- if .Values.operator.webhook.host }}
+            - name: CF_OPERATOR_WEBHOOK_SERVICE_HOST
+              value: {{ .Values.operator.webhook.host | quote }}
+            {{- end }}
+              value: {{ .Release.Name }}-webhook
+            - name: CF_OPERATOR_WEBHOOK_SERVICE_PORT
+              value: {{ .Values.operator.webhook.host | quote }}
+            {{- if .Values.operator.webhook.useServiceReference  }}
             - name: CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE
-              value: "{{ .Values.operator.webhookUseServiceReference }}"
+              value: "{{ .Values.operator.webhook.useServiceReference }}"
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /readyz

--- a/deploy/helm/cf-operator/templates/service.yaml
+++ b/deploy/helm/cf-operator/templates/service.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   name: cf-operator-webhook
 spec:
+  {{- if or .Values.operator.webhook.useServiceReference (not .Values.operator.webhook.endpoint) }}
   selector:
     name: cf-operator
+  {{- end }}
   ports:
   - port: 443
     targetPort: 2999

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -8,9 +8,10 @@ image:
 operator:
   watchNamespace: ""
   webhook:
+    endpoint: ~
     host: ~
     port: "2999"
-    useServiceReference: false
+    useServiceReference: true
 
 cluster:
   domain: ~

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -7,7 +7,10 @@ image:
 
 operator:
   watchNamespace: ""
-  webhookUseServiceReference: true
+  webhook:
+    host: ~
+    port: "2999"
+    useServiceReference: false
 
 cluster:
   domain: ~

--- a/docs/commands/cf-operator.md
+++ b/docs/commands/cf-operator.md
@@ -31,7 +31,7 @@ cf-operator [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```
 

--- a/docs/commands/cf-operator_util.md
+++ b/docs/commands/cf-operator_util.md
@@ -37,7 +37,7 @@ Calls a utility subcommand.
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```
 

--- a/docs/commands/cf-operator_util_bpm-configs.md
+++ b/docs/commands/cf-operator_util_bpm-configs.md
@@ -44,7 +44,7 @@ cf-operator util bpm-configs [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_util_instance-group.md
+++ b/docs/commands/cf-operator_util_instance-group.md
@@ -44,7 +44,7 @@ cf-operator util instance-group [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_util_persist-output.md
+++ b/docs/commands/cf-operator_util_persist-output.md
@@ -43,7 +43,7 @@ cf-operator util persist-output [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_util_tail-logs.md
+++ b/docs/commands/cf-operator_util_tail-logs.md
@@ -46,7 +46,7 @@ cf-operator util tail-logs [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_util_template-render.md
+++ b/docs/commands/cf-operator_util_template-render.md
@@ -50,7 +50,7 @@ cf-operator util template-render [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_util_variable-interpolation.md
+++ b/docs/commands/cf-operator_util_variable-interpolation.md
@@ -45,7 +45,7 @@ cf-operator util variable-interpolation [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --output-file-path string                  (OUTPUT_FILE_PATH) Path of the file to which json output is redirected.
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```

--- a/docs/commands/cf-operator_version.md
+++ b/docs/commands/cf-operator_version.md
@@ -36,7 +36,7 @@ cf-operator version [flags]
       --max-extendedstatefulset-workers int      (MAX_EXTENDEDSTATEFULSET_WORKERS) Maximum number of workers concurrently running ExtendedStatefulSet controller (default 1)
   -w, --operator-webhook-service-host string     (CF_OPERATOR_WEBHOOK_SERVICE_HOST) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     (CF_OPERATOR_WEBHOOK_SERVICE_PORT) Port the webhook server listens on (default "2999")
-  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   (CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE) If true the webhook service is targeted using a service reference instead of a URL
       --watch-namespace string                   (WATCH_NAMESPACE) Namespace to watch for BOSH deployments
 ```
 

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -47,7 +47,7 @@ var _ = Describe("CLI", func() {
       --operator-namespace string                \(OPERATOR_NAMESPACE\) The operator namespace \(default "default"\)
   -w, --operator-webhook-service-host string     \(CF_OPERATOR_WEBHOOK_SERVICE_HOST\) Hostname/IP under which the webhook server can be reached from the cluster
   -p, --operator-webhook-service-port string     \(CF_OPERATOR_WEBHOOK_SERVICE_PORT\) Port the webhook server listens on \(default "2999"\)
-  -x, --operator-webhook-use-service-reference   \(CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE\) If true the webhook service is targetted using a service reference instead of a URL
+  -x, --operator-webhook-use-service-reference   \(CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE\) If true the webhook service is targeted using a service reference instead of a URL
       --watch-namespace string                   \(WATCH_NAMESPACE\) Namespace to watch for BOSH deployments`))
 		})
 


### PR DESCRIPTION
[#167507466](https://www.pivotaltracker.com/story/show/167507466)


- Set `operator.webhook.endpoint` and `operator.webhook.useServiceReference` both
```
bjxzi$ helm template deploy/helm/cf-operator/ --set operator.webhook.endpoint=fake.com,operator.webhook.useServiceReference=true
---
# Source: cf-operator/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: cf-operator-webhook
spec:
  selector:
    name: cf-operator
  ports:
  - port: 443
    targetPort: 2999

---
# Source: cf-operator/templates/operator.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-cf-operator
spec:
  replicas: 1
  selector:
    matchLabels:
      name: cf-operator
  template:
    metadata:
      labels:
        name: cf-operator
    spec:
      serviceAccountName: release-name-cf-operator
      containers:
        - name: cf-operator
          image: "cfcontainerization/cf-operator:foobar"
          ports:
          - containerPort: 60000
            name: metrics
          - containerPort: 2999
            name: operator-webhook
          command:
          - cf-operator
          imagePullPolicy: "IfNotPresent"
          env:
            - name: CF_OPERATOR_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: CTX_TIMEOUT
              value: ""
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: "cf-operator"
            - name: DOCKER_IMAGE_ORG
              value: "cfcontainerization"
            - name: DOCKER_IMAGE_REPOSITORY
              value: "cf-operator"
            - name: DOCKER_IMAGE_TAG
              value: "foobar"
            - name: DOCKER_IMAGE_PULL_POLICY
              value: "IfNotPresent"
            - name: CF_OPERATOR_WEBHOOK_SERVICE_PORT
              value: "2999"
            - name: CF_OPERATOR_WEBHOOK_USE_SERVICE_REFERENCE
              value: "true"
          readinessProbe:
            httpGet:
              path: /readyz
              port: 2999
              scheme: "HTTPS"
            initialDelaySeconds: 2

```

- Set `operator.webhook.endpoint`
```
bjxzi$ helm template deploy/helm/cf-operator/ --set operator.webhook.endpoint=fake.com
---
# Source: cf-operator/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: cf-operator-webhook
spec:
  ports:
  - port: 443
    targetPort: 2999

---
# Source: cf-operator/templates/operator.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-cf-operator
spec:
  replicas: 1
  selector:
    matchLabels:
      name: cf-operator
  template:
    metadata:
      labels:
        name: cf-operator
    spec:
      serviceAccountName: release-name-cf-operator
      containers:
        - name: cf-operator
          image: "cfcontainerization/cf-operator:foobar"
          ports:
          - containerPort: 60000
            name: metrics
          - containerPort: 2999
            name: operator-webhook
          command:
          - cf-operator
          imagePullPolicy: "IfNotPresent"
          env:
            - name: CF_OPERATOR_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: CTX_TIMEOUT
              value: ""
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: "cf-operator"
            - name: DOCKER_IMAGE_ORG
              value: "cfcontainerization"
            - name: DOCKER_IMAGE_REPOSITORY
              value: "cf-operator"
            - name: DOCKER_IMAGE_TAG
              value: "foobar"
            - name: DOCKER_IMAGE_PULL_POLICY
              value: "IfNotPresent"
            - name: CF_OPERATOR_WEBHOOK_SERVICE_HOST
              value: "fake.com"
            - name: CF_OPERATOR_WEBHOOK_SERVICE_PORT
              value: "2999"
          readinessProbe:
            httpGet:
              path: /readyz
              port: 2999
              scheme: "HTTPS"
            initialDelaySeconds: 2

```