### PR TITLE
Propagate canary_watch_time to StatefulSet

### DIFF
--- a/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-bosh-dns.yaml
@@ -7,6 +7,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable-disable-sidecar.yaml
@@ -15,6 +15,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-custom-variable.yaml
@@ -15,6 +15,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment-with-implicit-variable.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-implicit-variable.yaml
@@ -15,6 +15,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment-with-persistent-disk.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-persistent-disk.yaml
@@ -17,6 +17,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment-with-service.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment-with-service.yaml
@@ -21,6 +21,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/docs/examples/bosh-deployment/boshdeployment.yaml
+++ b/docs/examples/bosh-deployment/boshdeployment.yaml
@@ -17,6 +17,8 @@ data:
   manifest: |
     ---
     name: nats-manifest
+    update:
+      canary_watch_time: "120000000"
     releases:
     - name: nats
       version: "26"

--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -123,6 +123,12 @@ func (kc *KubeConverter) serviceToExtendedSts(
 	volumeClaims = append(volumeClaims, defaultVolumeClaims...)
 	volumeClaims = append(volumeClaims, bpmVolumeClaims...)
 
+	statefulSetAnnotations := instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations
+	if statefulSetAnnotations == nil {
+		statefulSetAnnotations = make(map[string]string)
+	}
+	statefulSetAnnotations["quarks.cloudfoundry.org/canary-watch-time"] = instanceGroup.Update.CanaryWatchTime
+
 	extSts := essv1.ExtendedStatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        instanceGroup.ExtendedStatefulsetName(manifestName),
@@ -137,7 +143,7 @@ func (kc *KubeConverter) serviceToExtendedSts(
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        instanceGroup.NameSanitized(),
 					Labels:      instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Labels,
-					Annotations: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations,
+					Annotations: statefulSetAnnotations,
 				},
 				Spec: v1beta2.StatefulSetSpec{
 					Replicas: pointers.Int32(int32(instanceGroup.Instances)),

--- a/pkg/bosh/converter/bpm_resources_test.go
+++ b/pkg/bosh/converter/bpm_resources_test.go
@@ -263,6 +263,23 @@ var _ = Describe("kube converter", func() {
 					Expect(stS.Spec.Affinity).To(BeNil())
 				})
 			})
+			It("adds the canaryWatchTime of an instance group to an ExtendedStatefulSet", func() {
+				resources, err := act(bpmConfigs[1], m.InstanceGroups[1])
+				Expect(err).ShouldNot(HaveOccurred())
+
+				extStS := resources.InstanceGroups[0]
+				Expect(extStS.Spec.Template.Annotations).To(HaveKeyWithValue("quarks.cloudfoundry.org/canary-watch-time", "20000-1200000"))
+			})
+			It("combines the canaryWatchTime and custom annotations and adds them to ExtendedStatefulSet", func() {
+				m.InstanceGroups[1].Env.AgentEnvBoshConfig.Agent.Settings.Annotations = make(map[string]string)
+				m.InstanceGroups[1].Env.AgentEnvBoshConfig.Agent.Settings.Annotations["custom-annotation"] = "bar"
+				resources, err := act(bpmConfigs[1], m.InstanceGroups[1])
+				Expect(err).ShouldNot(HaveOccurred())
+
+				extStS := resources.InstanceGroups[0]
+				Expect(extStS.Spec.Template.Annotations).To(HaveKeyWithValue("quarks.cloudfoundry.org/canary-watch-time", "20000-1200000"))
+				Expect(extStS.Spec.Template.Annotations).To(HaveKeyWithValue("custom-annotation", "bar"))
+			})
 
 			It("converts the AgentEnvBoshConfig information", func() {
 				serviceAccount := "fake-service-account"

--- a/pkg/bosh/converter/resolver.go
+++ b/pkg/bosh/converter/resolver.go
@@ -135,9 +135,7 @@ func (r *ResolverImpl) WithOpsManifest(ctx context.Context, instance *bdv1.BOSHD
 	if err != nil {
 		return nil, varSecrets, errors.Wrapf(err, "failed to apply addons")
 	}
-
-	manifest.CalculateRequiredServices()
-
+	manifest.ApplyUpdateBlock()
 	return manifest, varSecrets, err
 }
 
@@ -213,7 +211,7 @@ func (r *ResolverImpl) WithOpsManifestDetailed(ctx context.Context, instance *bd
 		return nil, varSecrets, errors.Wrapf(err, "failed to apply addons")
 	}
 
-	manifest.CalculateRequiredServices()
+	manifest.ApplyUpdateBlock()
 
 	return manifest, varSecrets, err
 }

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -192,16 +192,13 @@ func (m *Manifest) loadDNS() error {
 	return nil
 }
 
-// CalculateRequiredServices calculates the required services using the update.serial property
-func (m *Manifest) CalculateRequiredServices() {
+// calculateRequiredServices calculates the required services using the update.serial property
+func (m *Manifest) calculateRequiredServices() {
 	var requiredService *string
 	var requiredSerialService *string
 
 	for _, ig := range m.InstanceGroups {
 		serial := true
-		if m.Update != nil && m.Update.Serial != nil {
-			serial = *m.Update.Serial
-		}
 		if ig.Update != nil && ig.Update.Serial != nil {
 			serial = *ig.Update.Serial
 		}
@@ -546,4 +543,25 @@ func (m *Manifest) ApplyAddons(ctx context.Context) error {
 	m.AddOnsApplied = true
 
 	return nil
+}
+
+//ApplyUpdateBlock interprets and propagates information of the 'update'-blocks
+func (m *Manifest) ApplyUpdateBlock() {
+	m.propagateGlobalUpdateBlockToIGs()
+	m.calculateRequiredServices()
+}
+
+func (m *Manifest) propagateGlobalUpdateBlockToIGs() {
+	for _, ig := range m.InstanceGroups {
+		if ig.Update == nil {
+			ig.Update = m.Update
+		} else {
+			if ig.Update.CanaryWatchTime == "" {
+				ig.Update.CanaryWatchTime = m.Update.CanaryWatchTime
+			}
+			if ig.Update.Serial == nil {
+				ig.Update.Serial = m.Update.Serial
+			}
+		}
+	}
 }

--- a/pkg/kube/controllers/boshdeployment/validating_webhook_test.go
+++ b/pkg/kube/controllers/boshdeployment/validating_webhook_test.go
@@ -1,0 +1,139 @@
+package boshdeployment
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
+
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
+	"code.cloudfoundry.org/cf-operator/testing"
+	cfcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
+	helper "code.cloudfoundry.org/quarks-utils/testing/testhelper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("When the validating webhook handles a manifest", func() {
+	var (
+		log                    *zap.SugaredLogger
+		ctx                    context.Context
+		env                    testing.Catalog
+		client                 client.Client
+		decoder                *admission.Decoder
+		manifest               *manifest.Manifest
+		validator              admission.Handler
+		boshDeploymentBytes    []byte
+		validateBoshDeployment func() admission.Response
+	)
+
+	BeforeEach(func() {
+		_, log = helper.NewTestLogger()
+		ctx = ctxlog.NewParentContext(log)
+
+		boshDeployment := bdv1.BOSHDeployment{
+			Spec: bdv1.BOSHDeploymentSpec{
+				Manifest: bdv1.ResourceReference{
+					Type: bdv1.ConfigMapReference,
+					Name: "base-manifest",
+				},
+			},
+		}
+		boshDeploymentBytes, _ = json.Marshal(boshDeployment)
+		manifest, _ = env.BOSHManifestWithZeroInstances()
+
+	})
+	JustBeforeEach(func() {
+		manifestBytes, _ := manifest.Marshal()
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		client = fake.NewFakeClientWithScheme(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "base-manifest",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				bdv1.ManifestSpecName: string(manifestBytes),
+			},
+		})
+		decoder, _ = admission.NewDecoder(scheme)
+		validator = NewValidator(log, &cfcfg.Config{CtxTimeOut: 10 * time.Second})
+		validator.(inject.Client).InjectClient(client)
+		validator.(admission.DecoderInjector).InjectDecoder(decoder)
+
+		validateBoshDeployment = func() admission.Response {
+			response := validator.Handle(ctx, admission.Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: boshDeploymentBytes,
+					},
+				},
+			})
+
+			return response
+		}
+	})
+	Context("with no update block", func() {
+		BeforeEach(func() {
+			manifest.Update = nil
+		})
+		It("the manifest is rejected", func() {
+			response := validateBoshDeployment()
+			Expect(response.AdmissionResponse.Allowed).To(BeFalse())
+			Expect(response.AdmissionResponse.Result.Message).To(ContainSubstring("no canary_watch_time specified"))
+		})
+	})
+	Context("with an invalid canary_watch_time", func() {
+		BeforeEach(func() {
+			manifest.Update.CanaryWatchTime = "notANumber"
+		})
+		It("the manifest is rejected", func() {
+			response := validateBoshDeployment()
+			Expect(response.AdmissionResponse.Allowed).To(BeFalse())
+			Expect(response.AdmissionResponse.Result.Message).To(ContainSubstring("Failed to validate canary_watch_time"))
+		})
+	})
+	Context("with a canary_watch_time range", func() {
+		BeforeEach(func() {
+			manifest.Update.CanaryWatchTime = "30000 - 1200000"
+		})
+		It("the manifest is accepted", func() {
+			response := validateBoshDeployment()
+			Expect(response.AdmissionResponse.Allowed).To(BeTrue())
+		})
+	})
+	Context("with an absolute canary_watch_time", func() {
+		BeforeEach(func() {
+			manifest.Update.CanaryWatchTime = "30000"
+		})
+		It("the manifest is accepted", func() {
+			response := validateBoshDeployment()
+			Expect(response.AdmissionResponse.Allowed).To(BeTrue())
+		})
+	})
+	Context("with a canary_watch_time containing measurement", func() {
+		BeforeEach(func() {
+			manifest.Update.CanaryWatchTime = "30000ms"
+		})
+		It("the manifest is rejected", func() {
+			response := validateBoshDeployment()
+			Expect(response.AdmissionResponse.Allowed).To(BeFalse())
+		})
+	})
+})

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -19,6 +19,8 @@ instance_groups:
   vm_type: medium
   stemcell: default
   persistent_disk_type: medium
+  update:
+    canary_watch_time: 20000-1200000
   networks:
   - name: default
   properties:
@@ -41,6 +43,8 @@ instance_groups:
   persistent_disk: 1024
   persistent_disk_type: "standard"
   vm_type: small-highmem
+  update:
+    canary_watch_time: 20000-1200000
   vm_extensions:
   - 100GB_ephemeral_disk
   stemcell: default
@@ -692,6 +696,8 @@ instance_groups:
 - name: fake-ig-1
   instances: 2
   lifecycle: errand
+  update:
+    canary_watch_time: 20000-1200000
   jobs:
   - name: fake-errand-a
     release: fake-release
@@ -702,6 +708,8 @@ instance_groups:
   - name: fake-errand-b
     release: fake-release
 - name: fake-ig-2
+  update:
+    canary_watch_time: 20000-1200000
   instances: 3
   jobs:
   - name: fake-job-a
@@ -711,6 +719,8 @@ instance_groups:
   - name: fake-job-c
     release: fake-release
 - name: fake-ig-3
+  update:
+    canary_watch_time: 20000-1200000
   instances: 1
   jobs:
   - name: fake-job-a
@@ -737,6 +747,8 @@ releases:
 
 instance_groups:
 - name: bpm
+  update:
+    canary_watch_time: 20000-1200000
   instances: 1
   jobs:
   - name: test-server
@@ -765,9 +777,12 @@ releases:
   stemcell:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_332.g0d8469bb
-
+update:
+  canary_watch_time: 20000-1200000
 instance_groups:
 - name: route_registrar
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: route_registrar
@@ -807,7 +822,8 @@ const Diego = `
     stemcell:
       os: opensuse-42.3
       version: 36.g03b4653-30.80-7.0.0_332.g0d8469bb
-
+  update:
+    canary_watch_time: 20000-1200000
   instance_groups:
   - name: file_server
     instances: 2
@@ -832,7 +848,8 @@ releases:
   stemcell:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
-
+update:
+  canary_watch_time: 20000-1200000
 instance_groups:
 - name: bpm
   instances: 1
@@ -853,6 +870,8 @@ instance_groups:
 // WithMultiBPMProcessesAndPersistentDisk is a BOSH manifest with multi BPM Processes and persistent disk definition
 const WithMultiBPMProcessesAndPersistentDisk = `---
 name: my-manifest
+update:
+  canary_watch_time: 20000-1200000
 releases:
 - name: fake-release
   version: "26"
@@ -916,8 +935,13 @@ releases:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
 
+update:
+  canary_watch_time: 10000-1100000
+
 instance_groups:
 - name: bpm1
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: test-server
@@ -948,6 +972,8 @@ instance_groups:
   persistent_disk: 10
   persistent_disk_type: ((operator_test_storage_class))
 - name: bpm2
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: test-server
@@ -980,6 +1006,8 @@ instance_groups:
   persistent_disk: 10
   persistent_disk_type: ((operator_test_storage_class))
 - name: bpm3
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: test-server
@@ -1033,6 +1061,8 @@ releases:
     version: 36.g03b4653-30.80-7.0.0_332.g0d8469bb
 instance_groups:
 - name: nats
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: nats
@@ -1051,6 +1081,8 @@ instance_groups:
           protocol: "TCP"
           internal: 4223
 - name: route_registrar
+  update:
+    canary_watch_time: 20000-1200000
   instances: 2
   jobs:
   - name: route_registrar
@@ -1077,15 +1109,21 @@ instance_groups:
         ca_cert: ""
         ssl:
           port: 8443
+update:
+  canary_watch_time: 20000-1200000
 `
 
 // ManifestWithLargeValues has large yaml values.
 const ManifestWithLargeValues = `
 director_uuid: ""
+update:
+  canary_watch_time: 20000-1200000
 instance_groups:
 - azs:
   - z1
   - z2
+  update:
+    canary_watch_time: 20000-1200000
   env:
     bosh:
       agent:
@@ -2645,6 +2683,63 @@ instance_groups:
 name: scf-dev
 variables: []`
 
+// BPMReleaseWithGlobalUpdateBlock contains a manifest with a global update block
+const BPMReleaseWithGlobalUpdateBlock = `
+name: bpm
+
+releases:
+- name: bpm
+  version: 1.0.4
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
+update:
+  serial: false
+  canary_watch_time: 20000-1200000
+instance_groups:
+- name: bpm1
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+- name: bpm2
+  update:
+    serial: true
+  jobs:
+  - name: test-server
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+- name: bpm3
+  update:
+    canary_watch_time: 10000-9900000
+  jobs:
+  - name: test-server3
+    release: bpm
+    properties:
+      quarks:
+        ports:
+        - name: test-server
+          protocol: TCP
+          internal: 1337
+        - name: alt-test-server
+          protocol: TCP
+          internal: 1338
+`
+
 // BPMReleaseWithUpdateSerial contains a manifest with some dependent instance groups
 const BPMReleaseWithUpdateSerial = `
 name: bpm
@@ -2658,6 +2753,7 @@ releases:
     version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
 update:
   serial: false
+  canary_watch_time: 20000-1200000
 instance_groups:
 - name: bpm1
   update:
@@ -2731,6 +2827,7 @@ releases:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
 update:
+  canary_watch_time: 20000-1200000
   serial: false
 instance_groups:
 - name: bpm1
@@ -2770,6 +2867,7 @@ releases:
     os: opensuse-42.3
     version: 36.g03b4653-30.80-7.0.0_316.gcf9fe4a7
 update:
+  canary_watch_time: 20000-1200000
   serial: true
 instance_groups:
 - name: bpm1

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -226,6 +226,8 @@ releases:
 // NatsSmall is a small manifest to start nats
 const NatsSmall = `---
 name: test
+update:
+  canary_watch_time: 20000-1200000
 releases:
 - name: nats
   version: "26"
@@ -257,6 +259,8 @@ instance_groups:
 // NatsSmallWithPatch is a manifest that patches the prestart hook to loop forever
 const NatsSmallWithPatch = `---
 name: test
+update:
+  canary_watch_time: 20000
 releases:
 - name: nats
   version: "26"
@@ -300,6 +304,8 @@ instance_groups:
 // Drains is a small manifest with jobs that include drain scripts
 const Drains = `---
 name: my-manifest
+update:
+  canary_watch_time: 20000
 releases:
 - name: cf-operator-testing
   version: "0.0.6"
@@ -323,6 +329,8 @@ stemcells:
 - alias: default
   os: opensuse-42.3
   version: 28.g837c5b3-30.263-7.0.0_234.gcd7d1132
+update:
+  canary_watch_time: 20000
 instance_groups:
 - name: redis-slave
   instances: 2

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -650,6 +650,15 @@ func (c *Catalog) NodePortService(name, ig string, targetPort int32) corev1.Serv
 	}
 }
 
+//BOSHManifestWithGlobalUpdateBlock returns a manifest with a global update block
+func (c *Catalog) BOSHManifestWithGlobalUpdateBlock() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithGlobalUpdateBlock))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}
+
 // BOSHManifestWithUpdateSerial returns a manifest with update serial
 func (c *Catalog) BOSHManifestWithUpdateSerial() (*manifest.Manifest, error) {
 	m, err := manifest.LoadYAML([]byte(bm.BPMReleaseWithUpdateSerial))


### PR DESCRIPTION
Needed for https://github.com/cloudfoundry-incubator/cf-operator/pull/692.

To do canary rollouts like Bosh does, we should support the `canary_watch_time` property.
We need to propagate this property from the BoshManifest to the StatefulSet, so the rollout controller can access it.

I also added a validation to the ValidatingWebhook so that we notice early if the property is misconfigured.