### PR TITLE
Update on 'quarks.ports' change

### DIFF
--- a/integration/environment/service.go
+++ b/integration/environment/service.go
@@ -1,0 +1,26 @@
+package environment
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	bdm "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
+)
+
+// WaitForServiceVersion blocks until the service of the instance group is created/updated. It fails after the timeout.
+func (m *Machine) WaitForServiceVersion(namespace string, serviceName string, version string) error {
+	return wait.PollImmediate(m.PollInterval, m.PollTimeout, func() (bool, error) {
+		svc, err := m.Clientset.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to get service '%s'", svc)
+		}
+
+		deploymentVersion, ok := svc.Labels[bdm.LabelDeploymentVersion]
+		if ok && deploymentVersion == version {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/pkg/bosh/bpm/config.go
+++ b/pkg/bosh/bpm/config.go
@@ -52,9 +52,17 @@ type Process struct {
 	Unsafe            Unsafe              `yaml:"unsafe,omitempty" json:"unsafe,omitempty"`
 }
 
+// Port represents the port to be opened up for this job only for tracing changes.
+type Port struct {
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
+	Internal int    `json:"internal"`
+}
+
 // Config represent a BPM configuration
 type Config struct {
 	Processes           []Process `yaml:"processes,omitempty" json:"processes,omitempty"`
+	Ports               []Port    `yaml:"ports,omitempty" json:"ports,omitempty"`
 	UnsupportedTemplate bool      `json:"unsupported_template"`
 }
 

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -436,6 +436,13 @@ func (igr *InstanceGroupResolver) renderJobBPM(currentJob *Job, jobSpecFile stri
 			renderedBPM.Processes[i].UpdateEnv(currentJob.Properties.Quarks.Envs)
 		}
 
+		// Add ports to BPM config
+		ports := []bpm.Port{}
+		for _, port := range currentJob.Properties.Quarks.Ports {
+			ports = append(ports, bpm.Port(port))
+		}
+		renderedBPM.Ports = ports
+
 		jobIndexBPM[i] = renderedBPM
 	}
 

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -3,12 +3,12 @@ package manifest_test
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/go-test/deep"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 
+	bpmConfig "code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/converter"
 	. "code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	"code.cloudfoundry.org/cf-operator/testing"
@@ -116,6 +116,12 @@ var _ = Describe("InstanceGroupResolver", func() {
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNAME"]).To(Equal("log-api-loggregator_trafficcontroller"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNETWORKS"]).To(Equal(""))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECADDRESS"]).To(Equal("cf-log-api-0"))
+
+				Expect(bpm.Ports).To(ContainElement(bpmConfig.Port{
+					Name:     "outgoing_dropsonde_port",
+					Protocol: "TCP",
+					Internal: 8081,
+				}))
 			})
 
 			Context("when manifest presets overridden bpm info", func() {

--- a/testing/boshmanifest/manifests_unit_only.go
+++ b/testing/boshmanifest/manifests_unit_only.go
@@ -447,6 +447,11 @@ instance_groups:
         tls_port: 9023
         mutual_tls:
           ca_cert: "((service_cf_internal_ca.certificate))"
+      quarks:
+        ports:
+        - name: "outgoing_dropsonde_port"
+          protocol: "TCP"
+          internal: 8081
 releases:
 - name: loggregator
   url: https://bosh.io/d/github.com/cloudfoundry/loggregator-release?v=105.0


### PR DESCRIPTION
fixes #734

When we updated ports:

https://github.com/cloudfoundry-incubator/cf-operator/blob/0442d7a67216d6f807533f8a586819787fdbb2b3/integration/deploy_test.go#L37-L42

We will see kube services updated on this change:

```
kubectl get svc -n test1576736164-101 -w
NAME          TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
test-nats     ClusterIP   None             <none>        4222/TCP,4223/TCP   23s
test-nats-0   ClusterIP   10.98.61.225     <none>        4222/TCP,4223/TCP   23s
test-nats-1   ClusterIP   10.109.167.100   <none>        4222/TCP,4223/TCP   23s
test-nats-0   ClusterIP   10.98.61.225     <none>        4222/TCP,4223/TCP,6443/TCP   25s
test-nats-1   ClusterIP   10.109.167.100   <none>        4222/TCP,4223/TCP,6443/TCP   25s
test-nats     ClusterIP   None             <none>        4222/TCP,4223/TCP,6443/TCP   25s
test-nats     ClusterIP   None             <none>        4222/TCP,4223/TCP,6443/TCP   25s
test-nats-0   ClusterIP   10.98.61.225     <none>        4222/TCP,4223/TCP,6443/TCP   25s
test-nats-1   ClusterIP   10.109.167.100   <none>        4222/TCP,4223/TCP,6443/TCP   25s
```
