### PR TITLE
No longer source .envrc in scripts

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-export DOCKER_IMAGE_ORG=${DOCKER_IMAGE_ORG:-'cfcontainerization'}
-
-[ -f .envrc.local ] && . ./.envrc.local

--- a/bin/build-helm
+++ b/bin/build-helm
@@ -5,7 +5,6 @@ set -euo pipefail
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . "${GIT_ROOT}/bin/include/versioning"
 . "${GIT_ROOT}/bin/include/docker"
-. "${GIT_ROOT}/.envrc"
 
 output_dir=${GIT_ROOT}/helm
 filename="${output_dir}/${ARTIFACT_NAME}-${ARTIFACT_VERSION}.tgz"

--- a/bin/build-image
+++ b/bin/build-image
@@ -5,7 +5,6 @@ set -o errexit
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
 . "${GIT_ROOT}/bin/include/docker"
-. "${GIT_ROOT}/.envrc"
 
 image="${DOCKER_IMAGE_ORG}/cf-operator:${DOCKER_IMAGE_TAG}"
 

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -5,7 +5,6 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
 . "${GIT_ROOT}/bin/include/docker"
 . "${GIT_ROOT}/bin/include/testing"
-. "${GIT_ROOT}/.envrc"
 
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"

--- a/bin/up
+++ b/bin/up
@@ -4,7 +4,6 @@ set -e
 
 . ./bin/include/versioning
 . ./bin/include/docker
-. ./.envrc
 
 if [ -z "$SKIP_IMAGE" ]; then
   bin/build-image


### PR DESCRIPTION
direnv and .envrc are meant to unclutter the shell, not provide defaults
to scripts.
The defaults can be set before running scripts, the one value
DOCKER_IMAGE_ORG was already set in `bin/include/docker`.