### PR TITLE
Add optional image pull secret to service account

### DIFF
--- a/deploy/helm/cf-operator/README.md
+++ b/deploy/helm/cf-operator/README.md
@@ -56,20 +56,21 @@ helm delete cf-operator --purge
 
 ## Configuration
 
-| Parameter                                         | Description                                                                          | Default                                        |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| `image.repository`                                | Docker hub repository for the cf-operator image                                      | `cf-operator`                                  |
-| `image.org`                                       | Docker hub organization for the cf-operator image                                    | `cfcontainerization`                           |
-| `image.tag`                                       | Docker image tag                                                                     | `foobar`                                       |
-| `global.contextTimeout`                           | Will set the context timeout in seconds, for future K8S API requests                 | `30`                                           |
-| `global.image.pullPolicy`                         | Kubernetes image pullPolicy                                                          | `IfNotPresent`                                 |
-| `global.operator.watchNamespace`                  | Namespace the operator will watch for BOSH deployments                               | the release namespace                          |
-| `global.rbacEnable`                               | Install required RBAC service account, roles and rolebindings                        | `true`                                         |
-| `operator.webhook.endpoint`                       | Hostname/IP under which the webhook server can be reached from the cluster           | the IP of service `cf-operator-webhook `       |
-| `operator.webhook.port`                           | Port the webhook server listens on                                                   | 2999                                           |
-| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP | `true`                                         |
-| `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name     | `true`                                         |
-| `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`            |                                                |
+| Parameter                                         | Description                                                                                       | Default                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `image.repository`                                | Docker hub repository for the cf-operator image                                                   | `cf-operator`                                  |
+| `image.org`                                       | Docker hub organization for the cf-operator image                                                 | `cfcontainerization`                           |
+| `image.tag`                                       | Docker image tag                                                                                  | `foobar`                                       |
+| `global.contextTimeout`                           | Will set the context timeout in seconds, for future K8S API requests                              | `30`                                           |
+| `global.image.pullPolicy`                         | Kubernetes image pullPolicy                                                                       | `IfNotPresent`                                 |
+| `global.image.credentials`                        | Kubernetes image pull secret credentials (map with keys `servername`, `username`, and `password`) | `nil`                                          |
+| `global.operator.watchNamespace`                  | Namespace the operator will watch for BOSH deployments                                            | the release namespace                          |
+| `global.rbacEnable`                               | Install required RBAC service account, roles and rolebindings                                     | `true`                                         |
+| `operator.webhook.endpoint`                       | Hostname/IP under which the webhook server can be reached from the cluster                        | the IP of service `cf-operator-webhook `       |
+| `operator.webhook.port`                           | Port the webhook server listens on                                                                | 2999                                           |
+| `operator.webhook.useServiceReference`            | If true, the webhook server is addressed using a service reference instead of the IP              | `true`                                         |
+| `serviceAccount.cfOperatorServiceAccount.create`  | Will set the value of `cf-operator.serviceAccountName` to the current chart name                  | `true`                                         |
+| `serviceAccount.cfOperatorServiceAccount.name`    | If the above is not set, it will set the `cf-operator.serviceAccountName`                         |                                                |
 
 > **Note:**
 >

--- a/deploy/helm/cf-operator/templates/service_account.yaml
+++ b/deploy/helm/cf-operator/templates/service_account.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cf-operator.serviceAccountName" . }}
+{{- if .Values.global.image.credentials }}
+imagePullSecrets:
+- name: {{ template "cf-operator.serviceAccountName" . }}-pull-secret
+{{- end }}

--- a/deploy/helm/cf-operator/templates/service_account_pull_secret.yaml
+++ b/deploy/helm/cf-operator/templates/service_account_pull_secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.global.image.credentials }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ template "cf-operator.serviceAccountName" . }}-pull-secret
+data:
+  .dockerconfigjson: {{ printf "{%q:{%q:{%q:%q,%q:%q,%q:%q}}}" "auths" .Values.global.image.credentials.servername "username" .Values.global.image.credentials.username "password" .Values.global.image.credentials.password "auth" (printf "%s:%s" .Values.global.image.credentials.username .Values.global.image.credentials.password | b64enc) | b64enc }}
+{{- end }}

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -33,6 +33,7 @@ global:
   contextTimeout: 30
   image:
     pullPolicy: IfNotPresent
+    credentials: ~
   operator:
     watchNamespace: ""
   rbacEnable: true


### PR DESCRIPTION
Add service account image pull secret to cf-operator [#169646805]

In case the `cf-operator` Docker image needs to be stored in a private
registry, the service account needs to know which image pull secret to
use and the respective image pull secret needs to be there.

Add condition to service account deployment YAML to add an image pull
secret reference (imagePullSecrets).

Use aforementioned condition to render a deployment YAML for a secret,
that matches the service account setting.

Add empty credentials entry in `values.yaml` as the default, which means
that no credentials are required.

Usage example:
```
 helm install \
  --namespace cfo \
  --name cf-operator \
  --set global.image.credentials.servername=private.registry.io \
  --set global.image.credentials.username=token \
  --set global.image.credentials.password=$(vault supersecret) \
  https://foobar.com/cf-operator-v0.47.11.tgz
```