### PR TITLE
Remove qjobs instance group label

### DIFF
--- a/bin/include/dependencies
+++ b/bin/include/dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-quarks_job_release="v0.0.0-0.gc3704bb"
+quarks_job_release="v0.0.0-0.g1642b1e"
 
 # QUARKS_JOB_IMAGE_TAG is used for integration tests
 if [ -z ${QUARKS_JOB_IMAGE_TAG+x} ]; then

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/cf-operator
 
 require (
-	code.cloudfoundry.org/quarks-job v0.0.0-20191118101604-b02b381d5aba
+	code.cloudfoundry.org/quarks-job v0.0.0-20191120115056-1642b1e5e3c5
 	code.cloudfoundry.org/quarks-utils v0.0.0-20191114145816-f753780f6d4f
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-code.cloudfoundry.org/quarks-job v0.0.0-20191114061609-c3704bb5fb45 h1:l8NlRNR08MclzP1JjaykYXUjCpKUq5LlrQ1ih9YG7Zo=
-code.cloudfoundry.org/quarks-job v0.0.0-20191114061609-c3704bb5fb45/go.mod h1:dDwAM6J54bBNVOdqnfEtmFgelr5m71prMs58oGzgLMc=
-code.cloudfoundry.org/quarks-job v0.0.0-20191118101604-b02b381d5aba h1:W0XYxwI/YhIjKmLVOIxkcQbkNEaI/xHLI2a9Qo+PD/Q=
-code.cloudfoundry.org/quarks-job v0.0.0-20191118101604-b02b381d5aba/go.mod h1:E1WpDsi0+UbI/W5mDCD6CYzUTh8p2nFIAoc3o3kLffQ=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191112142553-a2225c40261f/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191113134855-ab445bec32c6 h1:7pQtmKfqhvqjfeTK2rR8hd1rOwKMFwmG61UrQONrOP8=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191113134855-ab445bec32c6/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-job v0.0.0-20191120115056-1642b1e5e3c5 h1:vRveICJ9L+zOF0+K8b6hx7IBD/2a8T22Fr0m8Ff7QCY=
+code.cloudfoundry.org/quarks-job v0.0.0-20191120115056-1642b1e5e3c5/go.mod h1:E1WpDsi0+UbI/W5mDCD6CYzUTh8p2nFIAoc3o3kLffQ=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191114145816-f753780f6d4f h1:csZ/4q+RneCMG/peE4pl+9/yM69uMog7SH1Yibaw6oE=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191114145816-f753780f6d4f/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -282,6 +277,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/bosh/converter/container_factory.go
+++ b/pkg/bosh/converter/container_factory.go
@@ -13,6 +13,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/disk"
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
@@ -345,6 +346,10 @@ func templateRenderingContainer(instanceGroupName string, secretName string) cor
 		Env: []corev1.EnvVar{
 			{
 				Name:  EnvInstanceGroupName,
+				Value: instanceGroupName,
+			},
+			{
+				Name:  qjv1a1.RemoteIDKey,
 				Value: instanceGroupName,
 			},
 			{

--- a/pkg/bosh/converter/job_factory.go
+++ b/pkg/bosh/converter/job_factory.go
@@ -18,18 +18,18 @@ import (
 
 const (
 	// EnvInstanceGroupName is a key for the container Env identifying the
-	// instance group that container is started for
+	// instance group that container is started for (CLI)
 	EnvInstanceGroupName = "INSTANCE_GROUP_NAME"
-	// EnvBOSHManifestPath is a key for the container Env pointing to the BOSH manifest
+	// EnvBOSHManifestPath is a key for the container Env pointing to the BOSH manifest (CLI)
 	EnvBOSHManifestPath = "BOSH_MANIFEST_PATH"
 	// EnvCFONamespace is a key for the container Env used to lookup the
-	// namespace CF operator is running in
+	// namespace CF operator is running in (CLI)
 	EnvCFONamespace = "CF_OPERATOR_NAMESPACE"
-	// EnvBaseDir is a key for the container Env used to lookup the base dir
+	// EnvBaseDir is a key for the container Env used to lookup the base dir (CLI)
 	EnvBaseDir = "BASE_DIR"
-	// EnvVariablesDir is a key for the container Env used to lookup the variables dir
+	// EnvVariablesDir is a key for the container Env used to lookup the variables dir (CLI)
 	EnvVariablesDir = "VARIABLES_DIR"
-	// EnvOutputFilePath is path where json output is to be redirected
+	// EnvOutputFilePath is path where json output is to be redirected (CLI)
 	EnvOutputFilePath = "OUTPUT_FILE_PATH"
 	// EnvOutputFilePathValue is the value of filepath of json output file
 	EnvOutputFilePathValue = "/mnt/quarks/output.json"
@@ -37,9 +37,9 @@ const (
 	// performs variable interpolation for a manifest. It's also part of
 	// the output secret's name
 	VarInterpolationContainerName = "desired-manifest"
-	// PodNameEnvVar is the environment variable containing metadata.name used to render BOSH spec.id.
+	// PodNameEnvVar is the environment variable containing metadata.name used to render BOSH spec.id. (CLI)
 	PodNameEnvVar = "POD_NAME"
-	// PodIPEnvVar is the environment variable containing status.podIP used to render BOSH spec.ip.
+	// PodIPEnvVar is the environment variable containing status.podIP used to render BOSH spec.ip. (CLI)
 	PodIPEnvVar = "POD_IP"
 )
 
@@ -209,6 +209,10 @@ func (f *JobFactory) gatheringContainer(cmd, desiredManifestName string, instanc
 			{
 				Name:  EnvBaseDir,
 				Value: VolumeRenderingDataMountPath,
+			},
+			{
+				Name:  qjv1a1.RemoteIDKey,
+				Value: instanceGroupName,
 			},
 			{
 				Name:  EnvInstanceGroupName,

--- a/pkg/bosh/converter/job_factory.go
+++ b/pkg/bosh/converter/job_factory.go
@@ -99,7 +99,7 @@ func (f *JobFactory) VariableInterpolationJob(manifest bdm.Manifest) (*qjv1a1.Qu
 				SecretLabels: map[string]string{
 					bdv1.LabelDeploymentName:       manifest.Name,
 					bdv1.LabelDeploymentSecretType: names.DeploymentSecretTypeManifestWithOps.String(),
-					qjv1a1.LabelReferencedJobName:  fmt.Sprintf("instance-group-%s", manifest.Name),
+					bdm.LabelReferencedJobName:     fmt.Sprintf("instance-group-%s", manifest.Name),
 				},
 				Versioned: true,
 			},

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -84,27 +84,31 @@ func (dg *InstanceGroupResolver) Manifest() (Manifest, error) {
 	igJobs := []Job{}
 	for _, job := range dg.instanceGroup.Jobs {
 
-		igQuarks := Quarks{}
-		igQuarks.Consumes = job.Properties.Quarks.Consumes
-		igQuarks.PreRenderScripts = job.Properties.Quarks.PreRenderScripts
+		igQuarks := Quarks{
+			Consumes:         job.Properties.Quarks.Consumes,
+			PreRenderScripts: job.Properties.Quarks.PreRenderScripts,
+		}
 
-		igJobProperties := JobProperties{}
-		igJobProperties.Properties = job.Properties.Properties
-		igJobProperties.Quarks = igQuarks
+		igJobProperties := JobProperties{
+			Properties: job.Properties.Properties,
+			Quarks:     igQuarks,
+		}
 
-		igJob := Job{}
-		igJob.Name = job.Name
-		igJob.Release = job.Release
-		igJob.Properties = igJobProperties
+		igJob := Job{
+			Name:       job.Name,
+			Release:    job.Release,
+			Properties: igJobProperties,
+		}
 
 		igJobs = append(igJobs, igJob)
 	}
 
 	ig := &InstanceGroup{Name: dg.instanceGroup.Name, Jobs: igJobs}
 
-	igManifest := Manifest{}
-	igManifest.Name = dg.manifest.Name
-	igManifest.InstanceGroups = []*InstanceGroup{ig}
+	igManifest := Manifest{
+		Name:           dg.manifest.Name,
+		InstanceGroups: []*InstanceGroup{ig},
+	}
 
 	return igManifest, nil
 }

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -208,6 +208,8 @@ var (
 	LabelInstanceGroupName = fmt.Sprintf("%s/instance-group-name", apis.GroupName)
 	// LabelDeploymentVersion is the name of a label for the deployment's version.
 	LabelDeploymentVersion = fmt.Sprintf("%s/deployment-version", apis.GroupName)
+	// LabelReferencedJobName is the name key for dependent job
+	LabelReferencedJobName = fmt.Sprintf("%s/referenced-job-name", apis.GroupName)
 )
 
 // AgentSettings from BOSH deployment manifest.

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -116,7 +116,7 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	// Apply BPM information
-	instanceGroupName, ok := bpmSecret.Labels[qjv1a1.LabelInstanceGroup]
+	instanceGroupName, ok := bpmSecret.Labels[qjv1a1.LabelRemoteID]
 	if !ok {
 		return reconcile.Result{},
 			log.WithEvent(bpmSecret, "LabelMissingError").Errorf(ctx, "Missing container label for bpm information bpmSecret '%s'", request.NamespacedName)
@@ -175,7 +175,7 @@ func (r *ReconcileBPM) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 func (r *ReconcileBPM) applyBPMResources(bpmSecret *corev1.Secret, manifest *bdm.Manifest) (*converter.BPMResources, error) {
 
-	instanceGroupName, ok := bpmSecret.Labels[qjv1a1.LabelInstanceGroup]
+	instanceGroupName, ok := bpmSecret.Labels[qjv1a1.LabelRemoteID]
 	if !ok {
 		return nil, errors.Errorf("Missing container label for bpm information secret '%s'", bpmSecret.Name)
 	}

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -171,7 +171,7 @@ variables: []
 					bdv1.LabelDeploymentName:             "foo",
 					versionedsecretstore.LabelSecretKind: "versionedSecret",
 					versionedsecretstore.LabelVersion:    "1",
-					qjv1a1.LabelInstanceGroup:            "fakepod",
+					qjv1a1.LabelRemoteID:                 "fakepod",
 				},
 			},
 			Data: map[string][]byte{
@@ -193,7 +193,7 @@ variables: []
 					bdv1.LabelDeploymentName:             "foo",
 					versionedsecretstore.LabelSecretKind: "versionedSecret",
 					versionedsecretstore.LabelVersion:    "1",
-					qjv1a1.LabelInstanceGroup:            "fakepod",
+					qjv1a1.LabelRemoteID:                 "fakepod",
 				},
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
* adds a little documentation for using KinD in tests
* moves a constant from quarks-job to cf-operator
* removes 'instance group' concept from quarks-job, remote id is more generic


Preparing for [#169418463](https://www.pivotaltracker.com/story/show/169418463)