### PR TITLE
Implement explicit "quarks links" from NK -> B

### DIFF
--- a/cmd/internal/instance_group.go
+++ b/cmd/internal/instance_group.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 )
@@ -83,6 +84,11 @@ This will resolve the properties of an instance group and return a manifest for 
 		igr, err := manifest.NewInstanceGroupResolver(afero.NewOsFs(), baseDir, *m, instanceGroupName)
 		if err != nil {
 			return errors.Wrap(err, igFailedMessage)
+		}
+
+		err = igr.CollectQuarksLinks(filepath.Dir(converter.VolumeLinksPath))
+		if err != nil {
+			return errors.Wrapf(err, "%s failed to collect quarks links.", igFailedMessage)
 		}
 
 		initialRollout := viper.GetBool("initial-rollout")

--- a/integration/bosh_links_test.go
+++ b/integration/bosh_links_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 
 	bm "code.cloudfoundry.org/cf-operator/testing/boshmanifest"
@@ -65,6 +64,39 @@ var _ = Describe("BOSHLinks", func() {
 				secret, err := env.GetSecret(env.Namespace, "link-test-nats")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(secret.Data).Should(HaveKeyWithValue("nats.nuts", []byte("{\"nats\":{\"password\":\"changeme\",\"port\":4222,\"user\":\"admin\"}}")))
+			})
+		})
+	})
+
+	Context("when deployment has explicit external link dependencies", func() {
+		BeforeEach(func() {
+			natsConfigMap := env.Catalog.NatsConfigMap(deploymentName)
+			tearDown, err := env.CreateConfigMap(env.Namespace, natsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			tearDowns = append(tearDowns, tearDown)
+
+			natsSecret := env.Catalog.NatsSecret(deploymentName)
+			tearDown, err = env.CreateSecret(env.Namespace, natsSecret)
+			Expect(err).NotTo(HaveOccurred())
+			tearDowns = append(tearDowns, tearDown)
+
+			natsPod := env.Catalog.NatsPod(deploymentName)
+			tearDown, err = env.CreatePod(env.Namespace, natsPod)
+			Expect(err).NotTo(HaveOccurred())
+			tearDowns = append(tearDowns, tearDown)
+
+			natsService := env.Catalog.NatsService(deploymentName)
+			tearDown, err = env.CreateService(env.Namespace, natsService)
+			Expect(err).NotTo(HaveOccurred())
+			tearDowns = append(tearDowns, tearDown)
+
+			boshManifest = env.BOSHManifestSecret(manifestRef, bm.NatsSmokeTestWithExternalLinks)
+		})
+
+		It("creates a secret for each link", func() {
+			By("waiting for job rendering done", func() {
+				err := env.WaitForPods(env.Namespace,"quarks.cloudfoundry.org/instance-group-name=nats-smoke-tests")
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/bosh/converter/fakes/job_factory.go
+++ b/pkg/bosh/converter/fakes/job_factory.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeJobFactory struct {
-	BPMConfigsJobStub        func(manifest.Manifest, bool) (*v1alpha1.QuarksJob, error)
+	BPMConfigsJobStub        func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)
 	bPMConfigsJobMutex       sync.RWMutex
 	bPMConfigsJobArgsForCall []struct {
 		arg1 manifest.Manifest
-		arg2 bool
+		arg2 map[string]string
+		arg3 bool
 	}
 	bPMConfigsJobReturns struct {
 		result1 *v1alpha1.QuarksJob
@@ -24,11 +25,12 @@ type FakeJobFactory struct {
 		result1 *v1alpha1.QuarksJob
 		result2 error
 	}
-	InstanceGroupManifestJobStub        func(manifest.Manifest, bool) (*v1alpha1.QuarksJob, error)
+	InstanceGroupManifestJobStub        func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)
 	instanceGroupManifestJobMutex       sync.RWMutex
 	instanceGroupManifestJobArgsForCall []struct {
 		arg1 manifest.Manifest
-		arg2 bool
+		arg2 map[string]string
+		arg3 bool
 	}
 	instanceGroupManifestJobReturns struct {
 		result1 *v1alpha1.QuarksJob
@@ -55,17 +57,18 @@ type FakeJobFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeJobFactory) BPMConfigsJob(arg1 manifest.Manifest, arg2 bool) (*v1alpha1.QuarksJob, error) {
+func (fake *FakeJobFactory) BPMConfigsJob(arg1 manifest.Manifest, arg2 map[string]string, arg3 bool) (*v1alpha1.QuarksJob, error) {
 	fake.bPMConfigsJobMutex.Lock()
 	ret, specificReturn := fake.bPMConfigsJobReturnsOnCall[len(fake.bPMConfigsJobArgsForCall)]
 	fake.bPMConfigsJobArgsForCall = append(fake.bPMConfigsJobArgsForCall, struct {
 		arg1 manifest.Manifest
-		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("BPMConfigsJob", []interface{}{arg1, arg2})
+		arg2 map[string]string
+		arg3 bool
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("BPMConfigsJob", []interface{}{arg1, arg2, arg3})
 	fake.bPMConfigsJobMutex.Unlock()
 	if fake.BPMConfigsJobStub != nil {
-		return fake.BPMConfigsJobStub(arg1, arg2)
+		return fake.BPMConfigsJobStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -80,17 +83,17 @@ func (fake *FakeJobFactory) BPMConfigsJobCallCount() int {
 	return len(fake.bPMConfigsJobArgsForCall)
 }
 
-func (fake *FakeJobFactory) BPMConfigsJobCalls(stub func(manifest.Manifest, bool) (*v1alpha1.QuarksJob, error)) {
+func (fake *FakeJobFactory) BPMConfigsJobCalls(stub func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)) {
 	fake.bPMConfigsJobMutex.Lock()
 	defer fake.bPMConfigsJobMutex.Unlock()
 	fake.BPMConfigsJobStub = stub
 }
 
-func (fake *FakeJobFactory) BPMConfigsJobArgsForCall(i int) (manifest.Manifest, bool) {
+func (fake *FakeJobFactory) BPMConfigsJobArgsForCall(i int) (manifest.Manifest, map[string]string, bool) {
 	fake.bPMConfigsJobMutex.RLock()
 	defer fake.bPMConfigsJobMutex.RUnlock()
 	argsForCall := fake.bPMConfigsJobArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeJobFactory) BPMConfigsJobReturns(result1 *v1alpha1.QuarksJob, result2 error) {
@@ -119,17 +122,18 @@ func (fake *FakeJobFactory) BPMConfigsJobReturnsOnCall(i int, result1 *v1alpha1.
 	}{result1, result2}
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJob(arg1 manifest.Manifest, arg2 bool) (*v1alpha1.QuarksJob, error) {
+func (fake *FakeJobFactory) InstanceGroupManifestJob(arg1 manifest.Manifest, arg2 map[string]string, arg3 bool) (*v1alpha1.QuarksJob, error) {
 	fake.instanceGroupManifestJobMutex.Lock()
 	ret, specificReturn := fake.instanceGroupManifestJobReturnsOnCall[len(fake.instanceGroupManifestJobArgsForCall)]
 	fake.instanceGroupManifestJobArgsForCall = append(fake.instanceGroupManifestJobArgsForCall, struct {
 		arg1 manifest.Manifest
-		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("InstanceGroupManifestJob", []interface{}{arg1, arg2})
+		arg2 map[string]string
+		arg3 bool
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("InstanceGroupManifestJob", []interface{}{arg1, arg2, arg3})
 	fake.instanceGroupManifestJobMutex.Unlock()
 	if fake.InstanceGroupManifestJobStub != nil {
-		return fake.InstanceGroupManifestJobStub(arg1, arg2)
+		return fake.InstanceGroupManifestJobStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -144,17 +148,17 @@ func (fake *FakeJobFactory) InstanceGroupManifestJobCallCount() int {
 	return len(fake.instanceGroupManifestJobArgsForCall)
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJobCalls(stub func(manifest.Manifest, bool) (*v1alpha1.QuarksJob, error)) {
+func (fake *FakeJobFactory) InstanceGroupManifestJobCalls(stub func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)) {
 	fake.instanceGroupManifestJobMutex.Lock()
 	defer fake.instanceGroupManifestJobMutex.Unlock()
 	fake.InstanceGroupManifestJobStub = stub
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJobArgsForCall(i int) (manifest.Manifest, bool) {
+func (fake *FakeJobFactory) InstanceGroupManifestJobArgsForCall(i int) (manifest.Manifest, map[string]string, bool) {
 	fake.instanceGroupManifestJobMutex.RLock()
 	defer fake.instanceGroupManifestJobMutex.RUnlock()
 	argsForCall := fake.instanceGroupManifestJobArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeJobFactory) InstanceGroupManifestJobReturns(result1 *v1alpha1.QuarksJob, result2 error) {

--- a/pkg/bosh/converter/fakes/job_factory.go
+++ b/pkg/bosh/converter/fakes/job_factory.go
@@ -4,17 +4,18 @@ package fakes
 import (
 	"sync"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/boshdeployment"
 	"code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 )
 
 type FakeJobFactory struct {
-	BPMConfigsJobStub        func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)
+	BPMConfigsJobStub        func(manifest.Manifest, converter.LinkInfos, bool) (*v1alpha1.QuarksJob, error)
 	bPMConfigsJobMutex       sync.RWMutex
 	bPMConfigsJobArgsForCall []struct {
 		arg1 manifest.Manifest
-		arg2 map[string]string
+		arg2 converter.LinkInfos
 		arg3 bool
 	}
 	bPMConfigsJobReturns struct {
@@ -25,11 +26,11 @@ type FakeJobFactory struct {
 		result1 *v1alpha1.QuarksJob
 		result2 error
 	}
-	InstanceGroupManifestJobStub        func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)
+	InstanceGroupManifestJobStub        func(manifest.Manifest, converter.LinkInfos, bool) (*v1alpha1.QuarksJob, error)
 	instanceGroupManifestJobMutex       sync.RWMutex
 	instanceGroupManifestJobArgsForCall []struct {
 		arg1 manifest.Manifest
-		arg2 map[string]string
+		arg2 converter.LinkInfos
 		arg3 bool
 	}
 	instanceGroupManifestJobReturns struct {
@@ -57,12 +58,12 @@ type FakeJobFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeJobFactory) BPMConfigsJob(arg1 manifest.Manifest, arg2 map[string]string, arg3 bool) (*v1alpha1.QuarksJob, error) {
+func (fake *FakeJobFactory) BPMConfigsJob(arg1 manifest.Manifest, arg2 converter.LinkInfos, arg3 bool) (*v1alpha1.QuarksJob, error) {
 	fake.bPMConfigsJobMutex.Lock()
 	ret, specificReturn := fake.bPMConfigsJobReturnsOnCall[len(fake.bPMConfigsJobArgsForCall)]
 	fake.bPMConfigsJobArgsForCall = append(fake.bPMConfigsJobArgsForCall, struct {
 		arg1 manifest.Manifest
-		arg2 map[string]string
+		arg2 converter.LinkInfos
 		arg3 bool
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("BPMConfigsJob", []interface{}{arg1, arg2, arg3})
@@ -83,13 +84,13 @@ func (fake *FakeJobFactory) BPMConfigsJobCallCount() int {
 	return len(fake.bPMConfigsJobArgsForCall)
 }
 
-func (fake *FakeJobFactory) BPMConfigsJobCalls(stub func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)) {
+func (fake *FakeJobFactory) BPMConfigsJobCalls(stub func(manifest.Manifest, converter.LinkInfos, bool) (*v1alpha1.QuarksJob, error)) {
 	fake.bPMConfigsJobMutex.Lock()
 	defer fake.bPMConfigsJobMutex.Unlock()
 	fake.BPMConfigsJobStub = stub
 }
 
-func (fake *FakeJobFactory) BPMConfigsJobArgsForCall(i int) (manifest.Manifest, map[string]string, bool) {
+func (fake *FakeJobFactory) BPMConfigsJobArgsForCall(i int) (manifest.Manifest, converter.LinkInfos, bool) {
 	fake.bPMConfigsJobMutex.RLock()
 	defer fake.bPMConfigsJobMutex.RUnlock()
 	argsForCall := fake.bPMConfigsJobArgsForCall[i]
@@ -122,12 +123,12 @@ func (fake *FakeJobFactory) BPMConfigsJobReturnsOnCall(i int, result1 *v1alpha1.
 	}{result1, result2}
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJob(arg1 manifest.Manifest, arg2 map[string]string, arg3 bool) (*v1alpha1.QuarksJob, error) {
+func (fake *FakeJobFactory) InstanceGroupManifestJob(arg1 manifest.Manifest, arg2 converter.LinkInfos, arg3 bool) (*v1alpha1.QuarksJob, error) {
 	fake.instanceGroupManifestJobMutex.Lock()
 	ret, specificReturn := fake.instanceGroupManifestJobReturnsOnCall[len(fake.instanceGroupManifestJobArgsForCall)]
 	fake.instanceGroupManifestJobArgsForCall = append(fake.instanceGroupManifestJobArgsForCall, struct {
 		arg1 manifest.Manifest
-		arg2 map[string]string
+		arg2 converter.LinkInfos
 		arg3 bool
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("InstanceGroupManifestJob", []interface{}{arg1, arg2, arg3})
@@ -148,13 +149,13 @@ func (fake *FakeJobFactory) InstanceGroupManifestJobCallCount() int {
 	return len(fake.instanceGroupManifestJobArgsForCall)
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJobCalls(stub func(manifest.Manifest, map[string]string, bool) (*v1alpha1.QuarksJob, error)) {
+func (fake *FakeJobFactory) InstanceGroupManifestJobCalls(stub func(manifest.Manifest, converter.LinkInfos, bool) (*v1alpha1.QuarksJob, error)) {
 	fake.instanceGroupManifestJobMutex.Lock()
 	defer fake.instanceGroupManifestJobMutex.Unlock()
 	fake.InstanceGroupManifestJobStub = stub
 }
 
-func (fake *FakeJobFactory) InstanceGroupManifestJobArgsForCall(i int) (manifest.Manifest, map[string]string, bool) {
+func (fake *FakeJobFactory) InstanceGroupManifestJobArgsForCall(i int) (manifest.Manifest, converter.LinkInfos, bool) {
 	fake.instanceGroupManifestJobMutex.RLock()
 	defer fake.instanceGroupManifestJobMutex.RUnlock()
 	argsForCall := fake.instanceGroupManifestJobArgsForCall[i]

--- a/pkg/bosh/converter/job_factory.go
+++ b/pkg/bosh/converter/job_factory.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1b1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -159,7 +158,7 @@ func (f *JobFactory) VariableInterpolationJob(manifest bdm.Manifest) (*qjv1a1.Qu
 }
 
 // InstanceGroupManifestJob generates the job to create an instance group manifest
-func (f *JobFactory) InstanceGroupManifestJob(manifest bdm.Manifest, initialRollout bool) (*qjv1a1.QuarksJob, error) {
+func (f *JobFactory) InstanceGroupManifestJob(manifest bdm.Manifest, linkSecrets map[string]string, initialRollout bool) (*qjv1a1.QuarksJob, error) {
 	containers := []corev1.Container{}
 	ct := containerTemplate{
 		manifestName:   desiredManifestName(manifest.Name),
@@ -170,6 +169,14 @@ func (f *JobFactory) InstanceGroupManifestJob(manifest bdm.Manifest, initialRoll
 
 	linkOutputs := map[string]string{}
 
+	// Volume mounts for explicit linking provider links
+	linkVolumes := []corev1.Volume{}
+	linkVolumeMounts := []corev1.VolumeMount{}
+	for secretName, providerName := range linkSecrets {
+		linkVolumes = append(linkVolumes, linkVolume(secretName))
+		linkVolumeMounts = append(linkVolumeMounts, linkVolumeMount(secretName, providerName))
+	}
+
 	for _, ig := range manifest.InstanceGroups {
 		if ig.Instances != 0 {
 			// Additional secret for BOSH links per instance group
@@ -177,13 +184,13 @@ func (f *JobFactory) InstanceGroupManifestJob(manifest bdm.Manifest, initialRoll
 			linkOutputs[containerName] = names.EntanglementSecretName(manifest.Name, ig.Name)
 
 			// One container per instance group
-			containers = append(containers, ct.newUtilContainer(ig.Name))
+			containers = append(containers, ct.newUtilContainer(ig.Name, linkVolumeMounts))
 		}
 	}
 
 	qJobName := fmt.Sprintf("ig-%s", manifest.Name)
 
-	qJob, err := f.releaseImageQJob(qJobName, manifest, names.DeploymentSecretTypeInstanceGroupResolvedProperties, containers)
+	qJob, err := f.releaseImageQJob(qJobName, manifest, names.DeploymentSecretTypeInstanceGroupResolvedProperties, containers, linkVolumes)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +205,7 @@ func (f *JobFactory) InstanceGroupManifestJob(manifest bdm.Manifest, initialRoll
 }
 
 // BPMConfigsJob returns an quarks job to calculate BPM information
-func (f *JobFactory) BPMConfigsJob(manifest bdm.Manifest, initialRollout bool) (*qjv1a1.QuarksJob, error) {
+func (f *JobFactory) BPMConfigsJob(manifest bdm.Manifest, linkSecrets map[string]string, initialRollout bool) (*qjv1a1.QuarksJob, error) {
 	containers := []corev1.Container{}
 	ct := containerTemplate{
 		manifestName:   desiredManifestName(manifest.Name),
@@ -207,11 +214,19 @@ func (f *JobFactory) BPMConfigsJob(manifest bdm.Manifest, initialRollout bool) (
 		initialRollout: initialRollout,
 	}
 
+	// Volume mounts for explicit linking provider links
+	linkVolumes := []corev1.Volume{}
+	linkVolumeMounts := []corev1.VolumeMount{}
+	for secretName, providerName := range linkSecrets {
+		linkVolumes = append(linkVolumes, linkVolume(secretName))
+		linkVolumeMounts = append(linkVolumeMounts, linkVolumeMount(secretName, providerName))
+	}
+
 	for _, ig := range manifest.InstanceGroups {
 		if ig.Instances != 0 {
 			// One container per instance group
 			// There will be one BPM secret generated for each of these containers
-			container := ct.newUtilContainer(ig.Name)
+			container := ct.newUtilContainer(ig.Name, linkVolumeMounts)
 
 			env := corev1.EnvVar{Name: qjv1a1.RemoteIDKey, Value: ig.Name}
 			container.Env = append(container.Env, env)
@@ -220,7 +235,7 @@ func (f *JobFactory) BPMConfigsJob(manifest bdm.Manifest, initialRollout bool) (
 	}
 
 	qJobName := fmt.Sprintf("bpm-%s", manifest.Name)
-	return f.releaseImageQJob(qJobName, manifest, names.DeploymentSecretBpmInformation, containers)
+	return f.releaseImageQJob(qJobName, manifest, names.DeploymentSecretBpmInformation, containers, linkVolumes)
 }
 
 // desiredManifestName returns the sanitized, versioned name of the manifest.
@@ -236,16 +251,16 @@ type containerTemplate struct {
 	initialRollout bool
 }
 
-func (ct *containerTemplate) newUtilContainer(instanceGroupName string) corev1.Container {
+func (ct *containerTemplate) newUtilContainer(instanceGroupName string, linkVolumeMounts []corev1.VolumeMount) corev1.Container {
 	return corev1.Container{
 		Name:            names.Sanitize(instanceGroupName),
 		Image:           GetOperatorDockerImage(),
 		ImagePullPolicy: GetOperatorImagePullPolicy(),
 		Args:            []string{"util", ct.cmd, "--initial-rollout", strconv.FormatBool(ct.initialRollout)},
-		VolumeMounts: []corev1.VolumeMount{
+		VolumeMounts: append(linkVolumeMounts, []corev1.VolumeMount{
 			withOpsVolumeMount(ct.manifestName),
 			releaseSourceVolumeMount(),
-		},
+		}...),
 		Env: []corev1.EnvVar{
 			{
 				Name:  EnvBOSHManifestPath,
@@ -272,7 +287,7 @@ func (ct *containerTemplate) newUtilContainer(instanceGroupName string) corev1.C
 }
 
 // releaseImageQJob collects outputs, like bpm, links or ig manifests, from the BOSH release images
-func (f *JobFactory) releaseImageQJob(name string, manifest bdm.Manifest, secretType names.DeploymentSecretType, containers []corev1.Container) (*qjv1a1.QuarksJob, error) {
+func (f *JobFactory) releaseImageQJob(name string, manifest bdm.Manifest, secretType names.DeploymentSecretType, containers []corev1.Container, linkVolumes []corev1.Volume) (*qjv1a1.QuarksJob, error) {
 	initContainers := []corev1.Container{}
 	doneSpecCopyingReleases := map[string]bool{}
 	for _, ig := range manifest.InstanceGroups {
@@ -348,10 +363,10 @@ func (f *JobFactory) releaseImageQJob(name string, manifest bdm.Manifest, secret
 							// Container to run data gathering
 							Containers: containers,
 							// Volumes for secrets
-							Volumes: []corev1.Volume{
+							Volumes: append(linkVolumes, []corev1.Volume{
 								*withOpsVolume(desiredManifestName(manifest.Name)),
 								releaseSourceVolume(),
-							},
+							}...),
 						},
 					},
 				},

--- a/pkg/bosh/converter/job_factory_test.go
+++ b/pkg/bosh/converter/job_factory_test.go
@@ -12,23 +12,23 @@ import (
 
 var _ = Describe("JobFactory", func() {
 	var (
-		factory     *JobFactory
-		m           *manifest.Manifest
-		env         testing.Catalog
-		err         error
-		linkSecrets map[string]string
+		factory   *JobFactory
+		m         *manifest.Manifest
+		env       testing.Catalog
+		err       error
+		linkInfos LinkInfos
 	)
 
 	BeforeEach(func() {
 		m, err = env.DefaultBOSHManifest()
-		linkSecrets = map[string]string{}
+		linkInfos = LinkInfos{}
 		Expect(err).NotTo(HaveOccurred())
 		factory = NewJobFactory("namespace")
 	})
 
 	Describe("InstanceGroupManifestJob", func() {
 		It("creates init containers", func() {
-			qJob, err := factory.InstanceGroupManifestJob(*m, linkSecrets, true)
+			qJob, err := factory.InstanceGroupManifestJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 			jobIG := qJob.Spec.Template.Spec
 			// Test init containers in the ig manifest qJob
@@ -39,11 +39,14 @@ var _ = Describe("JobFactory", func() {
 		})
 
 		It("creates relative volume infos when having link secrets", func() {
-			linkSecrets = map[string]string{
-				"fake-secret-name": "fake-link-name",
+			linkInfos = LinkInfos{
+				{
+					SecretName:   "fake-secret-name",
+					ProviderName: "fake-link-name",
+				},
 			}
 
-			qJob, err := factory.InstanceGroupManifestJob(*m, linkSecrets, true)
+			qJob, err := factory.InstanceGroupManifestJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 			jobIG := qJob.Spec.Template.Spec
 			// Test init containers in the ig manifest qJob
@@ -59,14 +62,14 @@ var _ = Describe("JobFactory", func() {
 
 		It("handles an error when getting release image", func() {
 			m.Stemcells = nil
-			_, err := factory.InstanceGroupManifestJob(*m, linkSecrets, true)
+			_, err := factory.InstanceGroupManifestJob(*m, linkInfos, true)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Generation of gathering job failed for manifest"))
 		})
 
 		It("does not generate the instance group containers when its instances is zero", func() {
 			m.InstanceGroups[0].Instances = 0
-			qJob, err := factory.InstanceGroupManifestJob(*m, linkSecrets, true)
+			qJob, err := factory.InstanceGroupManifestJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 			jobIG := qJob.Spec.Template.Spec
 			Expect(len(jobIG.Template.Spec.InitContainers)).To(BeNumerically("<", 2))
@@ -77,7 +80,7 @@ var _ = Describe("JobFactory", func() {
 			It("creates output entries for all provides", func() {
 				m, err = env.ElaboratedBOSHManifest()
 				Expect(err).NotTo(HaveOccurred())
-				qJob, err := factory.InstanceGroupManifestJob(*m, linkSecrets, true)
+				qJob, err := factory.InstanceGroupManifestJob(*m, linkInfos, true)
 				Expect(err).ToNot(HaveOccurred())
 				om := qJob.Spec.Output.OutputMap
 				Expect(om).To(Equal(
@@ -108,7 +111,7 @@ var _ = Describe("JobFactory", func() {
 
 	Describe("BPMConfigsJob", func() {
 		It("has one spec-copier init container per instance group", func() {
-			job, err := factory.BPMConfigsJob(*m, linkSecrets, true)
+			job, err := factory.BPMConfigsJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			spec := job.Spec.Template.Spec.Template.Spec
@@ -119,7 +122,7 @@ var _ = Describe("JobFactory", func() {
 		})
 
 		It("has one bpm-configs container per instance group", func() {
-			job, err := factory.BPMConfigsJob(*m, linkSecrets, true)
+			job, err := factory.BPMConfigsJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			spec := job.Spec.Template.Spec.Template.Spec
@@ -130,7 +133,7 @@ var _ = Describe("JobFactory", func() {
 
 		It("does not generate the instance group containers when its instances is zero", func() {
 			m.InstanceGroups[0].Instances = 0
-			job, err := factory.BPMConfigsJob(*m, linkSecrets, true)
+			job, err := factory.BPMConfigsJob(*m, linkInfos, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			spec := job.Spec.Template.Spec.Template.Spec

--- a/pkg/bosh/converter/quarks_links.go
+++ b/pkg/bosh/converter/quarks_links.go
@@ -1,0 +1,56 @@
+package converter
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// VolumeLinksPath is the mount path for the links data.
+	VolumeLinksPath = "/var/run/secrets/links/"
+)
+
+// LinkInfo Specify link provider and its secret name from Kube native components
+type LinkInfo struct {
+	SecretName   string
+	ProviderName string
+}
+
+// LinkInfos a list of LinkInfo
+type LinkInfos []LinkInfo
+
+// Volumes return a list of volumes from LinkInfos
+func (q *LinkInfos) Volumes() []corev1.Volume {
+	volumes := []corev1.Volume{}
+	for _, l := range *q {
+		volumes = append(volumes, l.linkVolume())
+	}
+
+	return volumes
+}
+
+// VolumeMounts return a list of volumeMounts from LinkInfos
+func (q *LinkInfos) VolumeMounts() []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{}
+	for _, l := range *q {
+		volumeMounts = append(volumeMounts, l.linkVolumeMount())
+	}
+
+	return volumeMounts
+}
+
+func (q *LinkInfo) linkVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: generateVolumeName(q.SecretName),
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: q.SecretName,
+			},
+		},
+	}
+}
+
+func (q *LinkInfo) linkVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      generateVolumeName(q.SecretName),
+		MountPath: VolumeLinksPath + q.ProviderName,
+		ReadOnly:  true,
+	}
+}

--- a/pkg/bosh/converter/quarks_links.go
+++ b/pkg/bosh/converter/quarks_links.go
@@ -7,16 +7,16 @@ const (
 	VolumeLinksPath = "/var/run/secrets/links/"
 )
 
-// LinkInfo Specify link provider and its secret name from Kube native components
+// LinkInfo specifies the link provider and its secret name from Kube native components
 type LinkInfo struct {
 	SecretName   string
 	ProviderName string
 }
 
-// LinkInfos a list of LinkInfo
+// LinkInfos is a list of LinkInfo
 type LinkInfos []LinkInfo
 
-// Volumes return a list of volumes from LinkInfos
+// Volumes returns a list of volumes from LinkInfos
 func (q *LinkInfos) Volumes() []corev1.Volume {
 	volumes := []corev1.Volume{}
 	for _, l := range *q {
@@ -26,7 +26,7 @@ func (q *LinkInfos) Volumes() []corev1.Volume {
 	return volumes
 }
 
-// VolumeMounts return a list of volumeMounts from LinkInfos
+// VolumeMounts returns a list of volumeMounts from LinkInfos
 func (q *LinkInfos) VolumeMounts() []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{}
 	for _, l := range *q {

--- a/pkg/bosh/converter/volume_factory.go
+++ b/pkg/bosh/converter/volume_factory.go
@@ -62,9 +62,6 @@ const (
 	// UnrestrictedVolumeBaseName is the volume name for the unrestricted ones.
 	UnrestrictedVolumeBaseName = "bpm-unrestricted-volume"
 
-	// VolumeLinksPath is the mount path for the links data.
-	VolumeLinksPath = "/var/run/secrets/links/"
-
 	secretsPath         = "/var/run/secrets/variables/"
 	withOpsManifestPath = "/var/run/secrets/deployment/"
 	// releaseSourceName is the folder for release sources
@@ -498,23 +495,4 @@ func generateVolumeName(secretName string) string {
 		volName = nameSlices[0]
 	}
 	return names.Sanitize(volName)
-}
-
-func linkVolume(secretName string) corev1.Volume {
-	return corev1.Volume{
-		Name: generateVolumeName(secretName),
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName,
-			},
-		},
-	}
-}
-
-func linkVolumeMount(secretName string, providerName string) corev1.VolumeMount {
-	return corev1.VolumeMount{
-		Name:      generateVolumeName(secretName),
-		MountPath: VolumeLinksPath + providerName,
-		ReadOnly:  true,
-	}
 }

--- a/pkg/bosh/converter/volume_factory.go
+++ b/pkg/bosh/converter/volume_factory.go
@@ -62,14 +62,14 @@ const (
 	// UnrestrictedVolumeBaseName is the volume name for the unrestricted ones.
 	UnrestrictedVolumeBaseName = "bpm-unrestricted-volume"
 
+	// VolumeLinksPath is the mount path for the links data.
+	VolumeLinksPath = "/var/run/secrets/links/"
+
 	secretsPath         = "/var/run/secrets/variables/"
 	withOpsManifestPath = "/var/run/secrets/deployment/"
 	// releaseSourceName is the folder for release sources
 	releaseSourceName        = "instance-group"
 	resolvedPropertiesFormat = "/var/run/secrets/resolved-properties/%s"
-
-	// linksPath is the mount path for the links data.
-	linksPath = "/var/run/secrets/links/"
 )
 
 // VolumeFactoryImpl is a concrete implementation of VolumeFactoryImpl
@@ -514,7 +514,7 @@ func linkVolume(secretName string) corev1.Volume {
 func linkVolumeMount(secretName string, providerName string) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      generateVolumeName(secretName),
-		MountPath: linksPath + providerName,
+		MountPath: VolumeLinksPath + providerName,
 		ReadOnly:  true,
 	}
 }

--- a/pkg/bosh/converter/volume_factory.go
+++ b/pkg/bosh/converter/volume_factory.go
@@ -67,6 +67,9 @@ const (
 	// releaseSourceName is the folder for release sources
 	releaseSourceName        = "instance-group"
 	resolvedPropertiesFormat = "/var/run/secrets/resolved-properties/%s"
+
+	// linksPath is the mount path for the links data.
+	linksPath = "/var/run/secrets/links/"
 )
 
 // VolumeFactoryImpl is a concrete implementation of VolumeFactoryImpl
@@ -495,4 +498,23 @@ func generateVolumeName(secretName string) string {
 		volName = nameSlices[0]
 	}
 	return names.Sanitize(volName)
+}
+
+func linkVolume(secretName string) corev1.Volume {
+	return corev1.Volume{
+		Name: generateVolumeName(secretName),
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+}
+
+func linkVolumeMount(secretName string, providerName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      generateVolumeName(secretName),
+		MountPath: linksPath + providerName,
+		ReadOnly:  true,
+	}
 }

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -178,6 +178,14 @@ func (igr *InstanceGroupResolver) resolveManifest(initialRollout bool) error {
 
 // CollectQuarksLinks collect all links from path
 func (igr *InstanceGroupResolver) CollectQuarksLinks(linksPath string) error {
+	exist, err := afero.DirExists(igr.fs, linksPath)
+	if err != nil {
+		return errors.Wrapf(err, "could not check if a path exists")
+	}
+	if !exist {
+		return nil
+	}
+
 	links, err := afero.ReadDir(igr.fs, linksPath)
 	if err != nil {
 		return errors.Wrapf(err, "could not read links directory")
@@ -229,6 +237,9 @@ func (igr *InstanceGroupResolver) CollectQuarksLinks(linksPath string) error {
 				}
 				return nil
 			})
+			if err != nil {
+				return errors.Wrapf(err, "Walking links path")
+			}
 
 			err = igr.jobProviderLinks.AddExternalLink(linkName, linkType, q.Address, q.Instances, properties)
 			if err != nil {

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -242,8 +242,8 @@ var _ = Describe("InstanceGroupResolver", func() {
 						expectedProperties := JobLinkProperties{
 							"doppler": map[string]interface{}{
 								"grpc_port": json.Number("7765"),
+								"fooprop":   json.Number("10001"),
 							},
-							"fooprop": json.Number("10001"),
 						}
 
 						Expect(deep.Equal(jobConsumesFromDoppler.Properties, expectedProperties)).To(HaveLen(0))
@@ -320,16 +320,16 @@ var _ = Describe("InstanceGroupResolver", func() {
 					_, err = fileP1.WriteString("fake_prop")
 					Expect(err).NotTo(HaveOccurred())
 
-					fileP2, err := fs.Create(converter.VolumeLinksPath + "doppler/doppler")
+					fileP2, err := fs.Create(converter.VolumeLinksPath + "doppler/grpc_port")
 					Expect(err).NotTo(HaveOccurred())
 					defer fileP2.Close()
-					_, err = fileP2.WriteString(`grpc_port: 7765`)
+					_, err = fileP2.WriteString(`7765`)
 					Expect(err).NotTo(HaveOccurred())
 
 				})
 
 				It("stores all the links of the instance group in a file", func() {
-					err = igr.CollectQuarksLinks("/var/run/secrets/links/")
+					err = igr.CollectQuarksLinks(converter.VolumeLinksPath)
 					Expect(err).ToNot(HaveOccurred())
 
 					m, err := igr.Manifest(true)
@@ -348,8 +348,10 @@ var _ = Describe("InstanceGroupResolver", func() {
 							},
 						},
 						Properties: JobLinkProperties{
-							"doppler": "grpc_port: 7765",
-							"fooprop": "fake_prop",
+							"doppler": map[string]interface{}{
+								"grpc_port": "7765",
+								"fooprop":   "fake_prop",
+							},
 						},
 					}))
 

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -315,11 +315,13 @@ var _ = Describe("InstanceGroupResolver", func() {
 					ig = "log-api"
 
 					fileP1, err := fs.Create(converter.VolumeLinksPath + "doppler/fooprop")
+					Expect(err).NotTo(HaveOccurred())
 					defer fileP1.Close()
 					_, err = fileP1.WriteString("fake_prop")
 					Expect(err).NotTo(HaveOccurred())
 
 					fileP2, err := fs.Create(converter.VolumeLinksPath + "doppler/doppler")
+					Expect(err).NotTo(HaveOccurred())
 					defer fileP2.Close()
 					_, err = fileP2.WriteString(`grpc_port: 7765`)
 					Expect(err).NotTo(HaveOccurred())
@@ -330,9 +332,9 @@ var _ = Describe("InstanceGroupResolver", func() {
 					err = igr.CollectQuarksLinks("/var/run/secrets/links/")
 					Expect(err).ToNot(HaveOccurred())
 
-					m, err := igr.Manifest()
+					m, err := igr.Manifest(true)
 					Expect(err).ToNot(HaveOccurred())
-					// log-api instance_group, with loggregator_trafficcontroller job, consumes nil link from external doppler
+					// log-api instance_group, with loggregator_trafficcontroller job, consumes links from external doppler
 					jobQuarksConsumes := m.InstanceGroups[0].Jobs[0].Properties.Quarks.Consumes
 					Expect(jobQuarksConsumes).To(ContainElement(JobLink{
 						Address: "doppler-0.default.svc.cluster.local",

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -84,6 +84,6 @@ type PostStartCondition struct {
 // QuarksLinks represents the links to share/discover information between BOSH and Kube Native components
 type QuarksLink struct {
 	Type      string        `json:"type,omitempty"`
-	Address   string        `json:"address"`
-	Instances []JobInstance `json:"instances"`
+	Address   string        `json:"address,omitempty"`
+	Instances []JobInstance `json:"instances,omitempty"`
 }

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -80,3 +80,10 @@ type PostStart struct {
 type PostStartCondition struct {
 	Exec *corev1.ExecAction `json:"exec,omitempty"`
 }
+
+// QuarksLinks represents the links to share/discover information between BOSH and Kube Native components
+type QuarksLink struct {
+	Type      string        `json:"type,omitempty"`
+	Address   string        `json:"address"`
+	Instances []JobInstance `json:"instances"`
+}

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -81,7 +81,7 @@ type PostStartCondition struct {
 	Exec *corev1.ExecAction `json:"exec,omitempty"`
 }
 
-// QuarksLinks represents the links to share/discover information between BOSH and Kube Native components
+// QuarksLink represents the links to share/discover information between BOSH and Kube Native components
 type QuarksLink struct {
 	Type      string        `json:"type,omitempty"`
 	Address   string        `json:"address,omitempty"`

--- a/pkg/bosh/manifest/dns.go
+++ b/pkg/bosh/manifest/dns.go
@@ -42,6 +42,11 @@ func SetClusterDomain(domain string) {
 	clusterDomain = domain
 }
 
+// GetClusterDomain returns the package scoped clusterDomain variable.
+func GetClusterDomain() string {
+	return clusterDomain
+}
+
 // DomainNameService abstraction.
 type DomainNameService interface {
 	// HeadlessServiceName constructs the headless service name for the instance group.

--- a/pkg/bosh/manifest/job_provider_links.go
+++ b/pkg/bosh/manifest/job_provider_links.go
@@ -105,3 +105,17 @@ func (jpl jobProviderLinks) Add(igName string, job Job, spec JobSpec, jobsInstan
 	}
 	return nil
 }
+
+// AddExternalLink add link info from external
+func (jpl jobProviderLinks) AddExternalLink(linkName string, linkType string, linkAddress string, jobsInstances []JobInstance, properties JobLinkProperties) error {
+	if _, ok := jpl.links[linkType]; !ok {
+		jpl.links[linkType] = map[string]JobLink{}
+	}
+
+	jpl.links[linkType][linkName] = JobLink{
+		Address:    linkAddress,
+		Instances:  jobsInstances,
+		Properties: properties,
+	}
+	return nil
+}

--- a/pkg/bosh/manifest/job_provider_links.go
+++ b/pkg/bosh/manifest/job_provider_links.go
@@ -106,8 +106,8 @@ func (jpl jobProviderLinks) Add(igName string, job Job, spec JobSpec, jobsInstan
 	return nil
 }
 
-// AddExternalLink add link info from external
-func (jpl jobProviderLinks) AddExternalLink(linkName string, linkType string, linkAddress string, jobsInstances []JobInstance, properties JobLinkProperties) error {
+// AddExternalLink adds link info from an external (non-BOSH) source
+func (jpl jobProviderLinks) AddExternalLink(linkName string, linkType string, linkAddress string, jobsInstances []JobInstance, properties JobLinkProperties) {
 	if _, ok := jpl.links[linkType]; !ok {
 		jpl.links[linkType] = map[string]JobLink{}
 	}
@@ -117,5 +117,4 @@ func (jpl jobProviderLinks) AddExternalLink(linkName string, linkType string, li
 		Instances:  jobsInstances,
 		Properties: properties,
 	}
-	return nil
 }

--- a/pkg/bosh/manifest/manifest.go
+++ b/pkg/bosh/manifest/manifest.go
@@ -134,19 +134,19 @@ type AddOn struct {
 
 // Manifest is a BOSH deployment manifest
 type Manifest struct {
-	Name           string                   `json:"name"`
-	DirectorUUID   string                   `json:"director_uuid"`
-	InstanceGroups InstanceGroups           `json:"instance_groups,omitempty"`
-	Features       *Feature                 `json:"features,omitempty"`
-	Tags           map[string]string        `json:"tags,omitempty"`
-	Releases       []*Release               `json:"releases,omitempty"`
-	Stemcells      []*Stemcell              `json:"stemcells,omitempty"`
-	AddOns         []*AddOn                 `json:"addons,omitempty"`
-	Properties     []map[string]interface{} `json:"properties,omitempty"`
-	Variables      []Variable               `json:"variables,omitempty"`
-	Update         *Update                  `json:"update,omitempty"`
-	AddOnsApplied  bool                     `json:"addons_applied,omitempty"`
-	DNS            DomainNameService        `json:"-"`
+	Name           string                 `json:"name"`
+	DirectorUUID   string                 `json:"director_uuid"`
+	InstanceGroups InstanceGroups         `json:"instance_groups,omitempty"`
+	Features       *Feature               `json:"features,omitempty"`
+	Tags           map[string]string      `json:"tags,omitempty"`
+	Releases       []*Release             `json:"releases,omitempty"`
+	Stemcells      []*Stemcell            `json:"stemcells,omitempty"`
+	AddOns         []*AddOn               `json:"addons,omitempty"`
+	Properties     map[string]interface{} `json:"properties,omitempty"`
+	Variables      []Variable             `json:"variables,omitempty"`
+	Update         *Update                `json:"update,omitempty"`
+	AddOnsApplied  bool                   `json:"addons_applied,omitempty"`
+	DNS            DomainNameService      `json:"-"`
 }
 
 // duplicateYamlValue is a struct used for size compression

--- a/pkg/kube/apis/boshdeployment/v1alpha1/types.go
+++ b/pkg/kube/apis/boshdeployment/v1alpha1/types.go
@@ -34,6 +34,8 @@ var (
 	LabelDeploymentName = fmt.Sprintf("%s/deployment-name", apis.GroupName)
 	// LabelDeploymentSecretType is the label key for secret type name
 	LabelDeploymentSecretType = fmt.Sprintf("%s/secret-name", apis.GroupName)
+	// AnnotationLinkProviderName is the annotation key for link provider name
+	AnnotationLinkProviderName = fmt.Sprintf("%s/link-provider-name", apis.GroupName)
 )
 
 // BOSHDeploymentSpec defines the desired state of BOSHDeployment

--- a/pkg/kube/apis/boshdeployment/v1alpha1/types.go
+++ b/pkg/kube/apis/boshdeployment/v1alpha1/types.go
@@ -32,10 +32,12 @@ const (
 var (
 	// LabelDeploymentName is the label key for manifest name
 	LabelDeploymentName = fmt.Sprintf("%s/deployment-name", apis.GroupName)
-	// LabelDeploymentSecretType is the label key for secret type name
-	LabelDeploymentSecretType = fmt.Sprintf("%s/secret-name", apis.GroupName)
+	// LabelDeploymentSecretType is the label key for secret type
+	LabelDeploymentSecretType = fmt.Sprintf("%s/secret-type", apis.GroupName)
 	// AnnotationLinkProviderName is the annotation key for link provider name
 	AnnotationLinkProviderName = fmt.Sprintf("%s/link-provider-name", apis.GroupName)
+	// AnnotationLinkProviderType is the annotation key for link provider type
+	AnnotationLinkProviderType = fmt.Sprintf("%s/link-provider-type", apis.GroupName)
 )
 
 // BOSHDeploymentSpec defines the desired state of BOSHDeployment

--- a/pkg/kube/controllers/boshdeployment/deployment_controller.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_controller.go
@@ -174,7 +174,7 @@ func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manag
 	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestsFromMapFunc{
 		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
 			// Get one request from one service at most
-			reconciles := make([]reconcile.Request, 0, 1)
+			reconciles := make([]reconcile.Request, 1)
 
 			svc := a.Object.(*corev1.Service)
 			if provider, ok := svc.GetAnnotations()[bdv1.AnnotationLinkProviderName]; ok {

--- a/pkg/kube/controllers/boshdeployment/deployment_controller.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_controller.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -155,5 +156,52 @@ func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manag
 
 	}
 
+	// Watch Services routing to external link provider
+	servicesPredicates := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			service := e.Object.(*corev1.Service)
+
+			return isLinkProviderService(service)
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newService := e.ObjectNew.(*corev1.Service)
+
+			return isLinkProviderService(newService)
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: handler.ToRequestsFunc(func(a handler.MapObject) []reconcile.Request {
+			// Get one request from one service at most
+			reconciles := make([]reconcile.Request, 0, 1)
+
+			svc := a.Object.(*corev1.Service)
+			if provider, ok := svc.GetAnnotations()[bdv1.AnnotationLinkProviderName]; ok {
+				reconciles[0] = reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: svc.Namespace,
+						Name:      provider,
+					},
+				}
+				ctxlog.NewMappingEvent(a.Object).Debug(ctx, reconciles[0], "BOSHDeployment", a.Meta.GetName(), "ServiceOfLinkProvider")
+			}
+
+			return reconciles
+		}),
+	}, servicesPredicates)
+	if err != nil {
+		return errors.Wrapf(err, "Watching services failed in bosh deployment controller.")
+
+	}
+
 	return nil
+}
+
+func isLinkProviderService(svc *corev1.Service) bool {
+	if _, ok := svc.GetAnnotations()[bdv1.AnnotationLinkProviderName]; ok {
+		return true
+	}
+
+	return false
 }

--- a/pkg/kube/controllers/boshdeployment/deployment_controller.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_controller.go
@@ -156,7 +156,7 @@ func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manag
 
 	}
 
-	// Watch Services routing to external link provider
+	// Watch Services that route (select) pods that are external link providers
 	servicesPredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			service := e.Object.(*corev1.Service)
@@ -191,7 +191,7 @@ func AddDeployment(ctx context.Context, config *config.Config, mgr manager.Manag
 		}),
 	}, servicesPredicates)
 	if err != nil {
-		return errors.Wrapf(err, "Watching services failed in bosh deployment controller.")
+		return errors.Wrapf(err, "watching services failed in bosh deployment controller.")
 
 	}
 

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -281,7 +281,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 					}
 
 					linkInfos = append(linkInfos, converter.LinkInfo{
-						SecretName: s.Name,
+						SecretName:   s.Name,
 						ProviderName: providerName,
 					})
 					if providerType, ok := s.GetAnnotations()[bdv1.AnnotationLinkProviderType]; ok {
@@ -299,7 +299,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 			return linkInfos, errors.New(fmt.Sprintf("Failed to get link services for: %s", instance.Name))
 		}
 
-		for qName, _ := range quarksLinks {
+		for qName := range quarksLinks {
 			if svcRecord, ok := serviceRecords[qName]; ok {
 				pods, err := r.listPodsFromSelector(instance.Namespace, svcRecord.selector)
 				if err != nil {

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler.go
@@ -86,7 +86,7 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 		}
 
 		return reconcile.Result{},
-			log.WithEvent(instance, "GetBOSHDeploymentError").Errorf(ctx, "Failed to get BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "GetBOSHDeploymentError").Errorf(ctx, "failed to get BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	if meltdown.NewWindow(r.config.MeltdownDuration, instance.Status.LastReconcile).Contains(time.Now()) {
@@ -98,14 +98,14 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 	manifest, err := r.resolveManifest(ctx, instance)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "WithOpsManifestError").Errorf(ctx, "Failed to get with-ops manifest for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "WithOpsManifestError").Errorf(ctx, "failed to get with-ops manifest for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Get link infos containing provider name and its secret name
 	linkInfos, err := r.listLinkInfos(instance, manifest)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "Failed to listing link secrets for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "failed to list quarks-link secrets for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Apply the "with-ops" manifest secret
@@ -113,7 +113,7 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 	err = r.createManifestWithOps(ctx, instance, *manifest)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "WithOpsManifestError").Errorf(ctx, "Failed to create with-ops manifest secret for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "WithOpsManifestError").Errorf(ctx, "failed to create with-ops manifest secret for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	log.Debug(ctx, "Rendering manifest")
@@ -121,41 +121,41 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 	// Apply the "Variable Interpolation" QuarksJob, which creates the desired manifest secret
 	qJob, err := r.jobFactory.VariableInterpolationJob(*manifest)
 	if err != nil {
-		return reconcile.Result{}, log.WithEvent(instance, "DesiredManifestError").Errorf(ctx, "Failed to build the desired manifest qJob: %v", err)
+		return reconcile.Result{}, log.WithEvent(instance, "DesiredManifestError").Errorf(ctx, "failed to build the desired manifest qJob: %v", err)
 	}
 
 	log.Debug(ctx, "Creating desired manifest QuarksJob")
 	err = r.createQuarksJob(ctx, instance, qJob)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "DesiredManifestError").Errorf(ctx, "Failed to create desired manifest qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "DesiredManifestError").Errorf(ctx, "failed to create desired manifest qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Apply the "Instance group manifest" QuarksJob, which creates instance group manifests (ig-resolved) secrets
 	qJob, err = r.jobFactory.InstanceGroupManifestJob(*manifest, linkInfos, instance.ObjectMeta.Generation == 1)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "Failed to build instance group manifest qJob: %v", err)
+			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "failed to build instance group manifest qJob: %v", err)
 	}
 
 	log.Debug(ctx, "Creating instance group manifest QuarksJob")
 	err = r.createQuarksJob(ctx, instance, qJob)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "Failed to create instance group manifest qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "InstanceGroupManifestError").Errorf(ctx, "failed to create instance group manifest qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Apply the "BPM Configs" QuarksJob, which creates BPM config secrets
 	qJob, err = r.jobFactory.BPMConfigsJob(*manifest, linkInfos, instance.ObjectMeta.Generation == 1)
 	if err != nil {
-		return reconcile.Result{}, log.WithEvent(instance, "BPMConfigsError").Errorf(ctx, "Failed to build BPM configs qJob: %v", err)
+		return reconcile.Result{}, log.WithEvent(instance, "BPMConfigsError").Errorf(ctx, "failed to build BPM configs qJob: %v", err)
 
 	}
 	log.Debug(ctx, "Creating BPM configs QuarksJob")
 	err = r.createQuarksJob(ctx, instance, qJob)
 	if err != nil {
 		return reconcile.Result{},
-			log.WithEvent(instance, "BPMConfigsError").Errorf(ctx, "Failed to create BPM configs qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
+			log.WithEvent(instance, "BPMConfigsError").Errorf(ctx, "failed to create BPM configs qJob for BOSHDeployment '%s': %v", request.NamespacedName, err)
 	}
 
 	// Update status of bdpl with the timestamp of the last reconcile
@@ -164,7 +164,7 @@ func (r *ReconcileBOSHDeployment) Reconcile(request reconcile.Request) (reconcil
 
 	err = r.client.Status().Update(ctx, instance)
 	if err != nil {
-		log.WithEvent(instance, "UpdateError").Errorf(ctx, "Failed to update reconcile timestamp on bdpl '%s' (%v): %s", instance.Name, instance.ResourceVersion, err)
+		log.WithEvent(instance, "UpdateError").Errorf(ctx, "failed to update reconcile timestamp on bdpl '%s' (%v): %s", instance.Name, instance.ResourceVersion, err)
 		return reconcile.Result{Requeue: false}, nil
 	}
 
@@ -210,13 +210,13 @@ func (r *ReconcileBOSHDeployment) createManifestWithOps(ctx context.Context, ins
 
 	// Set ownership reference
 	if err := r.setReference(instance, manifestSecret, r.scheme); err != nil {
-		return log.WithEvent(instance, "ManifestWithOpsRefError").Errorf(ctx, "Failed to set ownerReference for Secret '%s': %v", manifestSecretName, err)
+		return log.WithEvent(instance, "ManifestWithOpsRefError").Errorf(ctx, "failed to set ownerReference for Secret '%s': %v", manifestSecretName, err)
 	}
 
 	// Apply the secret
 	op, err := controllerutil.CreateOrUpdate(ctx, r.client, manifestSecret, mutate.SecretMutateFn(manifestSecret))
 	if err != nil {
-		return log.WithEvent(instance, "ManifestWithOpsApplyError").Errorf(ctx, "Failed to apply Secret '%s': %v", manifestSecretName, err)
+		return log.WithEvent(instance, "ManifestWithOpsApplyError").Errorf(ctx, "failed to apply Secret '%s': %v", manifestSecretName, err)
 	}
 
 	log.Debugf(ctx, "ResourceReference secret '%s' has been %s", manifestSecret.Name, op)
@@ -245,10 +245,10 @@ func (r *ReconcileBOSHDeployment) createQuarksJob(ctx context.Context, instance 
 func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, manifest *bdm.Manifest) (converter.LinkInfos, error) {
 	linkInfos := converter.LinkInfos{}
 
-	// find all missing providers in the manifest to track duplicated secrets then
+	// find all missing providers in the manifest, so we can look for secrets
 	missingProviders := listMissingProviders(*manifest)
 
-	// quarksLinks store missing provider name with type from secrets
+	// quarksLinks store for missing provider names with types read from secrets
 	quarksLinks := map[string]bdm.QuarksLink{}
 	if len(missingProviders) != 0 {
 		// list secrets and services from target deployment
@@ -259,7 +259,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 			crc.InNamespace(instance.Namespace),
 		)
 		if err != nil {
-			return linkInfos, errors.Wrapf(err, "listing secrets for seeking links from '%s':", instance.Name)
+			return linkInfos, errors.Wrapf(err, "listing secrets for link in deployment '%s':", instance.Name)
 		}
 
 		servicesLabels := map[string]string{bdv1.LabelDeploymentName: instance.Name}
@@ -269,7 +269,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 			crc.InNamespace(instance.Namespace),
 		)
 		if err != nil {
-			return linkInfos, errors.Wrapf(err, "listing services for seeking links from '%s':", instance.Name)
+			return linkInfos, errors.Wrapf(err, "listing services for link in deployment '%s':", instance.Name)
 		}
 
 		for _, s := range secrets.Items {
@@ -296,14 +296,14 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 
 		serviceRecords, err := r.getServiceRecords(instance.Namespace, services.Items)
 		if err != nil {
-			return linkInfos, errors.Wrap(err, fmt.Sprintf("Failed to get link services for: %s", instance.Name))
+			return linkInfos, errors.Wrapf(err, "failed to get link services for: %s", instance.Name)
 		}
 
 		for qName := range quarksLinks {
 			if svcRecord, ok := serviceRecords[qName]; ok {
 				pods, err := r.listPodsFromSelector(instance.Namespace, svcRecord.selector)
 				if err != nil {
-					return linkInfos, errors.Wrap(err, fmt.Sprintf("Failed to get link pods for: %s", instance.Name))
+					return linkInfos, errors.Wrapf(err, "Failed to get link pods for: %s", instance.Name)
 				}
 
 				var jobsInstances []bdm.JobInstance
@@ -338,7 +338,7 @@ func (r *ReconcileBOSHDeployment) listLinkInfos(instance *bdv1.BOSHDeployment, m
 	}
 
 	if len(missingPs) != 0 {
-		return linkInfos, errors.New(fmt.Sprintf("missing secrets of providers: %s", strings.Join(missingPs, ", ")))
+		return linkInfos, errors.New(fmt.Sprintf("missing link secrets for providers: %s", strings.Join(missingPs, ", ")))
 	}
 
 	if len(quarksLinks) != 0 {
@@ -363,7 +363,7 @@ func (r *ReconcileBOSHDeployment) getServiceRecords(namespace string, svcs []cor
 
 			svcRecords[providerName] = serviceRecord{
 				selector:  svc.Spec.Selector,
-				dnsRecord: fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, namespace),
+				dnsRecord: fmt.Sprintf("%s.%s.svc.%s", svc.Name, namespace, bdm.GetClusterDomain()),
 			}
 		}
 	}

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -468,12 +468,12 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 					})
 
 					_, err := reconciler.Reconcile(request)
-					Expect(err.Error()).To(ContainSubstring("listing secrets for seeking links"))
+					Expect(err.Error()).To(ContainSubstring("listing secrets for link in deployment"))
 				})
 				It("handles an error on missing providers when the secret doesn't have the annotation", func() {
 					bazSecret.Annotations = nil
 					_, err := reconciler.Reconcile(request)
-					Expect(err.Error()).To(ContainSubstring("missing secrets of providers"))
+					Expect(err.Error()).To(ContainSubstring("missing link secrets for providers"))
 				})
 
 				It("handles an error on duplicated secrets of provider when duplicated secrets match the annotation", func() {

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter/fakes"
 	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
@@ -440,13 +441,19 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 				It("passes link secrets to QJobs", func() {
 					_, err := reconciler.Reconcile(request)
 					Expect(err).ToNot(HaveOccurred())
-					_, linksSecrets := jobFactory.BPMConfigsJobArgsForCall(0)
-					Expect(linksSecrets).To(Equal(map[string]string{
-						"baz-sec": "baz",
+					_, linksSecrets, _ := jobFactory.BPMConfigsJobArgsForCall(0)
+					Expect(linksSecrets).To(Equal(converter.LinkInfos{
+						{
+							SecretName:   "baz-sec",
+							ProviderName: "baz",
+						},
 					}))
-					_, linksSecrets = jobFactory.InstanceGroupManifestJobArgsForCall(0)
-					Expect(linksSecrets).To(Equal(map[string]string{
-						"baz-sec": "baz",
+					_, linksSecrets, _ = jobFactory.InstanceGroupManifestJobArgsForCall(0)
+					Expect(linksSecrets).To(Equal(converter.LinkInfos{
+						{
+							SecretName:   "baz-sec",
+							ProviderName: "baz",
+						},
 					}))
 				})
 

--- a/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/deployment_reconciler_test.go
@@ -165,6 +165,10 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 		})
 
 		manager.GetClientReturns(client)
+
+		jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
+		jobFactory.InstanceGroupManifestJobReturns(igQJob, nil)
+		jobFactory.BPMConfigsJobReturns(bpmQJob, nil)
 	})
 
 	JustBeforeEach(func() {
@@ -283,8 +287,6 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 			})
 
 			It("handles an error when creating desired manifest qJob", func() {
-				jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
-
 				client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOption) error {
 					switch object := object.(type) {
 					case *qjv1a1.QuarksJob:
@@ -302,7 +304,6 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 			})
 
 			It("handles an error when building instance group manifest qJob", func() {
-				jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
 				jobFactory.InstanceGroupManifestJobReturns(dmQJob, errors.New("fake-error"))
 
 				_, err := reconciler.Reconcile(request)
@@ -311,9 +312,6 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 			})
 
 			It("handles an error when creating instance group manifest qJob", func() {
-				jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
-				jobFactory.InstanceGroupManifestJobReturns(igQJob, nil)
-
 				client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOption) error {
 					switch object := object.(type) {
 					case *qjv1a1.QuarksJob:
@@ -331,8 +329,6 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 			})
 
 			It("handles an error when building BPM configs qJob", func() {
-				jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
-				jobFactory.InstanceGroupManifestJobReturns(dmQJob, nil)
 				jobFactory.BPMConfigsJobReturns(dmQJob, errors.New("fake-error"))
 
 				_, err := reconciler.Reconcile(request)
@@ -341,10 +337,6 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 			})
 
 			It("handles an error when creating BPM configs qJob", func() {
-				jobFactory.VariableInterpolationJobReturns(dmQJob, nil)
-				jobFactory.InstanceGroupManifestJobReturns(igQJob, nil)
-				jobFactory.BPMConfigsJobReturns(bpmQJob, nil)
-
 				client.CreateCalls(func(context context.Context, object runtime.Object, _ ...crc.CreateOption) error {
 					switch object := object.(type) {
 					case *qjv1a1.QuarksJob:
@@ -359,6 +351,140 @@ var _ = Describe("ReconcileBoshDeployment", func() {
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to create BPM configs qJob for BOSHDeployment 'default/foo': creating or updating QuarksJob 'bpm-foo': fake-error"))
+			})
+
+			Context("when the manifest contains explicit links", func() {
+				var bazSecret *corev1.Secret
+
+				BeforeEach(func() {
+					bazSecret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "baz-sec",
+							Namespace: "default",
+							Labels: map[string]string{
+								bdv1.LabelDeploymentName: "foo",
+							},
+							Annotations: map[string]string{
+								bdv1.AnnotationLinkProviderName: "baz",
+							},
+						},
+						Data: map[string][]byte{},
+					}
+
+					manifest = &bdm.Manifest{
+						Name: "foo",
+						Releases: []*bdm.Release{
+							{
+								Name:    "bar",
+								URL:     "docker.io/cfcontainerization",
+								Version: "1.0",
+								Stemcell: &bdm.ReleaseStemcell{
+									OS:      "opensuse",
+									Version: "42.3",
+								},
+							},
+						},
+						InstanceGroups: []*bdm.InstanceGroup{
+							{
+								Name: "fakepod",
+								Jobs: []bdm.Job{
+									{
+										Name:    "foo",
+										Release: "bar",
+										Properties: bdm.JobProperties{
+											Properties: map[string]interface{}{
+												"password": "((foo_password))",
+											},
+											Quarks: bdm.Quarks{
+												Ports: []bdm.Port{
+													{
+														Name:     "foo",
+														Protocol: "TCP",
+														Internal: 8080,
+													},
+												},
+											},
+										},
+										Consumes: map[string]interface{}{
+											"baz": map[string]interface{}{
+												"from": "baz",
+											},
+										},
+									},
+								},
+							},
+						},
+						Variables: []bdm.Variable{
+							{
+								Name: "foo_password",
+								Type: "password",
+							},
+						},
+					}
+
+					client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
+						switch object := object.(type) {
+						case *corev1.SecretList:
+							secretList := corev1.SecretList{
+								Items: []corev1.Secret{*bazSecret},
+							}
+							secretList.DeepCopyInto(object)
+						}
+
+						return nil
+					})
+
+					client.StatusCalls(func() crc.StatusWriter { return &cfakes.FakeStatusWriter{} })
+				})
+
+				It("passes link secrets to QJobs", func() {
+					_, err := reconciler.Reconcile(request)
+					Expect(err).ToNot(HaveOccurred())
+					_, linksSecrets := jobFactory.BPMConfigsJobArgsForCall(0)
+					Expect(linksSecrets).To(Equal(map[string]string{
+						"baz-sec": "baz",
+					}))
+					_, linksSecrets = jobFactory.InstanceGroupManifestJobArgsForCall(0)
+					Expect(linksSecrets).To(Equal(map[string]string{
+						"baz-sec": "baz",
+					}))
+				})
+
+				It("handles an error when listing secretsn", func() {
+					client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
+						switch object.(type) {
+						case *corev1.SecretList:
+							return errors.New("fake-error")
+						}
+
+						return nil
+					})
+
+					_, err := reconciler.Reconcile(request)
+					Expect(err.Error()).To(ContainSubstring("listing secrets for seeking links"))
+				})
+				It("handles an error on missing providers when the secret doesn't have the annotation", func() {
+					bazSecret.Annotations = nil
+					_, err := reconciler.Reconcile(request)
+					Expect(err.Error()).To(ContainSubstring("missing secrets of providers"))
+				})
+
+				It("handles an error on duplicated secrets of provider when duplicated secrets match the annotation", func() {
+					client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
+						switch object := object.(type) {
+						case *corev1.SecretList:
+							secretList := corev1.SecretList{
+								Items: []corev1.Secret{*bazSecret, *bazSecret},
+							}
+							secretList.DeepCopyInto(object)
+						}
+
+						return nil
+					})
+
+					_, err := reconciler.Reconcile(request)
+					Expect(err.Error()).To(ContainSubstring("duplicated secrets of provider"))
+				})
 			})
 		})
 	})

--- a/testing/assets/gatherManifest.yml
+++ b/testing/assets/gatherManifest.yml
@@ -325,7 +325,7 @@ instance_groups:
                 properties:
                   doppler:
                     grpc_port: 7765
-                  fooprop: 10001
+                    fooprop: 10001
             instances: null
             release: loggregator
             envs:

--- a/testing/assets/jobs-src/loggregator/doppler/job.MF
+++ b/testing/assets/jobs-src/loggregator/doppler/job.MF
@@ -19,7 +19,7 @@ provides:
   type: doppler
   properties:
   - doppler.grpc_port
-  - fooprop
+  - doppler.fooprop
 - name: loggregator
   type: loggregator
   properties:
@@ -49,7 +49,7 @@ properties:
     description: Port for outgoing log messages via GRPC
     default: 8082
   
-  fooprop:
+  doppler.fooprop:
     description: Port for outgoing log messages via GRPC
     default: 10001
 

--- a/testing/assets/jobs-src/loggregator/loggregator_trafficcontroller/templates/bpm.yml.erb
+++ b/testing/assets/jobs-src/loggregator/loggregator_trafficcontroller/templates/bpm.yml.erb
@@ -22,7 +22,7 @@ processes:
       TRAFFIC_CONTROLLER_DISABLE_ACCESS_CONTROL: "<%= p("traffic_controller.disable_access_control") %>"
 
       FOOBARWITHLINKADDRESS: <%= link('doppler').address %>
-      FOOBARWITHLINKVALUES: <%= link('doppler').p("fooprop") %>
+      FOOBARWITHLINKVALUES: <%= link('doppler').p("doppler.fooprop") %>
       FOOBARWITHLINKNESTEDVALUES: <%= link('doppler').p("doppler.grpc_port") %>
       FOOBARWITHLINKINSTANCESINDEX: <%= link('doppler').instances[0].index %>
       FOOBARWITHLINKINSTANCESAZ: <%= link('doppler').instances[0].az %>

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -231,3 +231,67 @@ const Diego = `
         enable_consul_service_registration: false
         set_kernel_parameters: false
 `
+
+// ManifestWithExternalLinks has explicit BOSH links consumes.
+const ManifestWithExternalLinks = `---
+name: test
+releases:
+- name: loggregator
+  url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.0
+  version: "105.0"
+  sha1: d0bed91335aaac418eb6e8b2be13c6ecf4ce7b90
+stemcells:
+- alias: default
+  os: ubuntu-xenial
+  version: "250.17"
+instance_groups:
+- name: log-api
+  instances: 2
+  vm_type: minimal
+  stemcell: default
+  update:
+    serial: true
+  networks:
+  - name: default
+  jobs:
+  - name: loggregator_trafficcontroller
+    release: loggregator
+    consumes:
+      doppler: {from: doppler}
+    properties:
+      uaa:
+        internal_url: https://uaa.service.cf.internal:8443
+        ca_cert: "uaa_ca_certificate"
+      doppler:
+        grpc_port: 6060
+      loggregator:
+        tls:
+          cc_trafficcontroller:
+            cert: "fake_cert"
+            key: "fake_private_key"
+          ca_cert: "fake_ca_cert"
+          trafficcontroller:
+            cert: "fake_cert"
+            key: "fake_private_key"
+        uaa:
+          client_secret: "uaa_clients_doppler_secret"
+      system_domain: "system_domain"
+      ssl:
+        skip_cert_verify: true
+      cc:
+        internal_service_hostname: "cloud-controller-ng.service.cf.internal"
+        tls_port: 9023
+        mutual_tls:
+          ca_cert: "fake_certificate"
+properties:
+  quarks_links:
+    doppler:
+      type: doppler
+      address: doppler-0.default.svc.cluster.local
+      instances:
+      - name: doppler
+        id: pod-uuid
+        index: 0
+        address: 172.30.10.1
+        bootstrap: true
+`

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -110,6 +110,28 @@ instance_groups:
           internal: 4223
 `
 
+// NatsSmokeTestWithExternalLinks has explicit BOSH links.
+// It can be used in integration tests.
+const NatsSmokeTestWithExternalLinks = `---
+name: test
+releases:
+- name: nats
+  version: "26"
+  url: docker.io/cfcontainerization
+  stemcell:
+    os: opensuse-42.3
+    version: 30.g9c91e77-30.80-7.0.0_257.gb97ced55
+instance_groups:
+- name: nats-smoke-tests
+  instances: 1
+  lifecycle: auto-errand
+  jobs:
+  - name: smoke-tests
+    release: nats
+    consumes:
+      nats: {from: nats}
+`
+
 // Drains is a small manifest with jobs that include drain scripts
 // It can be used in integration tests.
 const Drains = `---

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -162,6 +162,16 @@ func (c *Catalog) BOSHManifestWithZeroInstances() (*manifest.Manifest, error) {
 	return m, nil
 }
 
+// BOSHManifestWithExternalLinks returns a manifest with external links
+// Also usable in integration tests
+func (c *Catalog) BOSHManifestWithExternalLinks() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.ManifestWithExternalLinks))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}
+
 // BPMReleaseWithAffinityConfigMap for tests
 func (c *Catalog) BPMReleaseWithAffinityConfigMap(name string) corev1.ConfigMap {
 	return corev1.ConfigMap{

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -18,6 +18,7 @@ import (
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/pkg/credsgen"
+	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/statefulset"
 	bm "code.cloudfoundry.org/cf-operator/testing/boshmanifest"
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
@@ -758,4 +759,194 @@ func (c *Catalog) BOSHManifestWithNilConsume() (*manifest.Manifest, error) {
 		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
 	}
 	return m, nil
+}
+
+// NatsPod for use in tests
+func (c *Catalog) NatsPod(deployName string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nats",
+			Labels: map[string]string{
+				bdv1.LabelDeploymentName: deployName,
+				"app":                    "nats",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "nats",
+					Image:           "docker.io/bitnami/nats:1.1.0",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"gnatsd"},
+					Args:            []string{"-c", "/opt/bitnami/nats/gnatsd.conf"},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "client",
+							ContainerPort: 4222,
+						},
+						{
+							Name:          "cluster",
+							ContainerPort: 6222,
+						},
+						{
+							Name:          "monitoring",
+							ContainerPort: 8222,
+						},
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/",
+								Port: intstr.FromString("monitoring"),
+							},
+						},
+						FailureThreshold:    6,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      5,
+						InitialDelaySeconds: 30,
+					},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/",
+								Port: intstr.FromString("monitoring"),
+							},
+						},
+						FailureThreshold:    6,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      5,
+						InitialDelaySeconds: 5,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "config",
+							MountPath: "/opt/bitnami/nats/gnatsd.conf",
+							SubPath:   "gnatsd.conf",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "nats",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// NatsConfigMap for use in tests
+func (c *Catalog) NatsConfigMap(deployName string) corev1.ConfigMap {
+	return corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nats",
+			Labels: map[string]string{
+				bdv1.LabelDeploymentName: deployName,
+			},
+		},
+		Data: map[string]string{
+			"gnatsd.conf": `listen: 0.0.0.0:4222
+http: 0.0.0.0:8222
+
+# Authorization for client connections
+authorization {
+  user: nats_client
+  password: r9fXAlY3gZ
+  timeout:  1
+}
+
+# Logging options
+debug: false
+trace: false
+logtime: false
+
+# Pid file
+pid_file: "/tmp/gnatsd.pid"
+
+# Some system overides
+
+
+# Clustering definition
+cluster {
+  listen: 0.0.0.0:6222
+
+  # Authorization for cluster connections
+  authorization {
+	user: nats_cluster
+	password: hK9awRcEYs
+	timeout:  1
+  }
+
+  # Routes are actively solicited and connected to from this server.
+  # Other servers can connect to us if they supply the correct credentials
+  # in their routes definitions from above
+  routes = [
+	nats://nats_cluster:hK9awRcEYs@nats-headless:6222
+  ]
+}`,
+		},
+	}
+}
+
+// NatsService for use in tests
+func (c *Catalog) NatsService(deployName string) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nats-headless",
+			Labels: map[string]string{
+				bdv1.LabelDeploymentName: deployName,
+			},
+			Annotations: map[string]string{
+				bdv1.AnnotationLinkProviderName: "nats",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"app": "nats",
+			},
+			Ports: []corev1.ServicePort{
+				corev1.ServicePort{
+					Name:       "client",
+					Port:       4222,
+					TargetPort: intstr.FromString("client"),
+				},
+				corev1.ServicePort{
+					Name:       "cluster",
+					Port:       6222,
+					TargetPort: intstr.FromString("cluster"),
+				},
+			},
+		},
+	}
+}
+
+// NatsSecret for use in tests
+func (c *Catalog) NatsSecret(deployName string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nats",
+			Labels: map[string]string{
+				bdv1.LabelDeploymentName: deployName,
+			},
+			Annotations: map[string]string{
+				bdv1.AnnotationLinkProviderName: "nats",
+				bdv1.AnnotationLinkProviderType: "nats",
+			},
+		},
+		StringData: map[string]string{
+			"user":     "nats_client",
+			"password": "r9fXAlY3gZ",
+			"port":     "4222",
+		},
+	}
 }


### PR DESCRIPTION
One part of quarks link:
[#169419605](https://www.pivotaltracker.com/story/show/169419605)

Introduced one annotation for link provider name, and reused deployment-name label to list secrets
The cf-o collects all providers from instance group's `consumes` and does the following:
- If this provider can be found from other instance groups, remove this item
- If this provider **cannot** be found, list secrets under the same namespace
  - If the secret annotation specifies one provider, mount this secret to IG/BPM QJobs
  - If no secret or multiple secrets are matched, return an error

Until all links secrets found, the controller creates relative IG/BPM QJobs.

And we enable `UpdateOnChange` for mounted secrets, cf-o also supports restarting IG/BPM QJobs when a "link secret" changes.

