### PR TITLE
Fix 'set -e' and others get lost when sourcing 'bin/include/versioning'

### DIFF
--- a/bin/include/docker
+++ b/bin/include/docker
@@ -10,7 +10,7 @@ if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
   export DOCKER_IMAGE_TAG
 fi
 
-if [ -z "$DOCKER_IMAGE_REPOSITORY" ]; then
+if [ -z ${DOCKER_IMAGE_REPOSITORY+x} ]; then
     DOCKER_IMAGE_REPOSITORY="cf-operator"
     export DOCKER_IMAGE_REPOSITORY
 fi

--- a/bin/include/testing
+++ b/bin/include/testing
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 function setup_testing_tmp {
-  if [ -z "${CF_OPERATOR_TESTING_TMP}" ]
+  if [ -z ${CF_OPERATOR_TESTING_TMP+x} ]
   then
     echo "[Error] Env variable \$CF_OPERATOR_TESTING_TMP is not set. Please set to continue."
     exit 1
   fi
 
+  SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=${SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP:-}
   if [ "$SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP" != "true" ]
   then
     echo "${CF_OPERATOR_TESTING_TMP} will be cleaned up after the tests. Set SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=true to skip cleanup."

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-set +o errexit +o nounset
-
-test -n "${XTRACE}" && set -o xtrace
-
+old_options="$(set +o); set -$-"
 set -o errexit -o nounset
+
+if [ -n "${XTRACE:-}" ] ; then
+    set -o xtrace
+fi
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
@@ -17,4 +18,6 @@ GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }')
 
 ARTIFACT_VERSION="${GIT_TAG}-${GIT_COMMITS}.${GIT_SHA}"
 
-set +o errexit +o nounset +o xtrace
+# Restore shell options (in case this script is being sourced)
+set +x;
+eval "$old_options"

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-old_options="$(set +o); set -$-"
-set -o errexit -o nounset
-
-if [ -n "${XTRACE:-}" ] ; then
-    set -o xtrace
-fi
-
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
 GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD)}
@@ -17,7 +10,3 @@ GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }')
 [ -z "$(git status --porcelain)" ] || GIT_TAG="${GIT_TAG}-dirty"
 
 ARTIFACT_VERSION="${GIT_TAG}-${GIT_COMMITS}.${GIT_SHA}"
-
-# Restore shell options (in case this script is being sourced)
-set +x;
-eval "$old_options"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -7,7 +7,7 @@ GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/testing"
 . "${GIT_ROOT}/bin/include/dependencies"
 
-name="$1"
+name="${1-}"
 
 if [ -z ${TEST_NAMESPACE+x} ]; then
   TEST_NAMESPACE="test$(date +%s)"
@@ -20,7 +20,8 @@ setup_testing_tmp
 trap cleanup_testing_tmp EXIT
 
 # Run code coverage only in CI
-if [ -n "$COVERAGE" ]; then
+COV_ARG=""
+if [ ${COVERAGE+x} ]; then
   pkgs="code.cloudfoundry.org/cf-operator/pkg/bosh/...,\
     code.cloudfoundry.org/cf-operator/pkg/credsgen/...,\
     code.cloudfoundry.org/cf-operator/pkg/kube/controllers/...,\


### PR DESCRIPTION
This removes shell options handling from the included script and fixes the other scripts. 
I wasn't able to update the existing PR #719