### PR TITLE
Introduce active-passive controller

### DIFF
--- a/docs/controllers/quarks_statefulset.md
+++ b/docs/controllers/quarks_statefulset.md
@@ -194,7 +194,7 @@ If zones are set for an `QuarksStatefulSet`, the following occurs:
 
 Active/passive model is application model that have multiple running instances, but only one instance is active and all other instances are passive (standby). If the active instance is down, one of the passive instances will be promoted to active immediately.
 
-The `activeProbe` key defines active probe to be performed on a container. The controller examines the active probe periodically to see if the active one is still active. If active pod is down or there isn’t an active pod, the first running pod will be promoted as active and label it as `quarks.cloudfoundry.org/pod-designation: active`.
+The `activeProbe` key defines active probe to be performed on a container. The controller examines the active probe periodically to see if the active one is still active. If active pod is down or there isn’t an active pod, the first running pod will be promoted as active and label it as `quarks.cloudfoundry.org/pod-active: active`.
 
 ```yaml
 apiVersion: quarks.cloudfoundry.org/v1alpha1

--- a/docs/examples/quarks-statefulset/qstatefulset_active_passive.yaml
+++ b/docs/examples/quarks-statefulset/qstatefulset_active_passive.yaml
@@ -1,0 +1,31 @@
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksStatefulSet
+metadata:
+  name: example-quarks-statefulset
+spec:
+  updateOnConfigChange: true
+  activePassiveProbe:
+    busybox:
+      periodSeconds: 5
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - date
+  template:
+    metadata:
+      labels:
+        app: example-statefulset
+    spec:
+      replicas: 1
+      template:
+        metadata:
+          labels:
+            app: example-statefulset
+        spec:
+          containers:
+          - name: busybox
+            image: busybox
+            command:
+            - sleep
+            - "3600"

--- a/e2e/kube/examples_count_test.go
+++ b/e2e/kube/examples_count_test.go
@@ -19,6 +19,6 @@ var _ = Describe("Examples Directory Files", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		// If this testcase fails that means a test case is missing for an example in the docs folder
-		Expect(countFile).To(Equal(20))
+		Expect(countFile).To(Equal(21))
 	})
 })

--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -113,6 +113,23 @@ var _ = Describe("Examples Directory", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("it labels the first pod as active", func() {
+			yamlUpdatedFilePath := examplesDir + "quarks-statefulset/qstatefulset_active_passive.yaml"
+			By("Applying a quarkstatefulset with active-passive probe")
+			err := cmdHelper.Apply(namespace, yamlUpdatedFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = wait.PollImmediate(time.Second*5, time.Second*35, func() (bool, error) {
+				err := kubectl.WaitForPod(namespace, "quarks.cloudfoundry.org/pod-active", "example-quarks-statefulset-0")
+				if err != nil {
+					return false, err
+				}
+				return true, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
 	})
 
 	Context("bosh-deployment service example", func() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cppforlife/go-patch v0.0.0-20171006213518-250da0e0e68c
 	github.com/daaku/go.zipexe v1.0.1 // indirect
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
+	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/go-test/deep v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9 h1:74lLNRzvsdIlkTgfD
 github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9/go.mod h1:GgB8SF9nRG+GqaDtLcwJZsQFhcogVCJ79j4EdT0c2V4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
+github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=

--- a/integration/quarks_statefulset_active_passive_test.go
+++ b/integration/quarks_statefulset_active_passive_test.go
@@ -1,0 +1,335 @@
+package integration_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	qstsv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/quarksstatefulset/v1alpha1"
+	utils "code.cloudfoundry.org/quarks-utils/testing/integration"
+	"code.cloudfoundry.org/quarks-utils/testing/machine"
+	helper "code.cloudfoundry.org/quarks-utils/testing/testhelper"
+)
+
+var _ = Describe("QuarksStatefulSetActivePassive", func() {
+	var (
+		podNameByIndex = func(podName, index string) string {
+			return fmt.Sprintf("%s-%s", podName, index)
+		}
+		qStsName, podDesignationLabel, labelKey, eventReason, patchPath, patchValue, patchOp string
+	)
+
+	BeforeEach(func() {
+		// Values required to define a patch mechanism
+		patchPath = fmt.Sprintf("%s%s%s", "/metadata/labels/quarks.cloudfoundry.org", "~1", "pod-active")
+		patchValue = "true"
+		patchOp = "add"
+		eventReason = "active-passive"
+		qStsName = fmt.Sprintf("test-ap-qsts-%s", helper.RandString(5))
+		podDesignationLabel = "quarks.cloudfoundry.org/pod-active=active"
+		labelKey = "quarks.cloudfoundry.org/pod-active"
+	})
+
+	AfterEach(func() {
+		Expect(env.WaitForPodsDelete(env.Namespace)).To(Succeed())
+		// Skipping wait for PVCs to be deleted until the following is fixed
+		// https://www.pivotaltracker.com/story/show/166896791
+		// Expect(env.WaitForPVCsDelete(env.Namespace)).To(Succeed())
+	})
+
+	Context("when pod-active label is not present and probe passes", func() {
+		sleepCMD := []string{"/bin/sh", "-c", "sleep 2"}
+		It("should label a single pod out of one", func() {
+			By("Creating a QuarksStatefulSet with a valid CRD probe cmd")
+			var qSts *qstsv1a1.QuarksStatefulSet
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithProbeSinglePod(
+				qStsName,
+				sleepCMD,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Wait for pod with pod-active label to be ready")
+			err = env.WaitForPods(env.Namespace, podDesignationLabel)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod with index 0 to become active")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+	})
+
+	Context("when pod-active label is present in one pod and probe fails", func() {
+
+		cmdSleepTypo := []string{"/bin/sh", "-c", "sleeps 2"}
+
+		It("should ensure all pods are pasive", func() {
+			By("Creating a QuarksStatefulSet with pods that contain a wrong command")
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithProbeMultiplePods(
+				qStsName,
+				cmdSleepTypo,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Waiting for pod with index 2 to be ready")
+			// wait till pod with the highest index is ready
+			err = env.WaitForPodReady(env.Namespace, podNameByIndex(qStsName, "2"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the pod-active label to pod with index 0")
+			err = env.PatchPod(env.Namespace, podNameByIndex(qStsName, "0"), patchOp, patchPath, patchValue)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking that no pods are marked as active")
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-1", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-2", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when pod-active label is present in multiple pods and only one probe pass", func() {
+		// two set of cmds, one that runs as the CRD probe
+		// the second one, runs as a patch, so that the next CRD probe executiong will pass
+		cmdCatScript := []string{"/bin/sh", "-c", "cat /tmp/busybox-script.sh"}
+		cmdTouchScript := []string{"/bin/sh", "-c", "touch /tmp/busybox-script.sh"}
+		containerName := "busybox"
+
+		It("should ensure only one pod is active", func() {
+			By("Creating a QuarksStatefulSet with pods that contain a probe that will initially fail")
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithProbeMultiplePods(
+				qStsName,
+				cmdCatScript,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Waiting for all pods owned by the qsts to be ready")
+			// wait till pod with the highest index is ready
+			err = env.WaitForPodReady(env.Namespace, podNameByIndex(qStsName, "2"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Adding the pod-active label to all pods")
+			err = env.PatchPod(env.Namespace, podNameByIndex(qStsName, "0"), patchOp, patchPath, patchValue)
+			Expect(err).NotTo(HaveOccurred())
+			err = env.PatchPod(env.Namespace, podNameByIndex(qStsName, "1"), patchOp, patchPath, patchValue)
+			Expect(err).NotTo(HaveOccurred())
+			err = env.PatchPod(env.Namespace, podNameByIndex(qStsName, "2"), patchOp, patchPath, patchValue)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Executing in pod with index 1 a cmd to force the probe to pass")
+			kubeConfig, err := utils.KubeConfig()
+			Expect(err).NotTo(HaveOccurred())
+			kclient, err := kubernetes.NewForConfig(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			p, err := env.GetPod(env.Namespace, fmt.Sprintf("%s-1", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+
+			ec, err := env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				cmdTouchScript,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			By("Checking for a single active pod")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-1", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking for other pods to be passive")
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-2", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when active passive pod fails a new one becomes active", func() {
+		cmdCatScript := []string{"/bin/sh", "-c", "cat /tmp/busybox-script.sh"}
+		cmdTouchScript := []string{"/bin/sh", "-c", "touch /tmp/busybox-script.sh"}
+		containerName := "busybox"
+		It("Creating a QuarksStatefulSet", func() {
+			By("Defining a probe cmd that will fail")
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithProbeMultiplePods(
+				qStsName,
+				cmdCatScript,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Waiting for all pods owned by the qsts to be ready")
+			// wait till pod with the highest index is ready
+			err = env.WaitForPodReady(env.Namespace, podNameByIndex(qStsName, "2"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Executing a cmd in pod index 0 to make the probe successful")
+			kubeConfig, err := utils.KubeConfig()
+			Expect(err).NotTo(HaveOccurred())
+			kclient, err := kubernetes.NewForConfig(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			p, err := env.GetPod(env.Namespace, fmt.Sprintf("%s-0", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+			ec, err := env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				cmdTouchScript,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			By("Waiting for pod with index 0 to have the label")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Excuting a cmd to make the active pod fail its probe")
+			p, err = env.GetPod(env.Namespace, fmt.Sprintf("%s-0", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+			ec, err = env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				[]string{"/bin/sh", "-c", "rm /tmp/busybox-script.sh"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			By("Waiting for pod with index 0 to lose the label")
+			err = env.WaitForPodLabelToNotExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Executing a cmd in another pod to make the probe successful")
+			p, err = env.GetPod(env.Namespace, fmt.Sprintf("%s-1", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+			ec, err = env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				cmdTouchScript,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			// By("Wait for pods with pod-active label to be ready")
+			// err = env.WaitForPods(env.Namespace, podDesignationLabel)
+			// Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod with index 1 to have the label")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-1", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+	})
+
+	Context("when multiple pods pass the probe multiple remain active", func() {
+		cmdCatScript := []string{"/bin/sh", "-c", "cat /tmp/busybox-script.sh"}
+		cmdTouchScript := []string{"/bin/sh", "-c", "touch /tmp/busybox-script.sh"}
+		containerName := "busybox"
+		It("Creating a QuarksStatefulSet", func() {
+			By("Defining a probe cmd that will fail")
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithProbeMultiplePods(
+				qStsName,
+				cmdCatScript,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Waiting for all pods owned by the qsts to be ready")
+			// wait till pod with the highest index is ready
+			err = env.WaitForPodReady(env.Namespace, podNameByIndex(qStsName, "2"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Executing a cmd in pod index 0 to make the probe successful")
+			kubeConfig, err := utils.KubeConfig()
+			Expect(err).NotTo(HaveOccurred())
+			kclient, err := kubernetes.NewForConfig(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			p, err := env.GetPod(env.Namespace, fmt.Sprintf("%s-0", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+			ec, err := env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				cmdTouchScript,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			By("Executing a cmd in pod index 1 to make the probe successful")
+			kubeConfig, err = utils.KubeConfig()
+			Expect(err).NotTo(HaveOccurred())
+			kclient, err = kubernetes.NewForConfig(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			p, err = env.GetPod(env.Namespace, fmt.Sprintf("%s-1", qStsName))
+			Expect(err).NotTo(HaveOccurred())
+			ec, err = env.ExecPodCMD(
+				kclient,
+				kubeConfig,
+				p,
+				containerName,
+				cmdTouchScript,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ec).To(Equal(true))
+
+			By("Waiting for pod with index 0 to have the label")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-0", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for pod with index 1 to have the label")
+			err = env.WaitForPodLabelToExist(env.Namespace, fmt.Sprintf("%s-1", qStsName), labelKey)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+	})
+
+	Context("when CRD does not specify a probe periodSeconds", func() {
+		cmdDate := []string{"/bin/sh", "-c", "date"}
+		It("should ensure the proper event takes place", func() {
+			By("Creating a QuarksStatefulSet with pods that contain a probe that will initially fail")
+			qSts, tearDown, err := env.CreateQuarksStatefulSet(env.Namespace, env.QstsWithoutProbeMultiplePods(
+				qStsName,
+				cmdDate,
+			))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qSts).NotTo(Equal(nil))
+			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+			By("Checking events to match the default periodSeconds")
+			objectName := qSts.ObjectMeta.Name
+			objectUID := string(qSts.ObjectMeta.UID)
+			err = wait.PollImmediate(5*time.Second, 35*time.Second, func() (bool, error) {
+				return env.GetNamespaceEvents(env.Namespace,
+					objectName,
+					objectUID,
+					eventReason,
+					"periodSeconds probe was not specified, going to default to 30 secs",
+				)
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/client-go/rest"
-
+	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/rest"
 
 	"code.cloudfoundry.org/cf-operator/integration/environment"
-	cmdHelper "code.cloudfoundry.org/quarks-utils/testing"
 	utils "code.cloudfoundry.org/quarks-utils/testing/integration"
 )
 

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/register.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/register.go
@@ -46,6 +46,10 @@ var (
 							Type:        "boolean",
 							Description: "Indicate whether to update Pods in the StatefulSet when an env value or mount changes",
 						},
+						"activePassiveProbe": {
+							Type:        "object",
+							Description: "Defines a probe to determine an active/passive component instance",
+						},
 						"zoneNodeLabel": {
 							Type:        "string",
 							Description: "Indicates the node label that a node locates",

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"code.cloudfoundry.org/cf-operator/pkg/kube/apis"
@@ -29,6 +30,8 @@ var (
 	LabelPodOrdinal = fmt.Sprintf("%s/pod-ordinal", apis.GroupName)
 	// LabelQStsName is the name of the QuarksStatefulSet owns this resource
 	LabelQStsName = fmt.Sprintf("%s/quarks-statefulset-name", apis.GroupName)
+	// LabelActiveContainer is the active container on an active/passive setup
+	LabelActiveContainer = fmt.Sprintf("%s/pod-active", apis.GroupName)
 )
 
 // QuarksStatefulSetSpec defines the desired state of QuarksStatefulSet
@@ -44,6 +47,10 @@ type QuarksStatefulSetSpec struct {
 
 	// Defines a regular StatefulSet template
 	Template appsv1.StatefulSet `json:"template"`
+
+	// Periodic probe for active/passive containers
+	// Only an active container will process request from a service
+	ActivePassiveProbe map[string]*corev1.Probe `json:"activePassiveProbe,omitempty"`
 }
 
 // QuarksStatefulSetStatus defines the observed state of QuarksStatefulSet

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@ Don't alter this file, it was generated.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -83,6 +84,21 @@ func (in *QuarksStatefulSetSpec) DeepCopyInto(out *QuarksStatefulSetSpec) {
 		copy(*out, *in)
 	}
 	in.Template.DeepCopyInto(&out.Template)
+	if in.ActivePassiveProbe != nil {
+		in, out := &in.ActivePassiveProbe, &out.ActivePassiveProbe
+		*out = make(map[string]*v1.Probe, len(*in))
+		for key, val := range *in {
+			var outVal *v1.Probe
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(v1.Probe)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/kube/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/kube/client/clientset/versioned/fake/clientset_generated.go
@@ -34,7 +34,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	cs := &Clientset{tracker: o}
+	cs := &Clientset{}
 	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
@@ -56,15 +56,10 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 type Clientset struct {
 	testing.Fake
 	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 	return c.discovery
-}
-
-func (c *Clientset) Tracker() testing.ObjectTracker {
-	return c.tracker
 }
 
 var _ clientset.Interface = &Clientset{}

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -50,6 +50,7 @@ var addToManagerFuncs = []func(context.Context, *config.Config, manager.Manager)
 	quarkssecret.AddCertificateSigningRequest,
 	quarksstatefulset.AddQuarksStatefulSet,
 	statefulset.AddStatefulSetRollout,
+	quarksstatefulset.AddStatefulSetActivePassive,
 }
 
 var addToSchemes = runtime.SchemeBuilder{

--- a/pkg/kube/controllers/quarksstatefulset/active_passive_controller.go
+++ b/pkg/kube/controllers/quarksstatefulset/active_passive_controller.go
@@ -1,0 +1,82 @@
+package quarksstatefulset
+
+import (
+	"context"
+	"fmt"
+
+	qstsv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/quarksstatefulset/v1alpha1"
+	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// AddStatefulSetActivePassive creates a new QuarksStatefulSet controller that watches multiple instances
+// of a specific resource, and decides which is active and which is passive
+func AddStatefulSetActivePassive(ctx context.Context, config *config.Config, mgr manager.Manager) error {
+	ctx = ctxlog.NewContextWithRecorder(ctx, "active-passive-reconciler", mgr.GetEventRecorderFor("quarks-active-passive-recorder"))
+	kubeConfig, _ := KubeConfig()
+
+	kclient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed retrieving kubernetes client configuration")
+	}
+
+	r := NewActivePassiveReconciler(ctx, config, mgr, kclient)
+
+	// Create new controller
+	c, err := controller.New("active-passive-controller", mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: config.MaxQuarksStatefulSetWorkers,
+	})
+	if err != nil {
+		return errors.Wrap(err, "adding active-passive controller to manager failed")
+	}
+
+	stsPredicates := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			qo, ok := e.Object.(*qstsv1a1.QuarksStatefulSet)
+			if !ok {
+				return false
+			}
+			activePassiveCmd := qo.Spec.ActivePassiveProbe
+			if activePassiveCmd != nil {
+				ctxlog.NewPredicateEvent(e.Object).Debug(
+					ctx, e.Meta, "qstsv1a1.QuarksStatefulSet",
+					fmt.Sprintf("Create predicate passed for active-passive '%s'", e.Meta.GetName()),
+				)
+				return true
+			}
+			return false
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newStatefulSet := e.ObjectNew.(*qstsv1a1.QuarksStatefulSet)
+
+			activePassiveCmd := newStatefulSet.Spec.ActivePassiveProbe
+			if activePassiveCmd != nil {
+				ctxlog.NewPredicateEvent(e.ObjectNew).Debug(
+					ctx, e.MetaNew, "qstsv1a1.QuarksStatefulSet",
+					fmt.Sprintf("Create predicate passed for active-passive '%s'", e.MetaNew.GetName()),
+				)
+				return true
+			}
+			return false
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &qstsv1a1.QuarksStatefulSet{}},
+		&handler.EnqueueRequestForObject{},
+		stsPredicates)
+	if err != nil {
+		return errors.Wrapf(err, "watching QuarksStatefulSet failed in active/passive controller")
+	}
+
+	return nil
+}

--- a/pkg/kube/controllers/quarksstatefulset/active_passive_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/active_passive_reconciler.go
@@ -1,0 +1,249 @@
+package quarksstatefulset
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	qstsv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/quarksstatefulset/v1alpha1"
+	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
+	podutil "code.cloudfoundry.org/quarks-utils/pkg/pod"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	crc "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewActivePassiveReconciler returns a new reconcile.Reconciler for the active/passive controller
+func NewActivePassiveReconciler(ctx context.Context, config *config.Config, mgr manager.Manager, kclient kubernetes.Interface) reconcile.Reconciler {
+	return &ReconcileStatefulSetActivePassive{
+		ctx:        ctx,
+		config:     config,
+		client:     mgr.GetClient(),
+		kclient:    kclient,
+		scheme:     mgr.GetScheme(),
+		restConfig: mgr.GetConfig(),
+	}
+}
+
+// ReconcileStatefulSetActivePassive reconciles an QuarksStatefulSet object when references change
+type ReconcileStatefulSetActivePassive struct {
+	ctx        context.Context
+	client     crc.Client
+	kclient    kubernetes.Interface
+	scheme     *runtime.Scheme
+	config     *config.Config
+	restConfig *restclient.Config
+}
+
+// Reconcile reads the state of the cluster for a QuarksStatefulSet object
+// and makes changes based on the state read and what is in the QuarksStatefulSet.Spec
+// Note:
+// The Reconcile Loop will always requeue the request stop before under completition. For this specific
+// loop, the requeue will happen after the ActivePassiveProbe PeriodSeconds is reached.
+func (r *ReconcileStatefulSetActivePassive) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	qSts := &qstsv1a1.QuarksStatefulSet{}
+
+	// Set the ctx to be Background, as the top-level context for incoming requests.
+	ctx, cancel := context.WithTimeout(r.ctx, r.config.CtxTimeOut)
+	defer cancel()
+
+	ctxlog.Info(ctx, "Reconciling for active/passive QuarksStatefulSet", request.NamespacedName)
+
+	if err := r.client.Get(ctx, request.NamespacedName, qSts); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Reconcile successful - don't requeue
+			ctxlog.Infof(ctx, "Failed to find quarks statefulset '%s', not retrying: %s", request.NamespacedName, err)
+			return reconcile.Result{}, nil
+		}
+		// Reconcile failed due to error - requeue
+		ctxlog.Errorf(ctx, "Failed to get quarks statefulset '%s': %s", request.NamespacedName, err)
+		return reconcile.Result{}, err
+	}
+
+	statefulSets, _, err := GetMaxStatefulSetVersion(ctx, r.client, qSts)
+	if err != nil {
+		// Reconcile failed due to error - requeue
+		return reconcile.Result{}, errors.Wrapf(err, "couldn't list StatefulSets for active/passive reconciliation")
+	}
+
+	ownedPods, err := r.getStsPodList(ctx, statefulSets)
+	if err != nil {
+		// Reconcile failed due to error - requeue
+		return reconcile.Result{}, errors.Wrapf(err, "couldn't retrieve pod items from sts: %s", qSts.Name)
+	}
+
+	// retrieves the ActivePassiveProbe children key,
+	// this is the container name in where the ActivePassiveProbe
+	// cmd, needs to be executed
+	containerName, err := getProbeContainerName(qSts.Spec.ActivePassiveProbe)
+	if err != nil {
+		// Reconcile failed due to error - requeue
+		return reconcile.Result{}, errors.Wrapf(err, "None container name found in probe for %s QuarksStatefulSet", qSts.Name)
+	}
+
+	err = r.markActiveContainers(ctx, containerName, ownedPods, qSts)
+	if err != nil {
+		// Reconcile failed due to error - requeue
+		return reconcile.Result{}, err
+	}
+
+	periodSeconds := time.Second * time.Duration(qSts.Spec.ActivePassiveProbe[containerName].PeriodSeconds)
+	if periodSeconds == (time.Second * time.Duration(0)) {
+		ctxlog.WithEvent(qSts, "active-passive").Debugf(ctx, "periodSeconds probe was not specified, going to default to 30 secs")
+		periodSeconds = time.Second * 30
+	}
+
+	// Reconcile for any reason than error after the ActivePassiveProbe PeriodSeconds
+	return reconcile.Result{RequeueAfter: periodSeconds}, nil
+}
+
+func (r *ReconcileStatefulSetActivePassive) markActiveContainers(ctx context.Context, container string, pods *corev1.PodList, qSts *qstsv1a1.QuarksStatefulSet) (err error) {
+
+	probeCmd := qSts.Spec.ActivePassiveProbe[container].Exec.Command
+
+	for _, pod := range pods.Items {
+		ctxlog.WithEvent(qSts, "active-passive").Debugf(ctx, "validating probe in pod: %s", pod.Name)
+		if err := r.execContainerCmd(&pod, container, probeCmd); err != nil {
+			ctxlog.WithEvent(qSts, "active-passive").Debugf(
+				ctx,
+				"failed to execute active/passive probe: %s",
+				err,
+			)
+			// mark as passive
+			err := r.deleteActiveLabel(ctx, &pod, qSts)
+			if err != nil {
+				return errors.Wrapf(err, "couldn't remove label from active pod %s", pod.Name)
+			}
+		} else {
+			if podutil.IsPodReady(&pod) {
+				// mark as active
+				err := r.addActiveLabel(ctx, &pod, qSts)
+				if err != nil {
+					return errors.Wrapf(err, "couldn't label pod %s as active", pod.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileStatefulSetActivePassive) addActiveLabel(ctx context.Context, p *corev1.Pod, qSts *qstsv1a1.QuarksStatefulSet) error {
+	podLabels := p.GetLabels()
+	if podLabels == nil {
+		podLabels = map[string]string{}
+	}
+
+	if _, found := podLabels[qstsv1a1.LabelActiveContainer]; found {
+		return nil
+	}
+
+	podLabels[qstsv1a1.LabelActiveContainer] = "active"
+
+	return r.updatePodLabels(ctx, p, qSts, "active")
+}
+
+func (r *ReconcileStatefulSetActivePassive) deleteActiveLabel(ctx context.Context, p *corev1.Pod, qSts *qstsv1a1.QuarksStatefulSet) error {
+	podLabels := p.GetLabels()
+
+	if _, found := podLabels[qstsv1a1.LabelActiveContainer]; !found {
+		return nil
+	}
+	delete(podLabels, qstsv1a1.LabelActiveContainer)
+
+	return r.updatePodLabels(ctx, p, qSts, "passive")
+}
+
+func (r *ReconcileStatefulSetActivePassive) updatePodLabels(ctx context.Context, p *corev1.Pod, qSts *qstsv1a1.QuarksStatefulSet, mode string) error {
+	err := r.client.Update(r.ctx, p)
+	if err != nil {
+		return err
+	}
+
+	ctxlog.WithEvent(qSts, "active-passive").Debugf(
+		ctx,
+		"pod %s promoted to %s",
+		p.Name,
+		mode,
+	)
+	return nil
+}
+
+func (r *ReconcileStatefulSetActivePassive) execContainerCmd(pod *corev1.Pod, container string, command []string) error {
+	req := r.kclient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    false,
+		}, clientscheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(r.restConfig, "POST", req.URL())
+	if err != nil {
+		return errors.New("failed to initialize remote command executor")
+	}
+	if err = executor.Stream(remotecommand.StreamOptions{Stdin: os.Stdin, Stdout: os.Stdout, Tty: false}); err != nil {
+		return errors.Wrapf(err, "failed executing command in pod: %s, container: %s in namespace: %s",
+			pod.Name,
+			container,
+			pod.Namespace,
+		)
+	}
+	ctxlog.Info(r.ctx, "Succesfully exec cmd in container: ", container, ", inside pod: ", pod.Name)
+
+	return nil
+}
+
+func (r *ReconcileStatefulSetActivePassive) getStsPodList(ctx context.Context, desiredSts *appsv1.StatefulSet) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	err := r.client.List(ctx,
+		podList,
+		crc.InNamespace(desiredSts.Namespace),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return podList, nil
+}
+
+func getProbeContainerName(p map[string]*corev1.Probe) (string, error) {
+	for key := range p {
+		return key, nil
+	}
+	return "", errors.New("failed to find a container key in the active/passive probe in the current QuarksStatefulSet")
+}
+
+// KubeConfig returns a kube config for this environment
+func KubeConfig() (*rest.Config, error) {
+	location := os.Getenv("KUBECONFIG")
+	if location == "" {
+		location = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", location)
+	if err != nil {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return config, nil
+}

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_controller.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_controller.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -339,6 +339,50 @@ func (c *Catalog) DefaultStatefulSet(name string) appsv1.StatefulSet {
 	}
 }
 
+// DefaultStatefulSetWithActiveSinglePod for use in tests
+func (c *Catalog) DefaultStatefulSetWithActiveSinglePod(name string) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"testpod": "yes",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointers.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"testpod": "yes",
+				},
+			},
+			ServiceName: name,
+			Template:    c.DefaultPodTemplateWithActiveLabel(name),
+		},
+	}
+}
+
+// DefaultStatefulSetWithReplicasN for use in tests
+func (c *Catalog) DefaultStatefulSetWithReplicasN(name string) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"testpod": "yes",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointers.Int32(3),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"testpod": "yes",
+				},
+			},
+			ServiceName: name,
+			Template:    c.DefaultPodTemplate(name),
+		},
+	}
+}
+
 // StatefulSetWithPVC for use in tests
 func (c *Catalog) StatefulSetWithPVC(name, pvcName string, storageClassName string) appsv1.StatefulSet {
 	labels := map[string]string{
@@ -526,6 +570,20 @@ func (c *Catalog) DefaultPodTemplate(name string) corev1.PodTemplateSpec {
 			Name: name,
 			Labels: map[string]string{
 				"testpod": "yes",
+			},
+		},
+		Spec: c.Sleep1hPodSpec(),
+	}
+}
+
+// DefaultPodTemplateWithActiveLabel defines a pod template with a simple web server useful for testing
+func (c *Catalog) DefaultPodTemplateWithActiveLabel(name string) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"testpod":                            "yes",
+				"quarks.cloudfoundry.org/pod-active": "active",
 			},
 		},
 		Spec: c.Sleep1hPodSpec(),

--- a/testing/catalog_qstsv1.go
+++ b/testing/catalog_qstsv1.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	qstsv1a1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/quarksstatefulset/v1alpha1"
@@ -14,6 +15,89 @@ func (c *Catalog) DefaultQuarksStatefulSet(name string) qstsv1a1.QuarksStatefulS
 		},
 		Spec: qstsv1a1.QuarksStatefulSetSpec{
 			Template: c.DefaultStatefulSet(name),
+		},
+	}
+}
+
+// QstsWithProbeSinglePod for use in tests
+func (c *Catalog) QstsWithProbeSinglePod(name string, cmd []string) qstsv1a1.QuarksStatefulSet {
+	return qstsv1a1.QuarksStatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qstsv1a1.QuarksStatefulSetSpec{
+			Template: c.DefaultStatefulSet(name),
+			ActivePassiveProbe: map[string]*v1.Probe{
+				"busybox": &v1.Probe{
+					PeriodSeconds: 2,
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							Command: cmd,
+						},
+					},
+				}},
+		},
+	}
+}
+
+// QstsWithActiveSinglePod for use in tests
+func (c *Catalog) QstsWithActiveSinglePod(name string, cmd []string) qstsv1a1.QuarksStatefulSet {
+	return qstsv1a1.QuarksStatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qstsv1a1.QuarksStatefulSetSpec{
+			Template: c.DefaultStatefulSetWithActiveSinglePod(name),
+			ActivePassiveProbe: map[string]*v1.Probe{
+				"busybox": &v1.Probe{
+					PeriodSeconds: 2,
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							Command: cmd,
+						},
+					},
+				}},
+		},
+	}
+}
+
+// QstsWithoutProbeMultiplePods for use in tests
+func (c *Catalog) QstsWithoutProbeMultiplePods(name string, cmd []string) qstsv1a1.QuarksStatefulSet {
+	return qstsv1a1.QuarksStatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qstsv1a1.QuarksStatefulSetSpec{
+			Template: c.DefaultStatefulSetWithReplicasN(name),
+			ActivePassiveProbe: map[string]*v1.Probe{
+				"busybox": &v1.Probe{
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							Command: cmd,
+						},
+					},
+				}},
+		},
+	}
+}
+
+// QstsWithProbeMultiplePods for use in tests
+func (c *Catalog) QstsWithProbeMultiplePods(name string, cmd []string) qstsv1a1.QuarksStatefulSet {
+	return qstsv1a1.QuarksStatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qstsv1a1.QuarksStatefulSetSpec{
+			Template: c.DefaultStatefulSetWithReplicasN(name),
+			ActivePassiveProbe: map[string]*v1.Probe{
+				"busybox": &v1.Probe{
+					PeriodSeconds: 2,
+					Handler: v1.Handler{
+						Exec: &v1.ExecAction{
+							Command: cmd,
+						},
+					},
+				}},
 		},
 	}
 }


### PR DESCRIPTION
[#169117521](https://www.pivotaltracker.com/story/show/169117521)
This controller reconciles on events from Quarksstatefulsets instances

The main logic around this controller is that it will execute a probe
based on a container name per pod. When the probe cmd executions succeeds,
it will label the pod with a `pod-designation` key, with a `true` value.

For pods, where the probe fails, if the label exists, it will be removed.

This PR contains the following:

- Adds a new controller to the Manager
- Adds a new active-passive controller under the `kube/controllers/quarkstatefulset` dir
- Adds a new active-passive reconciler for the above controller.
- Updates quarksstatefulset types
  - Introduces a new field call `ActivePassiveProbe`, which holds a value of the type
    `map[string]*corev1.Probe`, which basically reuses the existing k8s Probe functionality
  - The Probe `PeriodSeconds` field, will determine how often the active-passive controller
    will be reconciling.
- Update quarksstatefulset generated fake files
  - Due to new field for the CRD struct
- Adds only integration tests for this controller
  - New set of supportive funcs for the Machine interface
    This includes:
      - logic for events lookup
      - pod cmd execution in containers
      - ability to patch pods
  - added a new `quarks_statefulset_active_passive_test.go`
    - holds different scenarios to validate the crd behaviour.
- Adds a new sample document, with a ActivePassive Probe