### PR TITLE
Increase meltdown duration to 1 minute

### DIFF
--- a/e2e/kube/examples_test.go
+++ b/e2e/kube/examples_test.go
@@ -22,8 +22,10 @@ var _ = Describe("Examples Directory", func() {
 		yamlFilePath string
 	)
 
+	const pollInterval = 5 * time.Second
+
 	podRestarted := func(podName string, startTime time.Time) {
-		wait.PollImmediate(1*time.Second, kubectl.PollTimeout, func() (bool, error) {
+		wait.PollImmediate(pollInterval, kubectl.PollTimeout, func() (bool, error) {
 			status, err := kubectl.PodStatus(namespace, podName)
 			return ((err == nil) && status.StartTime.After(startTime)), err
 		})
@@ -54,7 +56,7 @@ var _ = Describe("Examples Directory", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the updated value in the env")
-			err = wait.PollImmediate(time.Second*5, time.Second*120, func() (bool, error) {
+			err = wait.PollImmediate(pollInterval, kubectl.PollTimeout, func() (bool, error) {
 				err := kubectl.RunCommandWithCheckString(namespace, "example-quarks-statefulset-0", "env", "SPECIAL_KEY=value1Updated")
 				if err != nil {
 					return false, nil
@@ -77,7 +79,7 @@ var _ = Describe("Examples Directory", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for failed pod")
-			err = wait.PollImmediate(time.Second*5, time.Second*120, func() (bool, error) {
+			err = wait.PollImmediate(pollInterval, kubectl.PollTimeout, func() (bool, error) {
 				podStatus, err := kubectl.PodStatus(namespace, "example-quarks-statefulset-1")
 				if err != nil {
 					return true, err
@@ -94,7 +96,7 @@ var _ = Describe("Examples Directory", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the updated value in the env")
-			err = wait.PollImmediate(time.Second*5, time.Second*120, func() (bool, error) {
+			err = wait.PollImmediate(pollInterval, kubectl.PollTimeout, func() (bool, error) {
 				err := kubectl.RunCommandWithCheckString(namespace, "example-quarks-statefulset-0", "env", "SPECIAL_KEY=value1Updated")
 				if err != nil {
 					return false, nil
@@ -113,14 +115,8 @@ var _ = Describe("Examples Directory", func() {
 			err := cmdHelper.Apply(namespace, yamlUpdatedFilePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = wait.PollImmediate(time.Second*5, time.Second*35, func() (bool, error) {
-				err := kubectl.WaitForPod(namespace, "quarks.cloudfoundry.org/pod-active", "example-quarks-statefulset-0")
-				if err != nil {
-					return false, err
-				}
-				return true, nil
-			})
-			Expect(err).ToNot(HaveOccurred(), "waiting for example-quarks-statefulset-1")
+			err = kubectl.WaitForPod(namespace, "quarks.cloudfoundry.org/pod-active", "example-quarks-statefulset-0")
+			Expect(err).ToNot(HaveOccurred(), "waiting for example-quarks-statefulset-0")
 		})
 
 	})

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.cloudfoundry.org/cf-operator
 
 require (
 	code.cloudfoundry.org/quarks-job v0.0.0-20200109094705-4db12e77f5e6
-	code.cloudfoundry.org/quarks-utils v0.0.0-20200107151858-94a806988b47
+	code.cloudfoundry.org/quarks-utils v0.0.0-20200113103742-673f14c44002
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 // indirect
 	github.com/cloudflare/cfssl v0.0.0-20181102015659-ea4033a214e7

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ code.cloudfoundry.org/quarks-job v0.0.0-20200109094705-4db12e77f5e6 h1:ShATyI/te
 code.cloudfoundry.org/quarks-job v0.0.0-20200109094705-4db12e77f5e6/go.mod h1:UoFtaj5zIi4N2q/tE6kqTK6+XbaBguaIFohTdenU5lE=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191220014113-dab838a1c0be h1:e0cGMd6GdQ01b4eAcYJIycsohlUhrO2v0Nq9dKCQyNI=
 code.cloudfoundry.org/quarks-utils v0.0.0-20191220014113-dab838a1c0be/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200107151858-94a806988b47 h1:xJVHCi4WEKHkE8kIEq/eUo0tM7OCPXvPo0+JuD+KyFg=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200107151858-94a806988b47/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200113103742-673f14c44002 h1:0OAvT5uLXXeDWeiF7+83/QJqm4JdyFf5HzeJbTxhDYc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200113103742-673f14c44002/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=

--- a/integration/environment/environment.go
+++ b/integration/environment/environment.go
@@ -47,8 +47,8 @@ func NewEnvironment(kubeConfig *rest.Config) *Environment {
 			KubeConfig: kubeConfig,
 			Config: &config.Config{
 				CtxTimeOut:           10 * time.Second,
-				MeltdownDuration:     1 * time.Second,
-				MeltdownRequeueAfter: 500 * time.Millisecond,
+				MeltdownDuration:     10 * time.Second,
+				MeltdownRequeueAfter: 1 * time.Second,
 				Fs:                   afero.NewOsFs(),
 			},
 		},


### PR DESCRIPTION
MeltdownDuration is now 1min (set via default in quarks-utils), because
e2e quarks-statefulset configs examples failed.

In integration tests duration is now 10s, because integration test time
nearly doubled locally (17min->30min).

[#170627191](https://www.pivotaltracker.com/story/show/170627191)

Needs: https://github.com/cloudfoundry-incubator/quarks-utils/pull/20