### PR TITLE
Allow updates to versioned secret status, despite them being immutable

### DIFF
--- a/integration/quarks_secret_test.go
+++ b/integration/quarks_secret_test.go
@@ -21,127 +21,125 @@ var _ = Describe("QuarksSecret", func() {
 		qSecret qsv1a1.QuarksSecret
 	)
 
-	Context("when correctly setup", func() {
-		BeforeEach(func() {
-			qsName := fmt.Sprintf("qs-%s", helper.RandString(5))
-			qSecret = env.DefaultQuarksSecret(qsName)
+	BeforeEach(func() {
+		qsName := fmt.Sprintf("qs-%s", helper.RandString(5))
+		qSecret = env.DefaultQuarksSecret(qsName)
+	})
+
+	It("generates a secret with a password and deletes it when being deleted", func() {
+		// Create an QuarksSecret
+		var qs *qsv1a1.QuarksSecret
+		qSecret.Spec.SecretName = "generated-password-secret"
+		qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(qs).NotTo(Equal(nil))
+		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+		// check for generated secret
+		secret, err := env.CollectSecret(env.Namespace, "generated-password-secret")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data["password"]).To(MatchRegexp("^\\w{64}$"))
+
+		// delete quarksSecret
+		err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+		Expect(err).NotTo(HaveOccurred())
+		err = env.WaitForSecretDeletion(env.Namespace, "generated-password-secret")
+		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+	})
+
+	It("generates a secret with an rsa key and deletes it when being deleted", func() {
+		// Create an quarksSecret
+		var qs *qsv1a1.QuarksSecret
+		qSecret.Spec.Type = "rsa"
+		qSecret.Spec.SecretName = "generated-rsa-secret"
+		qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(qs).NotTo(Equal(nil))
+		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+		// check for generated secret
+		secret, err := env.CollectSecret(env.Namespace, "generated-rsa-secret")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
+		Expect(secret.Data["public_key"]).To(ContainSubstring("PUBLIC KEY"))
+
+		// delete quarksSecret
+		err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+		Expect(err).NotTo(HaveOccurred())
+		err = env.WaitForSecretDeletion(env.Namespace, "generated-rsa-secret")
+		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+	})
+
+	It("generates a secret with an ssh key and deletes it when being deleted", func() {
+		// Create an quarksSecret
+		var qs *qsv1a1.QuarksSecret
+		qSecret.Spec.Type = "ssh"
+		qSecret.Spec.SecretName = "generated-ssh-secret"
+		qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(qs).NotTo(Equal(nil))
+		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+
+		// check for generated secret
+		secret, err := env.CollectSecret(env.Namespace, "generated-ssh-secret")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
+		Expect(secret.Data["public_key"]).To(ContainSubstring("ssh-rsa "))
+		Expect(secret.Data["public_key_fingerprint"]).To(MatchRegexp("([0-9a-f]{2}:){15}[0-9a-f]{2}"))
+
+		// delete quarksSecret
+		err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+		Expect(err).NotTo(HaveOccurred())
+		err = env.WaitForSecretDeletion(env.Namespace, "generated-ssh-secret")
+		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+	})
+
+	It("generates a secret with a certificate key and deletes it when being deleted", func() {
+		generator := inmemorygenerator.NewInMemoryGenerator(env.Log)
+		ca, err := generator.GenerateCertificate("default-ca", credsgen.CertificateGenerationRequest{
+			CommonName: "Fake CA",
+			IsCA:       true,
 		})
+		Expect(err).ToNot(HaveOccurred())
 
-		It("generates a secret with a password and deletes it when being deleted", func() {
-			// Create an QuarksSecret
-			var qs *qsv1a1.QuarksSecret
-			qSecret.Spec.SecretName = "generated-password-secret"
-			qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(qs).NotTo(Equal(nil))
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+		// Create the CA secret
+		casecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mysecret",
+				Namespace: env.Namespace,
+			},
+			Data: map[string][]byte{
+				"ca":  ca.Certificate,
+				"key": ca.PrivateKey,
+			},
+		}
+		tearDown, err := env.CreateSecret(env.Namespace, casecret)
+		Expect(err).NotTo(HaveOccurred())
+		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// check for generated secret
-			secret, err := env.CollectSecret(env.Namespace, "generated-password-secret")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret.Data["password"]).To(MatchRegexp("^\\w{64}$"))
+		// Create an quarksSecret
+		var qs *qsv1a1.QuarksSecret
+		qSecret.Spec.SecretName = "generated-cert-secret"
+		qSecret.Spec.Type = "certificate"
+		qSecret.Spec.Request.CertificateRequest.CommonName = "example.com"
+		qSecret.Spec.Request.CertificateRequest.CARef = qsv1a1.SecretReference{Name: "mysecret", Key: "ca"}
+		qSecret.Spec.Request.CertificateRequest.CAKeyRef = qsv1a1.SecretReference{Name: "mysecret", Key: "key"}
+		qSecret.Spec.Request.CertificateRequest.AlternativeNames = []string{"qux.com"}
+		qs, tearDown, err = env.CreateQuarksSecret(env.Namespace, qSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(qs).NotTo(Equal(nil))
+		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
 
-			// delete quarksSecret
-			err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
-			Expect(err).NotTo(HaveOccurred())
-			err = env.WaitForSecretDeletion(env.Namespace, "generated-password-secret")
-			Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
-		})
+		// check for generated secret
+		secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data["certificate"]).To(ContainSubstring("BEGIN CERTIFICATE"))
+		Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
 
-		It("generates a secret with an rsa key and deletes it when being deleted", func() {
-			// Create an quarksSecret
-			var qs *qsv1a1.QuarksSecret
-			qSecret.Spec.Type = "rsa"
-			qSecret.Spec.SecretName = "generated-rsa-secret"
-			qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(qs).NotTo(Equal(nil))
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
-
-			// check for generated secret
-			secret, err := env.CollectSecret(env.Namespace, "generated-rsa-secret")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
-			Expect(secret.Data["public_key"]).To(ContainSubstring("PUBLIC KEY"))
-
-			// delete quarksSecret
-			err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
-			Expect(err).NotTo(HaveOccurred())
-			err = env.WaitForSecretDeletion(env.Namespace, "generated-rsa-secret")
-			Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
-		})
-
-		It("generates a secret with an ssh key and deletes it when being deleted", func() {
-			// Create an quarksSecret
-			var qs *qsv1a1.QuarksSecret
-			qSecret.Spec.Type = "ssh"
-			qSecret.Spec.SecretName = "generated-ssh-secret"
-			qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(qs).NotTo(Equal(nil))
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
-
-			// check for generated secret
-			secret, err := env.CollectSecret(env.Namespace, "generated-ssh-secret")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
-			Expect(secret.Data["public_key"]).To(ContainSubstring("ssh-rsa "))
-			Expect(secret.Data["public_key_fingerprint"]).To(MatchRegexp("([0-9a-f]{2}:){15}[0-9a-f]{2}"))
-
-			// delete quarksSecret
-			err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
-			Expect(err).NotTo(HaveOccurred())
-			err = env.WaitForSecretDeletion(env.Namespace, "generated-ssh-secret")
-			Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
-		})
-
-		It("generates a secret with a certificate key and deletes it when being deleted", func() {
-			generator := inmemorygenerator.NewInMemoryGenerator(env.Log)
-			ca, err := generator.GenerateCertificate("default-ca", credsgen.CertificateGenerationRequest{
-				CommonName: "Fake CA",
-				IsCA:       true,
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Create the CA secret
-			casecret := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mysecret",
-					Namespace: env.Namespace,
-				},
-				Data: map[string][]byte{
-					"ca":  ca.Certificate,
-					"key": ca.PrivateKey,
-				},
-			}
-			tearDown, err := env.CreateSecret(env.Namespace, casecret)
-			Expect(err).NotTo(HaveOccurred())
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
-
-			// Create an quarksSecret
-			var qs *qsv1a1.QuarksSecret
-			qSecret.Spec.SecretName = "generated-cert-secret"
-			qSecret.Spec.Type = "certificate"
-			qSecret.Spec.Request.CertificateRequest.CommonName = "example.com"
-			qSecret.Spec.Request.CertificateRequest.CARef = qsv1a1.SecretReference{Name: "mysecret", Key: "ca"}
-			qSecret.Spec.Request.CertificateRequest.CAKeyRef = qsv1a1.SecretReference{Name: "mysecret", Key: "key"}
-			qSecret.Spec.Request.CertificateRequest.AlternativeNames = []string{"qux.com"}
-			qs, tearDown, err = env.CreateQuarksSecret(env.Namespace, qSecret)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(qs).NotTo(Equal(nil))
-			defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
-
-			// check for generated secret
-			secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret.Data["certificate"]).To(ContainSubstring("BEGIN CERTIFICATE"))
-			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
-
-			// delete QuarksSecret
-			err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
-			Expect(err).NotTo(HaveOccurred())
-			err = env.WaitForSecretDeletion(env.Namespace, "generated-cert-secret")
-			Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
-		})
+		// delete QuarksSecret
+		err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+		Expect(err).NotTo(HaveOccurred())
+		err = env.WaitForSecretDeletion(env.Namespace, "generated-cert-secret")
+		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
 	})
 })

--- a/integration/versionedsecret_test.go
+++ b/integration/versionedsecret_test.go
@@ -1,0 +1,69 @@
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"code.cloudfoundry.org/quarks-utils/testing/machine"
+)
+
+var _ = Describe("VersionedSecret", func() {
+	var (
+		secret    corev1.Secret
+		tearDowns []machine.TearDownFunc
+	)
+
+	const (
+		secretName = "versioned-secret"
+	)
+
+	BeforeEach(func() {
+		secret = env.VersionedSecret(secretName)
+		tearDown, err := env.CreateSecret(env.Namespace, secret)
+		Expect(err).NotTo(HaveOccurred())
+		tearDowns = append(tearDowns, tearDown)
+
+		_, err = env.CollectSecret(env.Namespace, secretName)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(env.TearDownAll(tearDowns)).To(Succeed())
+	})
+
+	Context("when updating data", func() {
+		BeforeEach(func() {
+			secret.StringData["new"] = "value"
+		})
+
+		It("fails because versioned secrets are immutable", func() {
+			_, _, err := env.UpdateSecret(env.Namespace, secret)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when updating annotations", func() {
+		BeforeEach(func() {
+			secret.Annotations = map[string]string{"foo": "bar"}
+		})
+
+		It("updates the annotation", func() {
+			_, _, err := env.UpdateSecret(env.Namespace, secret)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when updating annotation and data", func() {
+		BeforeEach(func() {
+			secret.StringData["new"] = "value"
+			secret.Annotations = map[string]string{"foo": "bar"}
+		})
+
+		It("fails because versioned secrets are immutable", func() {
+			_, _, err := env.UpdateSecret(env.Namespace, secret)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -24,6 +24,7 @@ import (
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/quarkssecret"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/quarksstatefulset"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/statefulset"
+	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/versionedsecret"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/controllers/watchnamespace"
 	wh "code.cloudfoundry.org/cf-operator/pkg/kube/util/webhook"
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
@@ -66,7 +67,7 @@ var addToSchemes = runtime.SchemeBuilder{
 
 var validatingHookFuncs = []func(*zap.SugaredLogger, *config.Config) *wh.OperatorWebhook{
 	boshdeployment.NewBOSHDeploymentValidator,
-	quarkssecret.NewSecretValidator,
+	versionedsecret.NewSecretValidator,
 }
 
 var mutatingHookFuncs = []func(*zap.SugaredLogger, *config.Config) *wh.OperatorWebhook{

--- a/pkg/kube/controllers/versionedsecret/suite_test.go
+++ b/pkg/kube/controllers/versionedsecret/suite_test.go
@@ -1,0 +1,13 @@
+package versionedsecret_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestQuarksSecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VersionedSecret Suite")
+}

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -24,6 +24,7 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 	"code.cloudfoundry.org/quarks-utils/pkg/pointers"
+	"code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 )
 
 const (
@@ -236,6 +237,21 @@ func (c *Catalog) StorageClassSecret(name string, class string) corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		StringData: map[string]string{
 			"value": class,
+		},
+	}
+}
+
+// VersionedSecret for tests
+func (c *Catalog) VersionedSecret(name string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				versionedsecretstore.LabelSecretKind: versionedsecretstore.VersionSecretKind,
+			},
+		},
+		StringData: map[string]string{
+			name: "default-value",
 		},
 	}
 }


### PR DESCRIPTION
* versioned secret validator was in unrelated quarks secret package,
  quarks secret does not support the creation of versioned secret
* creating a new parent context in a request, does not create a new
  logger
* use existing request context
* add caller skip to logger, so source location is reported right


[#171328241](https://www.pivotaltracker.com/story/show/171328241)