### PR TITLE
Base image contains dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-FROM alpine AS dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/bin/dumb-init
-RUN chmod +x /usr/bin/dumb-init
-
 FROM golang:1.13.3 AS build
 ARG GOPROXY
 ENV GOPROXY $GOPROXY
@@ -20,11 +16,11 @@ RUN make build && \
     cp -p binaries/cf-operator /usr/local/bin/cf-operator
 RUN ./bin/build-container-run /usr/local/bin
 
-FROM cfcontainerization/cf-operator-base@sha256:2bb233fea55317729ebba6636976459e56d3c6605eaf3c54774449e9507341a5
+FROM cfcontainerization/cf-operator-base@sha256:6495dd2e427e716fcdf1153dbca57e5ac6b1c68ca34c6ebb23be46d186fc2474
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
+RUN cp /usr/sbin/dumb-init /usr/bin/dumb-init
 USER vcap
-COPY --from=dumb-init /usr/bin/dumb-init /usr/bin/dumb-init
 COPY --from=build /usr/local/bin/cf-operator /usr/local/bin/cf-operator
 COPY --from=build /usr/local/bin/container-run /usr/local/bin/container-run
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "cf-operator"]

--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -19,6 +19,7 @@ import (
 var (
 	rootUserID = int64(0)
 	vcapUserID = int64(1000)
+	entrypoint = []string{"/usr/bin/dumb-init", "--"}
 )
 
 const (
@@ -278,7 +279,7 @@ func containerRunCopier() corev1.Container {
 				MountPath: VolumeRenderingDataMountPath,
 			},
 		},
-		Command: []string{"/usr/bin/dumb-init", "--"},
+		Command: entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-c",
@@ -303,7 +304,7 @@ func jobSpecCopierContainer(releaseName string, jobImage string, volumeMountName
 				MountPath: VolumeRenderingDataMountPath,
 			},
 		},
-		Command: []string{"/usr/bin/dumb-init", "--"},
+		Command: entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-xc",
@@ -344,7 +345,7 @@ func templateRenderingContainer(instanceGroupName string, secretName string) cor
 				},
 			},
 		},
-		Command: []string{"/usr/bin/dumb-init", "--"},
+		Command: entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-xc",
@@ -365,7 +366,7 @@ func createDirContainer(jobs []bdm.Job) corev1.Container {
 		Image:           GetOperatorDockerImage(),
 		ImagePullPolicy: GetOperatorImagePullPolicy(),
 		VolumeMounts:    []corev1.VolumeMount{*dataDirVolumeMount(), *sysDirVolumeMount()},
-		Command:         []string{"/usr/bin/dumb-init", "--"},
+		Command:         entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-xc",
@@ -402,7 +403,7 @@ func boshPreStartInitContainer(
 		Name:         names.Sanitize(fmt.Sprintf("bosh-pre-start-%s", jobName)),
 		Image:        jobImage,
 		VolumeMounts: deduplicateVolumeMounts(volumeMounts),
-		Command:      []string{"/usr/bin/dumb-init", "--"},
+		Command:      entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-xc",
@@ -443,7 +444,7 @@ func bpmPreStartInitContainer(
 		Name:         names.Sanitize(fmt.Sprintf("bpm-pre-start-%s", process.Name)),
 		Image:        jobImage,
 		VolumeMounts: deduplicateVolumeMounts(volumeMounts),
-		Command:      []string{"/usr/bin/dumb-init", "--"},
+		Command:      entrypoint,
 		Args: []string{
 			"/bin/sh",
 			"-xc",


### PR DESCRIPTION
Don't download it every time.

One problem was that the RPM used in the `cf-operator-base` image installs to `/usr/sbin`, but the job containers are based on the fissile stemcell and use `/usr/bin` for `dumb-init`.