### PR TITLE
Use plus instead of dash in version number

### DIFF
--- a/bin/build-helm
+++ b/bin/build-helm
@@ -8,7 +8,11 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . "${GIT_ROOT}/bin/include/dependencies"
 
 output_dir=${GIT_ROOT}/helm
-version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//')
+
+# https://semver.org/#semantic-versioning-200
+# helm does not accept ^v and considers any version with a dash to be a
+# pre-release
+version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//; s/-/+/')
 filename="${output_dir}/cf-operator-${version}.tgz"
 
 [ -d "${output_dir}" ] && rm -r "${output_dir}"
@@ -22,10 +26,11 @@ perl -pi -e "s|version: .*|version: ${version}|g" "${output_dir}/cf-operator/Cha
 perl -pi -e "s|appVersion: .*|appVersion: ${version}|g" "${output_dir}/cf-operator/Chart.yaml"
 
 repo="https://cf-operators.s3.amazonaws.com/helm-charts/"
-qj="quarks-job-$QUARKS_JOB_HELM_VERSION.tgz"
+qj="quarks-job-${QUARKS_JOB_HELM_VERSION/+/%2b}.tgz"
 pushd "$output_dir/cf-operator"
   mkdir charts
-  curl -LO "$repo$qj"
+  echo "downloading $repo$qj"
+  curl -sLO "$repo$qj"
   tar xfz "$qj" -C charts
   rm "$qj"
 popd

--- a/bin/include/dependencies
+++ b/bin/include/dependencies
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-git_sha="62fcf84"
+git_sha="70ae34b"
 quarks_job_release="v0.0.0-0.g$git_sha"
+quarks_job_helm_release="0.0.0+0.g$git_sha"
 
 # QUARKS_JOB_IMAGE_TAG is used for integration tests
 if [ -z ${QUARKS_JOB_IMAGE_TAG+x} ]; then
@@ -11,6 +12,6 @@ fi
 
 # QUARKS_JOB_HELM_VERSION is used to build helm charts including sub-charts
 if [ -z ${QUARKS_JOB_HELM_VERSION+x} ]; then
-  QUARKS_JOB_HELM_VERSION=$(echo "$quarks_job_release" | sed 's/^v//')
+  QUARKS_JOB_HELM_VERSION="$quarks_job_helm_release"
   export QUARKS_JOB_HELM_VERSION
 fi

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/cf-operator
 
 require (
-	code.cloudfoundry.org/quarks-job v0.0.0-20200130141800-25a764f89866
+	code.cloudfoundry.org/quarks-job v0.0.0-20200203163102-70ae34b833a3
 	code.cloudfoundry.org/quarks-utils v0.0.0-20200130110052-eac67a73088b
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
-code.cloudfoundry.org/quarks-job v0.0.0-20200128080450-0deec9592a1e h1:eKxuDhITX02+q4+NagYT/eakaDk9IMNUgGt6Dlno2bk=
-code.cloudfoundry.org/quarks-job v0.0.0-20200128080450-0deec9592a1e/go.mod h1:fLlgnrSanve71EtkVswD8hoI6U2RYM4+0S3A2ajvTEI=
-code.cloudfoundry.org/quarks-job v0.0.0-20200130141800-25a764f89866 h1:EU2BCSJjcQLpqvkcJ8ShXS+LUb3OTrsmHJqeLR9bwP8=
-code.cloudfoundry.org/quarks-job v0.0.0-20200130141800-25a764f89866/go.mod h1:fLlgnrSanve71EtkVswD8hoI6U2RYM4+0S3A2ajvTEI=
+code.cloudfoundry.org/quarks-job v0.0.0-20200203163102-70ae34b833a3 h1:mxUu66bntxKHbgbRnwdUmB1VIffEg4yhZiknA3MWa9s=
+code.cloudfoundry.org/quarks-job v0.0.0-20200203163102-70ae34b833a3/go.mod h1:fLlgnrSanve71EtkVswD8hoI6U2RYM4+0S3A2ajvTEI=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200127150718-47028dacbc7c h1:nEbvnRc7JUgzLFfopuvdPBhT4nHQulxg8iVVPxuVZOM=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200127150718-47028dacbc7c/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200128080244-7f8de3f1673c h1:m0VovyZz1Ny2OtGn3siS6Q7JumekLW0hvIwoeKadl4c=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200128080244-7f8de3f1673c/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200130110052-eac67a73088b h1:vngvL8ncDz/ihUgnNZplK1gCwnxDppucvBLeYZKFqVc=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200130110052-eac67a73088b/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=


### PR DESCRIPTION
Helm follows semantic versioning and considers any version with dash to
be a pre-release.  Pre-releases are not found in search unless `--devel`
is used.

[#165014706](https://www.pivotaltracker.com/story/show/165014706)