### PR TITLE
Add helm value to control creation of watch namespace

### DIFF
--- a/deploy/helm/cf-operator/templates/namespace.yaml
+++ b/deploy/helm/cf-operator/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.operator.watchNamespace }}
+{{- if and .Values.global.operator.watchNamespace .Values.createWatchNamespace }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/deploy/helm/cf-operator/values.yaml
+++ b/deploy/helm/cf-operator/values.yaml
@@ -10,6 +10,9 @@ cluster:
   # domain is the the Kubernetes cluster domain
   domain: "cluster.local"
 
+# createWatchNamespace is a boolean to control creation of the watched namespace.
+createWatchNamespace: true
+
 # fullnameOverride overrides the release name
 fullnameOverride: ""
 
@@ -75,7 +78,7 @@ global:
     create: true
 
 quarks-job:
-  # createWatchNamespace is a boolean to control creation of watchnamespace.
+  # createWatchNamespace is a boolean to control creation of the watched namespace.
   createWatchNamespace: false
   serviceAccount:
     # create is a boolean to control the creation of service account name.


### PR DESCRIPTION
Setting this to false (`helm install --name cf-operator --namespace cfo --set "global.operator.watchNamespace=scf" --set "createWatchNamespace=false" helm/cf-operator`) also prevents deletion of the namespace, when running `helm delete --purge cf-operator`



[#171027585](https://www.pivotaltracker.com/story/show/171027585)