### PR TITLE
Switch from apps/v1beta2 to apps/v1

### DIFF
--- a/pkg/bosh/converter/bpm_resources.go
+++ b/pkg/bosh/converter/bpm_resources.go
@@ -15,7 +15,7 @@ import (
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 	"code.cloudfoundry.org/quarks-utils/pkg/pointers"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1b1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -139,13 +139,13 @@ func (kc *KubeConverter) serviceToQuarksStatefulSet(
 		Spec: qstsv1a1.QuarksStatefulSetSpec{
 			Zones:                instanceGroup.AZs,
 			UpdateOnConfigChange: true,
-			Template: v1beta2.StatefulSet{
+			Template: appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        instanceGroup.NameSanitized(),
 					Labels:      statefulSetLabels,
 					Annotations: statefulSetAnnotations,
 				},
-				Spec: v1beta2.StatefulSetSpec{
+				Spec: appsv1.StatefulSetSpec{
 					Replicas: pointers.Int32(int32(instanceGroup.Instances)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: statefulSetLabels,

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
@@ -43,7 +43,7 @@ type QuarksStatefulSetSpec struct {
 	Zones []string `json:"zones,omitempty"`
 
 	// Defines a regular StatefulSet template
-	Template v1beta2.StatefulSet `json:"template"`
+	Template appsv1.StatefulSet `json:"template"`
 }
 
 // QuarksStatefulSetStatus defines the observed state of QuarksStatefulSet

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_controller.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
-	appsv1beta2client "k8s.io/client-go/kubernetes/typed/apps/v1beta2"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -41,7 +41,7 @@ func AddQuarksStatefulSet(ctx context.Context, config *config.Config, mgr manage
 		return errors.Wrap(err, "Adding QuarksStatefulSet controller to manager failed.")
 	}
 
-	client, err := appsv1beta2client.NewForConfig(mgr.GetConfig())
+	client, err := appsv1client.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return errors.Wrap(err, "Could not get kube client")
 	}

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -166,8 +166,8 @@ func (r *ReconcileQuarksStatefulSet) UpdateVersions(ctx context.Context, qStatef
 }
 
 // calculateDesiredStatefulSets generates the desired StatefulSets that should exist
-func (r *ReconcileQuarksStatefulSet) calculateDesiredStatefulSets(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]v1beta2.StatefulSet, error) {
-	var desiredStatefulSets []v1beta2.StatefulSet
+func (r *ReconcileQuarksStatefulSet) calculateDesiredStatefulSets(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]appsv1.StatefulSet, error) {
+	var desiredStatefulSets []appsv1.StatefulSet
 
 	template := qStatefulSet.Spec.Template.DeepCopy()
 
@@ -208,7 +208,7 @@ func (r *ReconcileQuarksStatefulSet) calculateDesiredStatefulSets(ctx context.Co
 }
 
 // createStatefulSet creates a StatefulSet
-func (r *ReconcileQuarksStatefulSet) createStatefulSet(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet, statefulSet *v1beta2.StatefulSet) error {
+func (r *ReconcileQuarksStatefulSet) createStatefulSet(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet, statefulSet *appsv1.StatefulSet) error {
 
 	// Set the owner of the StatefulSet, so it's garbage collected,
 	// and we can find it later
@@ -226,7 +226,7 @@ func (r *ReconcileQuarksStatefulSet) createStatefulSet(ctx context.Context, qSta
 }
 
 // generateSingleStatefulSet creates a StatefulSet from one zone
-func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qstsv1a1.QuarksStatefulSet, template *v1beta2.StatefulSet, zoneIndex int, zoneName string, version int) (*v1beta2.StatefulSet, error) {
+func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qstsv1a1.QuarksStatefulSet, template *appsv1.StatefulSet, zoneIndex int, zoneName string, version int) (*appsv1.StatefulSet, error) {
 	statefulSet := template.DeepCopy()
 
 	statefulSetNamePrefix := qStatefulSet.GetName()
@@ -242,7 +242,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 
 		zonesBytes, err := json.Marshal(qStatefulSet.Spec.Zones)
 		if err != nil {
-			return &v1beta2.StatefulSet{}, errors.Wrapf(err, "Could not marshal zones: '%v'", qStatefulSet.Spec.Zones)
+			return &appsv1.StatefulSet{}, errors.Wrapf(err, "Could not marshal zones: '%v'", qStatefulSet.Spec.Zones)
 		}
 		annotations[qstsv1a1.AnnotationZones] = string(zonesBytes)
 
@@ -269,7 +269,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 }
 
 // updateAffinity Update current statefulSet Affinity from AZ specification
-func (r *ReconcileQuarksStatefulSet) updateAffinity(statefulSet *v1beta2.StatefulSet, zoneNodeLabel string, zoneName string) *v1beta2.StatefulSet {
+func (r *ReconcileQuarksStatefulSet) updateAffinity(statefulSet *appsv1.StatefulSet, zoneNodeLabel string, zoneName string) *appsv1.StatefulSet {
 	nodeInZoneSelector := corev1.NodeSelectorRequirement{
 		Key:      zoneNodeLabel,
 		Operator: corev1.NodeSelectorOpIn,

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,12 +85,12 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						UID:       "",
 					},
 					Spec: qstsv1a1.QuarksStatefulSetSpec{
-						Template: v1beta2.StatefulSet{
+						Template: appsv1.StatefulSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{existingAnnotation: existingValue},
 								Labels:      map[string]string{existingLabel: existingValue},
 							},
-							Spec: v1beta2.StatefulSetSpec{
+							Spec: appsv1.StatefulSetSpec{
 								Replicas: pointers.Int32(1),
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
@@ -130,7 +130,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 				err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ess)
 				Expect(err).ToNot(HaveOccurred())
 
-				ss := &v1beta2.StatefulSet{}
+				ss := &appsv1.StatefulSet{}
 				err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ss)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -142,13 +142,13 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 
-				ss := &v1beta2.StatefulSet{}
+				ss := &appsv1.StatefulSet{}
 				err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ss)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			Context("with multiple replicas", func() {
-				var ss *v1beta2.StatefulSet
+				var ss *appsv1.StatefulSet
 				BeforeEach(func() {
 					desiredQStatefulSet.Spec.Template.Spec.Replicas = pointers.Int32(3)
 					client = fake.NewFakeClient(
@@ -162,7 +162,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(result).To(Equal(reconcile.Result{}))
 
-					ss = &v1beta2.StatefulSet{}
+					ss = &appsv1.StatefulSet{}
 					err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ss)
 					Expect(err).ToNot(HaveOccurred())
 
@@ -205,19 +205,19 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ess)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ0 := &v1beta2.StatefulSet{}
+						ssZ0 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ1 := &v1beta2.StatefulSet{}
+						ssZ1 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ2 := &v1beta2.StatefulSet{}
+						ssZ2 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
-						for idx, ss := range []*v1beta2.StatefulSet{ssZ0, ssZ1, ssZ2} {
+						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
 							Expect(metav1.IsControlledBy(ss, ess)).To(BeTrue())
 
 							// Check statefulSet labels and annotations
@@ -310,19 +310,19 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ess)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ0 := &v1beta2.StatefulSet{}
+						ssZ0 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ1 := &v1beta2.StatefulSet{}
+						ssZ1 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
-						ssZ2 := &v1beta2.StatefulSet{}
+						ssZ2 := &appsv1.StatefulSet{}
 						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
-						for idx, ss := range []*v1beta2.StatefulSet{ssZ0, ssZ1, ssZ2} {
+						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
 							Expect(metav1.IsControlledBy(ss, ess)).To(BeTrue())
 
 							// Check statefulSet labels and annotations
@@ -420,7 +420,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 		Context("when there are two versions", func() {
 			var (
 				desiredQStatefulSet *qstsv1a1.QuarksStatefulSet
-				v2StatefulSet       *v1beta2.StatefulSet
+				v2StatefulSet       *appsv1.StatefulSet
 			)
 
 			BeforeEach(func() {
@@ -431,19 +431,19 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						UID:       "foo-uid",
 					},
 					Spec: qstsv1a1.QuarksStatefulSetSpec{
-						Template: v1beta2.StatefulSet{
+						Template: appsv1.StatefulSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"test": "2",
 								},
 							},
-							Spec: v1beta2.StatefulSetSpec{
+							Spec: appsv1.StatefulSetSpec{
 								Replicas: pointers.Int32(1),
 							},
 						},
 					},
 				}
-				v2StatefulSet = &v1beta2.StatefulSet{
+				v2StatefulSet = &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
@@ -470,7 +470,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 			})
 
 			It("creates version 3", func() {
-				ss := &v1beta2.StatefulSet{}
+				ss := &appsv1.StatefulSet{}
 				err := client.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "default"}, ss)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ss.GetAnnotations()).To(HaveKeyWithValue(qstsv1a1.AnnotationVersion, "2"))

--- a/pkg/kube/controllers/quarksstatefulset/util.go
+++ b/pkg/kube/controllers/quarksstatefulset/util.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appsv1beta2client "k8s.io/client-go/kubernetes/typed/apps/v1beta2"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	crc "sigs.k8s.io/controller-runtime/pkg/client"
 
 	qstsv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/quarksstatefulset/v1alpha1"
@@ -16,9 +16,9 @@ import (
 
 // GetMaxStatefulSetVersion returns the max version statefulSet
 // of the quarksStatefulSet.
-func GetMaxStatefulSetVersion(ctx context.Context, client crc.Client, qStatefulSet *qstsv1a1.QuarksStatefulSet) (*v1beta2.StatefulSet, int, error) {
+func GetMaxStatefulSetVersion(ctx context.Context, client crc.Client, qStatefulSet *qstsv1a1.QuarksStatefulSet) (*appsv1.StatefulSet, int, error) {
 	// Default response is an empty StatefulSet with version '0' and an empty signature
-	result := &v1beta2.StatefulSet{
+	result := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				qstsv1a1.AnnotationVersion: "0",
@@ -55,10 +55,10 @@ func GetMaxStatefulSetVersion(ctx context.Context, client crc.Client, qStatefulS
 }
 
 // listStatefulSetsFromInformer gets StatefulSets cross version owned by the QuarksStatefulSet from informer
-func listStatefulSetsFromInformer(ctx context.Context, client crc.Client, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]v1beta2.StatefulSet, error) {
+func listStatefulSetsFromInformer(ctx context.Context, client crc.Client, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]appsv1.StatefulSet, error) {
 	ctxlog.Debug(ctx, "Listing StatefulSets owned by QuarksStatefulSet '", qStatefulSet.Name, "'.")
 
-	allStatefulSets := &v1beta2.StatefulSetList{}
+	allStatefulSets := &appsv1.StatefulSetList{}
 	err := client.List(ctx, allStatefulSets,
 		crc.InNamespace(qStatefulSet.Namespace),
 	)
@@ -70,7 +70,7 @@ func listStatefulSetsFromInformer(ctx context.Context, client crc.Client, qState
 }
 
 // listStatefulSetsFromAPIClient gets StatefulSets cross version owned by the QuarksStatefulSet from API client directly
-func listStatefulSetsFromAPIClient(ctx context.Context, client appsv1beta2client.AppsV1beta2Interface, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]v1beta2.StatefulSet, error) {
+func listStatefulSetsFromAPIClient(ctx context.Context, client appsv1client.AppsV1Interface, qStatefulSet *qstsv1a1.QuarksStatefulSet) ([]appsv1.StatefulSet, error) {
 	ctxlog.Debug(ctx, "Listing StatefulSets owned by QuarksStatefulSet '", qStatefulSet.Name, "'.")
 
 	allStatefulSets, err := client.StatefulSets(qStatefulSet.Namespace).List(metav1.ListOptions{})
@@ -82,8 +82,8 @@ func listStatefulSetsFromAPIClient(ctx context.Context, client appsv1beta2client
 }
 
 // getStatefulSetsOwnedBy gets StatefulSets owned by the QuarksStatefulSet
-func getStatefulSetsOwnedBy(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet, statefulSets []v1beta2.StatefulSet) ([]v1beta2.StatefulSet, error) {
-	result := []v1beta2.StatefulSet{}
+func getStatefulSetsOwnedBy(ctx context.Context, qStatefulSet *qstsv1a1.QuarksStatefulSet, statefulSets []appsv1.StatefulSet) ([]appsv1.StatefulSet, error) {
+	result := []appsv1.StatefulSet{}
 
 	for _, statefulSet := range statefulSets {
 		if metav1.IsControlledBy(&statefulSet, qStatefulSet) {

--- a/pkg/kube/controllers/statefulset/statefulset_rollout_controller.go
+++ b/pkg/kube/controllers/statefulset/statefulset_rollout_controller.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -49,7 +49,7 @@ func AddStatefulSetRollout(ctx context.Context, config *config.Config, mgr manag
 			return false
 		},
 	}
-	err = c.Watch(&source.Kind{Type: &v1beta2.StatefulSet{}}, &handler.EnqueueRequestForObject{}, statefulSetPredicates)
+	err = c.Watch(&source.Kind{Type: &appsv1.StatefulSet{}}, &handler.EnqueueRequestForObject{}, statefulSetPredicates)
 	if err != nil {
 		return errors.Wrapf(err, "Watching StatefulSet failed in StatefulSet rollout controller.")
 	}
@@ -59,7 +59,7 @@ func AddStatefulSetRollout(ctx context.Context, config *config.Config, mgr manag
 
 // CheckUpdate checks if update event should be processed
 func CheckUpdate(e event.UpdateEvent) bool {
-	newSts := e.ObjectNew.(*v1beta2.StatefulSet)
+	newSts := e.ObjectNew.(*appsv1.StatefulSet)
 	state, ok := newSts.Annotations[AnnotationCanaryRollout]
 	if !ok || state == rolloutStateDone || state == rolloutStateFailed {
 		return false
@@ -67,7 +67,7 @@ func CheckUpdate(e event.UpdateEvent) bool {
 	if state == rolloutStatePending {
 		return true
 	}
-	oldSts := e.ObjectOld.(*v1beta2.StatefulSet)
+	oldSts := e.ObjectOld.(*appsv1.StatefulSet)
 	if oldSts.Status.ReadyReplicas == newSts.Status.ReadyReplicas &&
 		oldSts.Status.UpdatedReplicas == newSts.Status.UpdatedReplicas &&
 		oldSts.Status.Replicas == newSts.Status.Replicas {

--- a/pkg/kube/controllers/statefulset/statefulset_rollout_util_test.go
+++ b/pkg/kube/controllers/statefulset/statefulset_rollout_util_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +49,7 @@ var _ = Describe("CleanupNonReadyPod", func() {
 		ctx          context.Context
 		log          *zap.SugaredLogger
 		client       *cfakes.FakeClient
-		statefulSet  *v1beta2.StatefulSet
+		statefulSet  *appsv1.StatefulSet
 		readyPod     *corev1.Pod
 		pendingPod   *corev1.Pod
 		noneReadyPod *corev1.Pod
@@ -107,7 +107,7 @@ var _ = Describe("CleanupNonReadyPod", func() {
 				Phase: corev1.PodRunning,
 			},
 		}
-		statefulSet = &v1beta2.StatefulSet{
+		statefulSet = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "foo",
 				Namespace:   "default",
@@ -123,11 +123,11 @@ var _ = Describe("CleanupNonReadyPod", func() {
 					},
 				},
 			},
-			Spec: v1beta2.StatefulSetSpec{
+			Spec: appsv1.StatefulSetSpec{
 				Replicas: pointers.Int32(3),
 				Selector: &metav1.LabelSelector{MatchLabels: selector},
-				UpdateStrategy: v1beta2.StatefulSetUpdateStrategy{
-					RollingUpdate: &v1beta2.RollingUpdateStatefulSetStrategy{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+					RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
 						Partition: pointers.Int32(8),
 					},
 				},
@@ -135,7 +135,7 @@ var _ = Describe("CleanupNonReadyPod", func() {
 					Spec: readyPod.Spec,
 				},
 			},
-			Status: v1beta2.StatefulSetStatus{
+			Status: appsv1.StatefulSetStatus{
 				UpdatedReplicas: 3,
 				ReadyReplicas:   1,
 				Replicas:        3,

--- a/pkg/kube/controllers/statefulset/statefulset_webhook.go
+++ b/pkg/kube/controllers/statefulset/statefulset_webhook.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -40,15 +40,15 @@ func NewMutator(log *zap.SugaredLogger, config *config.Config) admission.Handler
 	}
 }
 
-func isControlledRolloutStatefulSet(statefulset *v1beta2.StatefulSet) bool {
+func isControlledRolloutStatefulSet(statefulset *appsv1.StatefulSet) bool {
 	enabled, ok := statefulset.GetAnnotations()[AnnotationCanaryRolloutEnabled]
 	return ok && enabled == "true"
 }
 
 // Handle set the partion for StatefulSets
 func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	statefulset := &v1beta2.StatefulSet{}
-	oldStatefulset := &v1beta2.StatefulSet{}
+	statefulset := &appsv1.StatefulSet{}
+	oldStatefulset := &appsv1.StatefulSet{}
 
 	err := m.decoder.Decode(req, statefulset)
 	if err != nil {
@@ -94,7 +94,7 @@ func NewStatefulSetRolloutMutator(log *zap.SugaredLogger, config *config.Config)
 			{
 				Rule: admissionregistrationv1beta1.Rule{
 					APIGroups:   []string{"apps"},
-					APIVersions: []string{"v1beta2"},
+					APIVersions: []string{"v1"},
 					Resources:   []string{"statefulsets"},
 					Scope:       &globalScopeType,
 				},

--- a/pkg/kube/controllers/statefulset/statefulset_webhook_test.go
+++ b/pkg/kube/controllers/statefulset/statefulset_webhook_test.go
@@ -15,7 +15,7 @@ import (
 	helper "code.cloudfoundry.org/quarks-utils/testing/testhelper"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,15 +29,15 @@ var _ = Describe("When the muatating webhook handles a statefulset", func() {
 		ctx     context.Context
 		decoder *admission.Decoder
 		mutator admission.Handler
-		old     v1beta2.StatefulSet
-		new     v1beta2.StatefulSet
+		old     appsv1.StatefulSet
+		new     appsv1.StatefulSet
 		request admission.Request
 	)
 
 	BeforeEach(func() {
 		_, log = helper.NewTestLogger()
 		ctx = ctxlog.NewParentContext(log)
-		old = v1beta2.StatefulSet{
+		old = appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-statefulset",
 				Namespace: "test",
@@ -45,7 +45,7 @@ var _ = Describe("When the muatating webhook handles a statefulset", func() {
 					AnnotationCanaryRolloutEnabled: "true",
 				},
 			},
-			Spec: v1beta2.StatefulSetSpec{
+			Spec: appsv1.StatefulSetSpec{
 				Replicas: pointers.Int32(2),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{

--- a/pkg/kube/util/mutate/mutate.go
+++ b/pkg/kube/util/mutate/mutate.go
@@ -3,7 +3,7 @@ package mutate
 import (
 	"reflect"
 
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -42,7 +42,7 @@ func QuarksStatefulSetMutateFn(qSts *qstsv1a1.QuarksStatefulSet) controllerutil.
 // StatefulSetMutateFn returns MutateFn which mutates StatefulSet including:
 // - labels, annotations
 // - spec
-func StatefulSetMutateFn(sfs *appsv1beta2.StatefulSet) controllerutil.MutateFn {
+func StatefulSetMutateFn(sfs *appsv1.StatefulSet) controllerutil.MutateFn {
 	updated := sfs.DeepCopy()
 	return func() error {
 		sfs.Labels = updated.Labels

--- a/pkg/kube/util/mutate/mutate_test.go
+++ b/pkg/kube/util/mutate/mutate_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	appsv1 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -282,15 +282,15 @@ func (c *Catalog) DefaultCA(name string, ca credsgen.Certificate) corev1.Secret 
 }
 
 // DefaultStatefulSet for use in tests
-func (c *Catalog) DefaultStatefulSet(name string) v1beta2.StatefulSet {
-	return v1beta2.StatefulSet{
+func (c *Catalog) DefaultStatefulSet(name string) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
 				"testpod": "yes",
 			},
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointers.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -304,17 +304,17 @@ func (c *Catalog) DefaultStatefulSet(name string) v1beta2.StatefulSet {
 }
 
 // StatefulSetWithPVC for use in tests
-func (c *Catalog) StatefulSetWithPVC(name, pvcName string, storageClassName string) v1beta2.StatefulSet {
+func (c *Catalog) StatefulSetWithPVC(name, pvcName string, storageClassName string) appsv1.StatefulSet {
 	labels := map[string]string{
 		"test-run-reference": name,
 		"testpod":            "yes",
 	}
 
-	return v1beta2.StatefulSet{
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointers.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
@@ -327,17 +327,17 @@ func (c *Catalog) StatefulSetWithPVC(name, pvcName string, storageClassName stri
 }
 
 // WrongStatefulSetWithPVC for use in tests
-func (c *Catalog) WrongStatefulSetWithPVC(name, pvcName string, storageClassName string) v1beta2.StatefulSet {
+func (c *Catalog) WrongStatefulSetWithPVC(name, pvcName string, storageClassName string) appsv1.StatefulSet {
 	labels := map[string]string{
 		"wrongpod":           "yes",
 		"test-run-reference": name,
 	}
 
-	return v1beta2.StatefulSet{
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointers.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
@@ -398,15 +398,15 @@ func (c *Catalog) DefaultVolumeMount(name string) corev1.VolumeMount {
 }
 
 // WrongStatefulSet for use in tests
-func (c *Catalog) WrongStatefulSet(name string) v1beta2.StatefulSet {
-	return v1beta2.StatefulSet{
+func (c *Catalog) WrongStatefulSet(name string) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
 				statefulset.AnnotationCanaryWatchTime: "30000",
 			},
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointers.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -420,12 +420,12 @@ func (c *Catalog) WrongStatefulSet(name string) v1beta2.StatefulSet {
 }
 
 // OwnedReferencesStatefulSet for use in tests
-func (c *Catalog) OwnedReferencesStatefulSet(name string) v1beta2.StatefulSet {
-	return v1beta2.StatefulSet{
+func (c *Catalog) OwnedReferencesStatefulSet(name string) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: pointers.Int32(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{


### PR DESCRIPTION
Switch from `apps/v1beta2` to `apps/v1`, because `v1beta2` is deprecated since kubernetes 1.9
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps