### PR TITLE
Moved interface back to implementor

### DIFF
--- a/bin/gen-fakes
+++ b/bin/gen-fakes
@@ -13,5 +13,5 @@ counterfeiter -o pkg/bosh/converter/fakes/container_factory.go pkg/bosh/converte
 counterfeiter -o pkg/bosh/converter/fakes/volume_factory.go pkg/bosh/converter/ VolumeFactory
 counterfeiter -o pkg/bosh/converter/fakes/job_factory.go pkg/kube/controllers/boshdeployment/ JobFactory
 counterfeiter -o pkg/bosh/converter/fakes/kube_converter.go pkg/kube/controllers/boshdeployment KubeConverter
-counterfeiter -o pkg/bosh/manifest/fakes/desired_manifest.go pkg/kube/controllers/boshdeployment DesiredManifest
+counterfeiter -o pkg/bosh/manifest/fakes/desired_manifest.go pkg/bosh/converter/ DesiredManifest
 counterfeiter -o pkg/credsgen/fakes/generator.go pkg/credsgen/ Generator

--- a/pkg/bosh/converter/resolver.go
+++ b/pkg/bosh/converter/resolver.go
@@ -26,6 +26,11 @@ type Resolver interface {
 	WithOpsManifestDetailed(ctx context.Context, instance *bdv1.BOSHDeployment, namespace string) (*bdm.Manifest, []string, error)
 }
 
+// DesiredManifest unmarshals desired manifest from the manifest secret
+type DesiredManifest interface {
+	DesiredManifest(ctx context.Context, boshDeploymentName, namespace string) (*bdm.Manifest, error)
+}
+
 // ResolverImpl resolves references from bdpl CRD to a BOSH manifest
 type ResolverImpl struct {
 	client               client.Client
@@ -36,8 +41,16 @@ type ResolverImpl struct {
 // NewInterpolatorFunc returns a fresh Interpolator
 type NewInterpolatorFunc func() Interpolator
 
+// NewDesiredManifest constructs a resolver
+func NewDesiredManifest(client client.Client) DesiredManifest {
+	return &ResolverImpl{
+		client:               client,
+		versionedSecretStore: versionedsecretstore.NewVersionedSecretStore(client),
+	}
+}
+
 // NewResolver constructs a resolver
-func NewResolver(client client.Client, f NewInterpolatorFunc) *ResolverImpl {
+func NewResolver(client client.Client, f NewInterpolatorFunc) Resolver {
 	return &ResolverImpl{
 		client:               client,
 		newInterpolatorFunc:  f,

--- a/pkg/bosh/converter/resolver_test.go
+++ b/pkg/bosh/converter/resolver_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Resolver", func() {
 		validOpsPath      string
 		invalidOpsPath    string
 
-		resolver         *converter.ResolverImpl
+		resolver         converter.Resolver
 		client           client.Client
 		interpolator     *fakes.FakeInterpolator
 		remoteFileServer *ghttp.Server

--- a/pkg/bosh/manifest/fakes/desired_manifest.go
+++ b/pkg/bosh/manifest/fakes/desired_manifest.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"sync"
 
+	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
-	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/boshdeployment"
 )
 
 type FakeDesiredManifest struct {
@@ -118,4 +118,4 @@ func (fake *FakeDesiredManifest) recordInvocation(key string, args []interface{}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ boshdeployment.DesiredManifest = new(FakeDesiredManifest)
+var _ converter.DesiredManifest = new(FakeDesiredManifest)

--- a/pkg/kube/controllers/boshdeployment/bpm_controller.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_controller.go
@@ -33,7 +33,7 @@ func AddBPM(ctx context.Context, config *config.Config, mgr manager.Manager) err
 	ctx = ctxlog.NewContextWithRecorder(ctx, "bpm-reconciler", mgr.GetEventRecorderFor("bpm-recorder"))
 	r := NewBPMReconciler(
 		ctx, config, mgr,
-		converter.NewResolver(mgr.GetClient(), func() converter.Interpolator { return converter.NewInterpolator() }),
+		converter.NewDesiredManifest(mgr.GetClient()),
 		controllerutil.SetControllerReference,
 		converter.NewKubeConverter(
 			config.Namespace,

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler.go
@@ -34,11 +34,6 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 )
 
-// DesiredManifest unmarshals desired manifest from the manifest secret
-type DesiredManifest interface {
-	DesiredManifest(ctx context.Context, boshDeploymentName, namespace string) (*bdm.Manifest, error)
-}
-
 // KubeConverter converts k8s resources from single BOSH manifest
 type KubeConverter interface {
 	BPMResources(manifestName string, dns manifest.DomainNameService, qStsVersion string, instanceGroup *bdm.InstanceGroup, releaseImageProvider converter.ReleaseImageProvider, bpmConfigs bpm.Configs, igResolvedSecretVersion string) (*converter.BPMResources, error)
@@ -48,7 +43,7 @@ type KubeConverter interface {
 var _ reconcile.Reconciler = &ReconcileBOSHDeployment{}
 
 // NewBPMReconciler returns a new reconcile.Reconciler
-func NewBPMReconciler(ctx context.Context, config *config.Config, mgr manager.Manager, resolver DesiredManifest, srf setReferenceFunc, kubeConverter KubeConverter) reconcile.Reconciler {
+func NewBPMReconciler(ctx context.Context, config *config.Config, mgr manager.Manager, resolver converter.DesiredManifest, srf setReferenceFunc, kubeConverter KubeConverter) reconcile.Reconciler {
 	return &ReconcileBPM{
 		ctx:                  ctx,
 		config:               config,
@@ -67,7 +62,7 @@ type ReconcileBPM struct {
 	config               *config.Config
 	client               client.Client
 	scheme               *runtime.Scheme
-	resolver             DesiredManifest
+	resolver             converter.DesiredManifest
 	setReference         setReferenceFunc
 	kubeConverter        KubeConverter
 	versionedSecretStore versionedsecretstore.VersionedSecretStore


### PR DESCRIPTION
Resolver interface is re-used across the app, DesiredManifest interface
is implemented by the same struct and will be re-used, too.

Also no consumer was using the Resolver interface.

[#169418463](https://www.pivotaltracker.com/story/show/169418463)