### PR TITLE
Sanitize link type and name string

### DIFF
--- a/integration/quarks_link_from_bosh_test.go
+++ b/integration/quarks_link_from_bosh_test.go
@@ -65,7 +65,7 @@ var _ = Describe("BOSHLinks", func() {
 		})
 
 		It("creates a secret for each link found in jobs", func() {
-			secretName := names.QuarksLinkSecretName(deploymentName, "nats", "nuts")
+			secretName := names.QuarksLinkSecretName(deploymentName, "nats", "nutty-nuts")
 
 			By("waiting for secrets", func() {
 				err := env.WaitForSecret(env.Namespace, secretName)

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -15,6 +15,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"code.cloudfoundry.org/cf-operator/pkg/bosh/bpm"
+	"code.cloudfoundry.org/quarks-utils/pkg/names"
 )
 
 // DomainNameService abstraction.
@@ -157,7 +158,7 @@ func (igr *InstanceGroupResolver) SaveLinks(path string) error {
 		}
 
 		if string(jsonBytes) != "null" {
-			result[id] = string(jsonBytes)
+			result[names.Sanitize(id)] = string(jsonBytes)
 		}
 	}
 

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -344,7 +344,7 @@ var _ = Describe("InstanceGroupResolver", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fileContentOf("/mnt/quarks/provides.json")).To(Equal(map[string]string{
-						"nats-nuts": `{"nats.password":"changeme","nats.port":"4222","nats.user":"admin"}`,
+						"nats-nutty-nuts": `{"nats.password":"changeme","nats.port":"4222","nats.user":"admin"}`,
 					}))
 				})
 			})

--- a/testing/boshmanifest/manifests.go
+++ b/testing/boshmanifest/manifests.go
@@ -148,7 +148,7 @@ instance_groups:
   jobs:
   - name: nats
     provides:
-      nats: { shared: true, as: nuts }
+      nats: { shared: true, as: nutty_nuts }
     release: nats
     properties:
       nats:


### PR DESCRIPTION
The link type and name can contain characters that are not allowed as
secret name. This leads to breaking the secret creation.

Add `Sanitize` call to the link type and name.