### PR TITLE
Fix generated dummy-container for volume management

### DIFF
--- a/pkg/kube/controllers/extendedstatefulset/volumes.go
+++ b/pkg/kube/controllers/extendedstatefulset/volumes.go
@@ -176,7 +176,7 @@ func (r *ReconcileExtendedStatefulSet) generateVolumeManagementSingleStatefulSet
 		VolumeMounts:    volumeMounts,
 		Image:           converter.GetOperatorDockerImage(),
 		ImagePullPolicy: converter.GetOperatorImagePullPolicy(),
-		Args: []string{
+		Command: []string{
 			"ruby",
 			"-e",
 			"sleep()",


### PR DESCRIPTION
The `volumeManagment` containers crash because of the `entrypoint` is set to the go-executable.
Using `command` instead of `args` fixes this.