### PR TITLE
Add .Release.Namespace to helm templates

### DIFF
--- a/deploy/helm/cf-operator/templates/operator.yaml
+++ b/deploy/helm/cf-operator/templates/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cf-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/deploy/helm/cf-operator/templates/role.yaml
+++ b/deploy/helm/cf-operator/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: cf-operator
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""

--- a/deploy/helm/cf-operator/templates/role_binding.yaml
+++ b/deploy/helm/cf-operator/templates/role_binding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cf-operator
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: cf-operator

--- a/deploy/helm/cf-operator/templates/service.yaml
+++ b/deploy/helm/cf-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cf-operator-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if or .Values.global.operator.webhook.useServiceReference (not .Values.operator.webhook.endpoint) }}
   selector:

--- a/deploy/helm/cf-operator/templates/service_account.yaml
+++ b/deploy/helm/cf-operator/templates/service_account.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cf-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.global.image.credentials }}
 imagePullSecrets:
 - name: {{ template "cf-operator.serviceAccountName" . }}-pull-secret

--- a/deploy/helm/cf-operator/templates/service_account_pull_secret.yaml
+++ b/deploy/helm/cf-operator/templates/service_account_pull_secret.yaml
@@ -5,6 +5,7 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ template "cf-operator.serviceAccountName" . }}-pull-secret
+  namespace: {{ .Release.Namespace }}
 data:
   .dockerconfigjson: {{ printf "{%q:{%q:{%q:%q,%q:%q,%q:%q}}}" "auths" .Values.global.image.credentials.servername "username" .Values.global.image.credentials.username "password" .Values.global.image.credentials.password "auth" (printf "%s:%s" .Values.global.image.credentials.username .Values.global.image.credentials.password | b64enc) | b64enc }}
 {{- end }}


### PR DESCRIPTION
Adds explicit namespaces to all resources so we can use
`helm template --namespace ns [...] | kubectl apply -f -`.

Part of fixing https://github.com/cloudfoundry-incubator/cf-operator/issues/763.