### PR TITLE
Make helm chart values available to quarks-job

### DIFF
--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -58,18 +58,18 @@ helm delete cf-operator --purge
 
 | Parameter                                         | Description                                                                          | Default                                        |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| `operator.watchNamespace`                         | namespace the operator will watch for BOSH deployments                               | the release namespace                          |
+| `image.repository`                                | Docker hub repository for the cf-operator image                                      | `cf-operator`                                  |
+| `image.org`                                       | Docker hub organization for the cf-operator image                                    | `cfcontainerization`                           |
+| `image.tag`                                       | Docker image tag                                                                     | `foobar`                                       |
+| `global.contextTimeout`                           | Will set the context timeout in seconds, for future K8S API requests                 | `30`                                           |
+| `global.image.pullPolicy`                         | Kubernetes image pullPolicy                                                          | `IfNotPresent`                                 |
+| `global.operator.watchNamespace`                  | Namespace the operator will watch for BOSH deployments                               | the release namespace                          |
+| `global.rbacEnable`                               | Install required RBAC service account, roles and rolebindings                        | `true`                                         |
 | `operator.webhook.endpoint`                       | Hostname/IP under which the webhook server can be reached from the cluster           | the IP of service `cf-operator-webhook `       |
 | `operator.webhook.port`                           | Port the webhook server listens on                                                   | 2999                                           |
-| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | `true`                                          |
-| `image.repository`                                | docker hub repository for the cf-operator image                                      | `cf-operator`                                  |
-| `image.org`                                       | docker hub organization for the cf-operator image                                    | `cfcontainerization`                           |
-| `image.tag`                                       | docker image tag                                                                     | `foobar`                                       |
-| `image.pullPolicy`                                | Kubernetes image pullPolicy                                                          | `IfNotPresent`                                 |
-| `rbacEnable`                                      | install required RBAC service account, roles and rolebindings                        | `true`                                         |
+| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name     | `true`                                         |
 | `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`            |                                                |
-| `contextTimeout`                                  | Will set the context timeout in seconds, for future K8S API requests                 | `30`                                           |
 
 > **Note:**
 >
@@ -78,10 +78,10 @@ helm delete cf-operator --purge
 
 ## Watched namespace
 
-By default the operator will watch for BOSH deployments in the same namespace as it has been deployed to. Optionally, the watched namespace can be changed to something else using the `operator.watchNamespace` value, e.g.
+By default the operator will watch for BOSH deployments in the same namespace as it has been deployed to. Optionally, the watched namespace can be changed to something else using the `global.operator.watchNamespace` value, e.g.
 
 ```bash
-$ helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz --set operator.watchNamespace=staging
+$ helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz --set global.operator.watchNamespace=staging
 ```
 
 ## RBAC
@@ -91,5 +91,5 @@ By default, the helm chart will install RBAC ClusterRole and ClusterRoleBinding 
 The RBAC resources are enable by default. To disable:
 
 ```bash
-helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz --set rbacEnable=false
+helm install --namespace cf-operator --name cf-operator https://s3.amazonaws.com/cf-operators/helm-charts/cf-operator-v0.2.2%2B47.g24492ea.tgz --set global.rbacEnable=false
 ```

--- a/deploy/helm/cf-operator/templates/NOTES.txt
+++ b/deploy/helm/cf-operator/templates/NOTES.txt
@@ -22,9 +22,9 @@ Interacting with the cf-operator pod
   kubectl -n {{ .Release.Namespace }} logs $OPERATOR_POD -f
 
 3. Apply one of the BOSH deployment manifest examples
-  kubectl -n {{ if .Values.operator.watchNamespace }}{{ .Values.operator.watchNamespace }}{{ else }}{{ .Release.Namespace }}{{ end }} apply -f docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
+  kubectl -n {{ if .Values.global.operator.watchNamespace }}{{ .Values.global.operator.watchNamespace }}{{ else }}{{ .Release.Namespace }}{{ end }} apply -f docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
 
 4. See the cf-operator in action!
-  watch -c "kubectl -n {{ if .Values.operator.watchNamespace }}{{ .Values.operator.watchNamespace }}{{ else }}{{ .Release.Namespace }}{{ end }} get pods"
+  watch -c "kubectl -n {{ if .Values.global.operator.watchNamespace }}{{ .Values.global.operator.watchNamespace }}{{ else }}{{ .Release.Namespace }}{{ end }} get pods"
 
 {{- end -}}

--- a/deploy/helm/cf-operator/templates/cluster_role.yaml
+++ b/deploy/helm/cf-operator/templates/cluster_role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.global.rbacEnable }}
 ---
 apiVersion: v1
 kind: List

--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -23,11 +23,11 @@ spec:
             name: webhook
           command:
           - cf-operator
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | quote }}
           env:
-            {{- if .Values.operator.watchNamespace }}
+            {{- if .Values.global.operator.watchNamespace }}
             - name: WATCH_NAMESPACE
-              value: "{{ .Values.operator.watchNamespace }}"
+              value: "{{ .Values.global.operator.watchNamespace }}"
             {{- end}}
             {{- if .Values.cluster.domain }}
             - name: CLUSTER_DOMAIN
@@ -38,7 +38,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CTX_TIMEOUT
-              value: "{{ .Values.contextTimeout }}"
+              value: "{{ .Values.global.contextTimeout }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -52,7 +52,7 @@ spec:
             - name: DOCKER_IMAGE_TAG
               value: "{{ .Values.image.tag }}"
             - name: DOCKER_IMAGE_PULL_POLICY
-              value: "{{ .Values.image.pullPolicy }}"
+              value: "{{ .Values.global.image.pullPolicy }}"
             {{- if and .Values.operator.webhook.endpoint (not .Values.operator.webhook.useServiceReference) }}
             - name: CF_OPERATOR_WEBHOOK_SERVICE_HOST
               value: {{ .Values.operator.webhook.endpoint | quote }}

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -3,10 +3,8 @@ image:
   repository: cf-operator
   org: cfcontainerization
   tag: foobar
-  pullPolicy: IfNotPresent
 
 operator:
-  watchNamespace: ""
   webhook:
     endpoint: ~
     host: ~
@@ -17,6 +15,7 @@ cluster:
   domain: ~
 
 nameOverride: ""
+
 fullnameOverride: ""
 
 nodeSelector: {}
@@ -25,9 +24,21 @@ tolerations: []
 
 affinity: {}
 
-rbacEnable: true
-
 serviceAccount:
   cfOperatorServiceAccount:
     create: true
     name:
+
+global:
+  contextTimeout: 30
+  image:
+    pullPolicy: IfNotPresent
+  operator:
+    watchNamespace: ""
+  rbacEnable: true
+
+quarks-job:
+  serviceAccount:
+    quarksJobServiceAccount:
+      create: true
+      name:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/cf-operator
 
 require (
-	code.cloudfoundry.org/quarks-job v0.0.0-20191028122144-b5dc24039577
+	code.cloudfoundry.org/quarks-job v0.0.0-20191105155809-54988ad6d8ff
 	code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 code.cloudfoundry.org/quarks-job v0.0.0-20191028122144-b5dc24039577 h1:BRt1yXLb9y9Jss8CRdktLAgqZn9PTN6b2o/GB5j5VYA=
 code.cloudfoundry.org/quarks-job v0.0.0-20191028122144-b5dc24039577/go.mod h1:oPUO3zM/AbjdHBcQXWn+yUfHq0nEqUoNXIvTb9/V3hg=
+code.cloudfoundry.org/quarks-job v0.0.0-20191105155809-54988ad6d8ff h1:i0fx+vmEcF8+dVIl7m/bePEfErXYmiDk+lSl/UAR6EE=
+code.cloudfoundry.org/quarks-job v0.0.0-20191105155809-54988ad6d8ff/go.mod h1:oPUO3zM/AbjdHBcQXWn+yUfHq0nEqUoNXIvTb9/V3hg=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67 h1:n/yH3UyKOEZFuykJYHQk3fjihZELMREwUAuXX0YXSNc=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=


### PR DESCRIPTION
Moves several helm values to `global:` so they can be used by the quarks-job sub helm chart.

Also adds defaults for the separate quarks-job service account.

This depends on https://github.com/cloudfoundry-incubator/quarks-job/pull/17

[#169095052](https://www.pivotaltracker.com/story/show/169095052)