### PR TITLE
Fix bug with parallel coverage reporting

### DIFF
--- a/bin/coverage
+++ b/bin/coverage
@@ -3,6 +3,5 @@ set -eu
 
  # Send code coverage report to coveralls.io
 gover
-sed -i 's/\([0-9]\)\(code.cloudfoundry.org\)/\1\n\2/g' gover.coverprofile
 
 goveralls -coverprofile gover.coverprofile -jobId "$BUILD_NUMBER" -service concourse -repotoken "$COVERALLS_TOKEN"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -6,6 +6,8 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/docker"
 . "${GIT_ROOT}/bin/include/testing"
 
+name="$1"
+
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"
   export TEST_NAMESPACE
@@ -16,19 +18,16 @@ echo "Test logs are here: ${CF_OPERATOR_TESTING_TMP}/cf-operator-tests-*.log"
 setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
-GOVER_FILE=${GOVER_FILE:-gover-integration.coverprofile}
-
-pkgs="code.cloudfoundry.org/cf-operator/cmd/...,\
-code.cloudfoundry.org/cf-operator/pkg/bosh/...,\
-code.cloudfoundry.org/cf-operator/pkg/credsgen/...,\
-code.cloudfoundry.org/cf-operator/pkg/kube/operator/...,\
-code.cloudfoundry.org/cf-operator/pkg/kube/controllers/...,\
-code.cloudfoundry.org/cf-operator/pkg/kube/util/...,\
-code.cloudfoundry.org/cf-operator/pkg/kube/config/..."
-
 # Run code coverage only in CI
 if [ -n "$COVERAGE" ]; then
-  COV_ARG="-cover -outputdir=./code-coverage  -coverprofile=${GOVER_FILE} -coverpkg ${pkgs}"
+  pkgs="code.cloudfoundry.org/cf-operator/pkg/bosh/...,\
+    code.cloudfoundry.org/cf-operator/pkg/credsgen/...,\
+    code.cloudfoundry.org/cf-operator/pkg/kube/controllers/...,\
+    code.cloudfoundry.org/cf-operator/pkg/kube/operator/...,\
+    code.cloudfoundry.org/cf-operator/pkg/kube/util/...,\
+    code.cloudfoundry.org/cf-operator/pkg/kube/config/..."
+  pkgs=${pkgs// /}
+  COV_ARG="-cover -outputdir=./code-coverage -coverprofile=integration$name.coverprofile -coverpkg $pkgs"
   mkdir -p code-coverage
 fi
 
@@ -40,4 +39,4 @@ ginkgo ${FOCUS:+ --focus "$FOCUS"} \
   --slowSpecThreshold=50 \
   --flakeAttempts="$FLAKE_ATTEMPTS" \
   $COV_ARG \
-  integration/"$1"
+  integration/"$name"

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-GOVER_FILE=${GOVER_FILE:-gover-unit.coverprofile}
-
 # Run code coverage only in CI
-if [ -n "$COVERAGE" ]; then COV_ARG="-cover -outputdir=./code-coverage  -coverprofile=${GOVER_FILE}"; fi
+if [ -n "$COVERAGE" ]; then
+  COV_ARG="-cover -outputdir=./code-coverage"
+  mkdir -p code-coverage
+fi
 
-mkdir -p code-coverage
 ginkgo -p -r \
   --randomizeAllSpecs \
   -failOnPending \


### PR DESCRIPTION
I suspect a bug in ginkgo, with the previous combination of flags: https://github.com/cloudfoundry-incubator/cf-operator-ci/pull/98

To work around that, coverage is now reported into separate files, the
CI pipeline will have to adapt: https://github.com/cloudfoundry-incubator/cf-operator-ci/pull/98


[#169329385](https://www.pivotaltracker.com/story/show/169329385)