### PR TITLE
Refine bpm for quarks properties

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -248,7 +247,7 @@ var _ = Describe("Deploy", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("checking for statefulset")
-				stsName := fmt.Sprintf("%s-%s", deploymentName, "nats")
+				stsName := "nats"
 
 				Eventually(func() []string {
 					sts, err := env.GetStatefulSet(env.Namespace, stsName)

--- a/pkg/bosh/bpm/config.go
+++ b/pkg/bosh/bpm/config.go
@@ -62,12 +62,63 @@ type Port struct {
 // Config represent a BPM configuration
 type Config struct {
 	Processes           []Process `yaml:"processes,omitempty" json:"processes,omitempty"`
-	Ports               []Port    `yaml:"ports,omitempty" json:"ports,omitempty"`
 	UnsupportedTemplate bool      `json:"unsupported_template"`
+
+	// Bind these to reflect quarks properties update
+	Ports               []Port                  `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Run                 RunConfig               `json:"run"`
+	PostStart           PostStart               `json:"post_start"`
+	Debug               bool                    `json:"debug"`
+	ActivePassiveProbes map[string]corev1.Probe `json:"activePassiveProbes"`
+}
+
+// RunConfig describes the runtime configuration for this job.
+type RunConfig struct {
+	HealthCheck     map[string]HealthCheck  `json:"healthcheck" yaml:"healthcheck"`
+	SecurityContext *corev1.SecurityContext `json:"security_context" yaml:"security_context"`
+}
+
+// HealthCheck defines liveness and readiness probes for a container.
+type HealthCheck struct {
+	ReadinessProbe *corev1.Probe `json:"readiness" yaml:"readiness"`
+	LivenessProbe  *corev1.Probe `json:"liveness"  yaml:"liveness"`
+}
+
+// PostStart allows post-start specifics to be passed through the manifest.
+type PostStart struct {
+	Condition *PostStartCondition `json:"condition,omitempty"`
+}
+
+// PostStartCondition represents the condition that should succeed in order to execute the
+// post-start script. It's often set to be the same as the readiness probe of a job.
+type PostStartCondition struct {
+	Exec *corev1.ExecAction `json:"exec,omitempty"`
 }
 
 // Configs holds a collection of BPM configurations by their according job
 type Configs map[string]Config
+
+// IsActivePassiveModel indicates weather this bpm configs contains ActivePassiveProbes
+func (c Configs) IsActivePassiveModel() (isActivePassiveModel bool) {
+	for _, config := range c {
+		if len(config.ActivePassiveProbes) > 0 {
+			isActivePassiveModel = true
+		}
+	}
+
+	return
+}
+
+// ActivePassiveProbes returns all activePassive probes defined in the bpm configs
+func (c Configs) ActivePassiveProbes() map[string]corev1.Probe {
+	probes := map[string]corev1.Probe{}
+	for _, config := range c {
+		for container, probe := range config.ActivePassiveProbes {
+			probes[container] = probe
+		}
+	}
+	return probes
+}
 
 // NewConfig creates a new Config object from the yaml
 func NewConfig(data []byte) (Config, error) {

--- a/pkg/bosh/bpm/config.go
+++ b/pkg/bosh/bpm/config.go
@@ -98,9 +98,9 @@ type PostStartCondition struct {
 // Configs holds a collection of BPM configurations by their according job
 type Configs map[string]Config
 
-// IsActivePassiveModel indicates weather this bpm configs contains ActivePassiveProbes
-func (c Configs) IsActivePassiveModel() (isActivePassiveModel bool) {
-	for _, config := range c {
+// IsActivePassiveModel indicates whether these bpm configs contain ActivePassiveProbes
+func (cs Configs) IsActivePassiveModel() (isActivePassiveModel bool) {
+	for _, config := range cs {
 		if len(config.ActivePassiveProbes) > 0 {
 			isActivePassiveModel = true
 		}
@@ -110,14 +110,30 @@ func (c Configs) IsActivePassiveModel() (isActivePassiveModel bool) {
 }
 
 // ActivePassiveProbes returns all activePassive probes defined in the bpm configs
-func (c Configs) ActivePassiveProbes() map[string]corev1.Probe {
+func (cs Configs) ActivePassiveProbes() map[string]corev1.Probe {
 	probes := map[string]corev1.Probe{}
-	for _, config := range c {
+	for _, config := range cs {
 		for container, probe := range config.ActivePassiveProbes {
 			probes[container] = probe
 		}
 	}
 	return probes
+}
+
+// ServicePorts returns the service ports defined in the bpm configs
+func (cs Configs) ServicePorts() []corev1.ServicePort {
+	ports := []corev1.ServicePort{}
+
+	for _, c := range cs {
+		for _, port := range c.Ports {
+			ports = append(ports, corev1.ServicePort{
+				Name:     port.Name,
+				Protocol: corev1.Protocol(port.Protocol),
+				Port:     int32(port.Internal),
+			})
+		}
+	}
+	return ports
 }
 
 // NewConfig creates a new Config object from the yaml

--- a/pkg/bosh/bpmconverter/container_factory.go
+++ b/pkg/bosh/bpmconverter/container_factory.go
@@ -116,8 +116,8 @@ func (c *ContainerFactoryImpl) JobsToInitContainers(
 					process,
 					jobImage,
 					processVolumeMounts,
-					job.Properties.Quarks.Debug,
-					job.Properties.Quarks.Run.SecurityContext.DeepCopy(),
+					bpmConfig.Debug,
+					bpmConfig.Run.SecurityContext.DeepCopy(),
 				)
 
 				bpmPreStartInitContainers = append(bpmPreStartInitContainers, *container.DeepCopy())
@@ -129,8 +129,8 @@ func (c *ContainerFactoryImpl) JobsToInitContainers(
 			job.Name,
 			jobImage,
 			append(defaultVolumeMounts, bpmDisks.VolumeMounts()...),
-			job.Properties.Quarks.Debug,
-			job.Properties.Quarks.Run.SecurityContext.DeepCopy(),
+			bpmConfig.Debug,
+			bpmConfig.Run.SecurityContext.DeepCopy(),
 		)
 		boshPreStartInitContainers = append(boshPreStartInitContainers, *boshPreStartInitContainer.DeepCopy())
 	}
@@ -225,7 +225,7 @@ func (c *ContainerFactoryImpl) JobsToContainers(
 			// process container.
 			var postStart postStart
 			if processIndex == 0 {
-				conditionProperty := job.Properties.Quarks.PostStart.Condition
+				conditionProperty := bpmConfig.PostStart.Condition
 				if conditionProperty != nil && conditionProperty.Exec != nil && len(conditionProperty.Exec.Command) > 0 {
 					postStart.condition = &containerrun.Command{
 						Name: conditionProperty.Exec.Command[0],
@@ -244,9 +244,9 @@ func (c *ContainerFactoryImpl) JobsToContainers(
 				jobImage,
 				process,
 				processVolumeMounts,
-				job.Properties.Quarks.Run.HealthCheck,
+				bpmConfig.Run.HealthCheck,
 				job.Properties.Quarks.Envs,
-				job.Properties.Quarks.Run.SecurityContext.DeepCopy(),
+				bpmConfig.Run.SecurityContext.DeepCopy(),
 				postStart,
 			)
 
@@ -496,7 +496,7 @@ func bpmProcessContainer(
 	jobImage string,
 	process bpm.Process,
 	volumeMounts []corev1.VolumeMount,
-	healthchecks map[string]bdm.HealthCheck,
+	healthChecks map[string]bpm.HealthCheck,
 	quarksEnvs []corev1.EnvVar,
 	securityContext *corev1.SecurityContext,
 	postStart postStart,
@@ -589,7 +589,7 @@ echo "Done"`,
 		},
 	}
 
-	for name, hc := range healthchecks {
+	for name, hc := range healthChecks {
 		if name == process.Name {
 			if hc.ReadinessProbe != nil {
 				container.ReadinessProbe = hc.ReadinessProbe

--- a/pkg/bosh/bpmconverter/container_factory_test.go
+++ b/pkg/bosh/bpmconverter/container_factory_test.go
@@ -451,8 +451,8 @@ var _ = Describe("ContainerFactory", func() {
 						Name: "fake-job",
 						Properties: bdm.JobProperties{
 							Quarks: bdm.Quarks{
-								PostStart: bdm.PostStart{
-									Condition: &bdm.PostStartCondition{
+								PostStart: bpm.PostStart{
+									Condition: &bpm.PostStartCondition{
 										Exec: &corev1.ExecAction{
 											Command: []string{"sh", "-c", "fake_health_check"},
 										},

--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -102,12 +102,12 @@ func (kc *BPMConverter) Resources(deploymentName string, dns DomainNameService, 
 
 	switch instanceGroup.LifeCycle {
 	case bdm.IGTypeService, "":
-		convertedExtStatefulSet, err := kc.serviceToQuarksStatefulSet(cfac, dns, instanceGroup, defaultDisks, bpmDisks)
+		convertedExtStatefulSet, err := kc.serviceToQuarksStatefulSet(cfac, dns, instanceGroup, defaultDisks, bpmDisks, bpmConfigs.ActivePassiveProbes())
 		if err != nil {
 			return nil, err
 		}
 
-		services := kc.serviceToKubeServices(deploymentName, dns, instanceGroup, &convertedExtStatefulSet)
+		services := kc.serviceToKubeServices(deploymentName, dns, instanceGroup, &convertedExtStatefulSet, bpmConfigs.IsActivePassiveModel())
 		if len(services) != 0 {
 			res.Services = append(res.Services, services...)
 		}
@@ -132,6 +132,7 @@ func (kc *BPMConverter) serviceToQuarksStatefulSet(
 	instanceGroup *bdm.InstanceGroup,
 	defaultDisks bdm.Disks,
 	bpmDisks bdm.Disks,
+	activePassiveProbes map[string]corev1.Probe,
 ) (qstsv1a1.QuarksStatefulSet, error) {
 	defaultVolumeMounts := defaultDisks.VolumeMounts()
 	initContainers, err := cfac.JobsToInitContainers(instanceGroup.Jobs, defaultVolumeMounts, bpmDisks, instanceGroup.Properties.Quarks.RequiredService)
@@ -171,7 +172,7 @@ func (kc *BPMConverter) serviceToQuarksStatefulSet(
 		Spec: qstsv1a1.QuarksStatefulSetSpec{
 			Zones:                instanceGroup.AZs,
 			UpdateOnConfigChange: true,
-			ActivePassiveProbes:  instanceGroup.ActivePassiveProbes(),
+			ActivePassiveProbes:  activePassiveProbes,
 			Template: appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        instanceGroup.NameSanitized(),
@@ -229,19 +230,12 @@ func (kc *BPMConverter) serviceToQuarksStatefulSet(
 }
 
 // serviceToKubeServices will generate Services which expose ports for InstanceGroup's jobs
-func (kc *BPMConverter) serviceToKubeServices(deploymentName string, dns DomainNameService, instanceGroup *bdm.InstanceGroup, qSts *qstsv1a1.QuarksStatefulSet) []corev1.Service {
+func (kc *BPMConverter) serviceToKubeServices(deploymentName string, dns DomainNameService, instanceGroup *bdm.InstanceGroup, qSts *qstsv1a1.QuarksStatefulSet, activePassiveModel bool) []corev1.Service {
 	var services []corev1.Service
 	// Collect ports to be exposed for each job
 	ports := instanceGroup.ServicePorts()
 	if len(ports) == 0 {
 		return services
-	}
-
-	activePassiveModel := false
-	for _, job := range instanceGroup.Jobs {
-		if len(job.Properties.Quarks.ActivePassiveProbes) > 0 {
-			activePassiveModel = true
-		}
 	}
 
 	if len(instanceGroup.AZs) > 0 {

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -210,6 +210,13 @@ var _ = Describe("BPM Converter", func() {
 					}
 					config := bpmConfigs[1]["cflinuxfs3-rootfs-setup"]
 					config.ActivePassiveProbes = activePassiveProbes
+					config.Ports = []bpm.Port{
+						{
+							Name:     "rep-server",
+							Protocol: "TCP",
+							Internal: 1801,
+						},
+					}
 					bpmConfigs[1]["cflinuxfs3-rootfs-setup"] = config
 
 					resources, err := act(bpmConfigs[1], m.InstanceGroups[1])
@@ -219,6 +226,7 @@ var _ = Describe("BPM Converter", func() {
 					stS := qSts.Spec.Template.Spec.Template
 
 					// Test services for the quarks statefulSet
+					//
 					service0 := resources.Services[0]
 					Expect(service0.Spec.Selector).To(Equal(map[string]string{
 						bdv1.LabelDeploymentName:    deploymentName,

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -238,7 +238,6 @@ var _ = Describe("BPM Converter", func() {
 				})
 
 				It("converts the instance group to an QuarksStatefulSet", func() {
-
 					tolerations := []corev1.Toleration{
 						{
 							Key:      "key",

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -447,6 +447,12 @@ func (igr *InstanceGroupResolver) renderJobBPM(currentJob *Job, jobSpecFile stri
 		}
 		renderedBPM.Ports = ports
 
+		// Add these to reflect quarks properties update
+		renderedBPM.Run = currentJob.Properties.Quarks.Run
+		renderedBPM.PostStart = currentJob.Properties.Quarks.PostStart
+		renderedBPM.Debug = currentJob.Properties.Quarks.Debug
+		renderedBPM.ActivePassiveProbes = currentJob.Properties.Quarks.ActivePassiveProbes
+
 		jobIndexBPM[i] = renderedBPM
 	}
 

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -232,14 +232,13 @@ var _ = Describe("InstanceGroupResolver", func() {
 					ig = "redis-slave"
 				})
 
-				It("should remove info about job instances, instance count, azs", func() {
+				It("should remove info about job instances, instance count", func() {
 					resolve()
 					manifest, err := igr.Manifest()
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(manifest.InstanceGroups[0].Jobs[0].Properties.Quarks.Instances).To(BeNil())
 					Expect(manifest.InstanceGroups[0].Instances).To(Equal(0))
-					Expect(manifest.InstanceGroups[0].AZs).To(Equal([]string{"z1", "z2"}))
 				})
 			})
 

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -14,9 +14,9 @@ type Quarks struct {
 	Release             string                  `json:"release"`
 	BPM                 *bpm.Config             `json:"bpm,omitempty" yaml:"bpm,omitempty"`
 	Ports               []Port                  `json:"ports"`
-	Run                 RunConfig               `json:"run"`
+	Run                 bpm.RunConfig           `json:"run"`
 	PreRenderScripts    PreRenderScripts        `json:"pre_render_scripts" yaml:"pre_render_scripts"`
-	PostStart           PostStart               `json:"post_start"`
+	PostStart           bpm.PostStart           `json:"post_start"`
 	Debug               bool                    `json:"debug" yaml:"debug"`
 	IsAddon             bool                    `json:"is_addon" yaml:"is_addon"`
 	Envs                []corev1.EnvVar         `json:"envs" yaml:"envs"`
@@ -52,28 +52,11 @@ type JobLink struct {
 	Properties JobLinkProperties `json:"properties"`
 }
 
-// HealthCheck defines liveness and readiness probes for a container.
-type HealthCheck struct {
-	ReadinessProbe *corev1.Probe `json:"readiness" yaml:"readiness"`
-	LivenessProbe  *corev1.Probe `json:"liveness"  yaml:"liveness"`
-}
-
-// RunConfig describes the runtime configuration for this job.
-type RunConfig struct {
-	HealthCheck     map[string]HealthCheck  `json:"healthcheck" yaml:"healthcheck"`
-	SecurityContext *corev1.SecurityContext `json:"security_context" yaml:"security_context"`
-}
-
 // PreRenderScripts describes the different types of scripts that can be run inside a job.
 type PreRenderScripts struct {
 	BPM        []string `json:"bpm" yaml:"bpm"`
 	IgResolver []string `json:"ig_resolver" yaml:"ig_resolver"`
 	Jobs       []string `json:"jobs" yaml:"jobs"`
-}
-
-// PostStart allows post-start specifics to be passed through the manifest.
-type PostStart struct {
-	Condition *PostStartCondition `json:"condition,omitempty"`
 }
 
 // PostStartCondition represents the condition that should succeed in order to execute the

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -111,17 +111,6 @@ func (ig *InstanceGroup) IndexedServiceName(index int, azIndex int) string {
 	return fmt.Sprintf("%s-%d", sn, index)
 }
 
-// ActivePassiveProbes returns all the probes defined in the instance group jobs
-func (ig *InstanceGroup) ActivePassiveProbes() map[string]corev1.Probe {
-	probes := map[string]corev1.Probe{}
-	for _, job := range ig.Jobs {
-		for container, probe := range job.Properties.Quarks.ActivePassiveProbes {
-			probes[container] = probe
-		}
-	}
-	return probes
-}
-
 func (ig *InstanceGroup) jobInstances(
 	jobName string,
 	initialRollout bool,

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ReconcileBPM", func() {
 		recorder                  *record.FakeRecorder
 		request                   reconcile.Request
 		ctx                       context.Context
-		resolver                  fakes.FakeDesiredManifest
+		resolver                  fakes.FakeInstanceGroupManifest
 		kubeConverter             fakes.FakeBPMConverter
 		manifest                  *bdm.Manifest
 		logs                      *observer.ObservedLogs
@@ -61,7 +61,7 @@ var _ = Describe("ReconcileBPM", func() {
 		manager = &fakes.FakeManager{}
 		manager.GetSchemeReturns(scheme.Scheme)
 		manager.GetEventRecorderForReturns(recorder)
-		resolver = fakes.FakeDesiredManifest{}
+		resolver = fakes.FakeInstanceGroupManifest{}
 		kubeConverter = fakes.FakeBPMConverter{}
 
 		kubeConverter.ResourcesReturns(&bpmconverter.Resources{}, nil)
@@ -232,7 +232,7 @@ variables: []
 	})
 
 	JustBeforeEach(func() {
-		resolver.DesiredManifestReturns(manifest, nil)
+		resolver.InstanceGroupManifestReturns(manifest, nil)
 		reconciler = cfd.NewBPMReconciler(ctx, config, manager, &resolver,
 			controllerutil.SetControllerReference, &kubeConverter,
 			func(m bdm.Manifest) (boshdns.DomainNameService, error) {

--- a/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
+++ b/pkg/kube/controllers/boshdeployment/bpm_reconciler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ReconcileBPM", func() {
 		recorder                  *record.FakeRecorder
 		request                   reconcile.Request
 		ctx                       context.Context
-		resolver                  fakes.FakeInstanceGroupManifest
+		resolver                  fakes.FakeDesiredManifest
 		kubeConverter             fakes.FakeBPMConverter
 		manifest                  *bdm.Manifest
 		logs                      *observer.ObservedLogs
@@ -61,7 +61,7 @@ var _ = Describe("ReconcileBPM", func() {
 		manager = &fakes.FakeManager{}
 		manager.GetSchemeReturns(scheme.Scheme)
 		manager.GetEventRecorderForReturns(recorder)
-		resolver = fakes.FakeInstanceGroupManifest{}
+		resolver = fakes.FakeDesiredManifest{}
 		kubeConverter = fakes.FakeBPMConverter{}
 
 		kubeConverter.ResourcesReturns(&bpmconverter.Resources{}, nil)
@@ -232,7 +232,7 @@ variables: []
 	})
 
 	JustBeforeEach(func() {
-		resolver.InstanceGroupManifestReturns(manifest, nil)
+		resolver.DesiredManifestReturns(manifest, nil)
 		reconciler = cfd.NewBPMReconciler(ctx, config, manager, &resolver,
 			controllerutil.SetControllerReference, &kubeConverter,
 			func(m bdm.Manifest) (boshdns.DomainNameService, error) {

--- a/pkg/kube/controllers/watchnamespace/controller.go
+++ b/pkg/kube/controllers/watchnamespace/controller.go
@@ -16,13 +16,13 @@ import (
 	"code.cloudfoundry.org/quarks-utils/pkg/config"
 )
 
-// Reconcile doesn't have any state
+// Reconcile implements reconcile.Reconciler
 type Reconcile struct {
 }
 
 var _ reconcile.Reconciler = &Reconcile{}
 
-// Reconcile is a null operation and not called, since the predicate never returns true
+// Reconcile doesn't do anything, because there is nothing to reconcile with the watched namespace
 func (r *Reconcile) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }

--- a/testing/boshreleases/releases.go
+++ b/testing/boshreleases/releases.go
@@ -54,6 +54,10 @@ processes:
     unrestricted_volumes:
     - path: /dev/log
       mount_only: true
+ports:
+- name: "rep-server"
+  protocol: "TCP"
+  internal: 1801
 `
 
 // EnablePersistentDiskBPMConfig is a BOSH Job configuration with persistent disks

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -369,6 +369,25 @@ func (c *Catalog) InterpolateOpsIncorrectSecret(name string) corev1.Secret {
 	}
 }
 
+// ReadinessProbeOpsConfigMap for ops interpolate configmap tests with readiness probe
+func (c *Catalog) ReadinessProbeOpsConfigMap(name string) corev1.ConfigMap {
+	return corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data: map[string]string{
+			"ops": `- type: replace
+  path: /instance_groups/name=nats?/jobs/name=nats?/properties/quarks/run
+  value:
+    healthcheck:
+      nats:
+        readiness:
+          exec:
+            command:
+            - "echo healthy"
+`,
+		},
+	}
+}
+
 // DefaultCA for use in tests
 func (c *Catalog) DefaultCA(name string, ca credsgen.Certificate) corev1.Secret {
 	return corev1.Secret{


### PR DESCRIPTION
[#171141986](https://www.pivotaltracker.com/story/show/171141986)

fixes: #812 
- Added quarks properties to bpm configs
- ~~Got instance group from ig-resovled manifest~~
- Built containers properties('run', 'post_start', 'debug', 'activePassiveProbes') from bpm configs

And it should not break the current integration cases.
