### PR TITLE
Fix 'set -e' and others get lost when sourcing 'bin/include/versioning'

### DIFF
--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-set +o errexit +o nounset
-
-test -n "${XTRACE}" && set -o xtrace
-
+old_options="$(set +o); set -$-"
 set -o errexit -o nounset
+
+if [ -n "${XTRACE:-}" ] ; then
+    set -o xtrace
+fi
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
@@ -17,4 +18,6 @@ GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }')
 
 ARTIFACT_VERSION="${GIT_TAG}-${GIT_COMMITS}.${GIT_SHA}"
 
-set +o errexit +o nounset +o xtrace
+# Restore shell options (in case this script is being sourced)
+set +x;
+eval "$old_options"


### PR DESCRIPTION
Currently when I run
```bash
make build-image
echo $?
```
it will echo `0` even if the docker build failes.

### Problem
inside `build-image` the `errexit` option is set correctly.
https://github.com/cloudfoundry-incubator/cf-operator/blob/bc3bd206d885765f9f09aba53b2d510edb8f57a9/bin/build-image#L3

But when sourcing `bin/include/versioning` the option gets resetted:
https://github.com/cloudfoundry-incubator/cf-operator/blob/bc3bd206d885765f9f09aba53b2d510edb8f57a9/bin/include/versioning#L20

### Proposed solution
In the beginning of `bin/include/versioning` current shell-options are stored and restored in the end.

This PR also changes how the `XTRACE` env varaible is evaluated.