### PR TITLE
Separate watch namespace for e2e tests

### DIFF
--- a/e2e/kube/bosh_deployment_test.go
+++ b/e2e/kube/bosh_deployment_test.go
@@ -31,7 +31,7 @@ var _ = Describe("BOSHDeployment", func() {
 			status, err := kubectl.PodStatus(namespace, "nats-deployment-nats-0")
 			Expect(err).ToNot(HaveOccurred(), "error getting pod start time")
 			startTime := status.StartTime
-			err = testing.RestartOperator(namespace)
+			err = testing.RestartOperator(operatorNamespace)
 			Expect(err).ToNot(HaveOccurred(), "error restarting cf-operator")
 
 			By("Checking for pod not restarted")

--- a/e2e/kube/storage/suite_test.go
+++ b/e2e/kube/storage/suite_test.go
@@ -18,8 +18,9 @@ func TestKubeStorage(t *testing.T) {
 }
 
 var (
-	nsTeardown e2ehelper.TearDownFunc
-	namespace  string
+	nsTeardown        e2ehelper.TearDownFunc
+	namespace         string
+	operatorNamespace string
 )
 
 var _ = BeforeEach(func() {
@@ -30,7 +31,7 @@ var _ = BeforeEach(func() {
 		log.Fatal(err)
 	}
 	chartPath := fmt.Sprintf("%s%s", dir, "/../../../helm/cf-operator")
-	namespace, nsTeardown, err = e2ehelper.SetUpEnvironment(chartPath)
+	namespace, operatorNamespace, nsTeardown, err = e2ehelper.SetUpEnvironment(chartPath)
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/e2e/kube/suite_test.go
+++ b/e2e/kube/suite_test.go
@@ -16,10 +16,11 @@ import (
 const examplesDir = "../../docs/examples/"
 
 var (
-	nsIndex   int
-	teardown  e2ehelper.TearDownFunc
-	namespace string
-	kubectl   *cmdHelper.Kubectl
+	nsIndex           int
+	teardown          e2ehelper.TearDownFunc
+	namespace         string
+	operatorNamespace string
+	kubectl           *cmdHelper.Kubectl
 )
 
 func FailAndCollectDebugInfo(description string, callerSkip ...int) {
@@ -47,7 +48,7 @@ var _ = BeforeEach(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	chartPath := fmt.Sprintf("%s%s", dir, "/../../helm/cf-operator")
-	namespace, teardown, err = e2ehelper.SetUpEnvironment(chartPath)
+	namespace, operatorNamespace, teardown, err = e2ehelper.SetUpEnvironment(chartPath)
 	Expect(err).ToNot(HaveOccurred())
 })
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.cloudfoundry.org/cf-operator
 
 require (
 	code.cloudfoundry.org/quarks-job v0.0.0-20191129095316-23b0d08e8376
-	code.cloudfoundry.org/quarks-utils v0.0.0-20191213222420-ca6f0a8579ed
+	code.cloudfoundry.org/quarks-utils v0.0.0-20191218072851-52c9a8ec8c73
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,13 @@ code.cloudfoundry.org/quarks-utils v0.0.0-20191213123347-7c0af90bcff2 h1:yb7/8/+
 code.cloudfoundry.org/quarks-utils v0.0.0-20191213123347-7c0af90bcff2/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191213222420-ca6f0a8579ed h1:w+sjnsq+UJF66a4tk6qr75VFo0fJ1XhE72o6S99udUs=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191213222420-ca6f0a8579ed/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191216233028-07a007dc152d/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191217203758-018a2054c12b h1:L7oB+25vF0TpCxDsTOAO5z4JfcD2lIFeclrhCsI5zdU=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191217203758-018a2054c12b/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191217212716-58a4ca7cfb86 h1:sgJdv9MK2bcUeizE8+HICzOyFdufv+3jktz2/JOkpVM=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191217212716-58a4ca7cfb86/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191218072851-52c9a8ec8c73 h1:k6ben/E7vGXoVCFRu+GDZ+scgO/PLxZGzVqgEtDo30c=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191218072851-52c9a8ec8c73/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=


### PR DESCRIPTION
This bump will cause e2e tests to use different namespaces for the operator and the watched namespace

[#170013570](https://www.pivotaltracker.com/story/show/170013570)