### PR TITLE
Quarks secret deletes CSR if cert secret was created

### DIFF
--- a/integration/quarks_secret_test.go
+++ b/integration/quarks_secret_test.go
@@ -94,52 +94,94 @@ var _ = Describe("QuarksSecret", func() {
 		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
 	})
 
-	It("generates a secret with a certificate key and deletes it when being deleted", func() {
-		generator := inmemorygenerator.NewInMemoryGenerator(env.Log)
-		ca, err := generator.GenerateCertificate("default-ca", credsgen.CertificateGenerationRequest{
-			CommonName: "Fake CA",
-			IsCA:       true,
+	Context("when quarks secret is a certificate", func() {
+		var (
+			tearDowns []machine.TearDownFunc
+		)
+
+		const qsName = "qsec-cert"
+
+		BeforeEach(func() {
+			qSecret = env.CertificateQuarksSecret(qsName, "mysecret", "ca", "key")
+
+			By("creating the CA and storing it in a secret")
+			generator := inmemorygenerator.NewInMemoryGenerator(env.Log)
+			ca, err := generator.GenerateCertificate("default-ca", credsgen.CertificateGenerationRequest{
+				CommonName: "Fake CA",
+				IsCA:       true,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			casecret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mysecret",
+					Namespace: env.Namespace,
+				},
+				Data: map[string][]byte{
+					"ca":  ca.Certificate,
+					"key": ca.PrivateKey,
+				},
+			}
+			tearDown, err := env.CreateSecret(env.Namespace, casecret)
+			Expect(err).NotTo(HaveOccurred())
+			tearDowns = append(tearDowns, tearDown)
 		})
-		Expect(err).ToNot(HaveOccurred())
 
-		// Create the CA secret
-		casecret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mysecret",
-				Namespace: env.Namespace,
-			},
-			Data: map[string][]byte{
-				"ca":  ca.Certificate,
-				"key": ca.PrivateKey,
-			},
-		}
-		tearDown, err := env.CreateSecret(env.Namespace, casecret)
-		Expect(err).NotTo(HaveOccurred())
-		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+		JustBeforeEach(func() {
+			By("creating the quarks secret")
+			var qs *qsv1a1.QuarksSecret
+			qs, tearDown, err := env.CreateQuarksSecret(env.Namespace, qSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(qs).NotTo(Equal(nil))
+			tearDowns = append(tearDowns, tearDown)
+		})
 
-		// Create an quarksSecret
-		var qs *qsv1a1.QuarksSecret
-		qSecret.Spec.SecretName = "generated-cert-secret"
-		qSecret.Spec.Type = "certificate"
-		qSecret.Spec.Request.CertificateRequest.CommonName = "example.com"
-		qSecret.Spec.Request.CertificateRequest.CARef = qsv1a1.SecretReference{Name: "mysecret", Key: "ca"}
-		qSecret.Spec.Request.CertificateRequest.CAKeyRef = qsv1a1.SecretReference{Name: "mysecret", Key: "key"}
-		qSecret.Spec.Request.CertificateRequest.AlternativeNames = []string{"qux.com"}
-		qs, tearDown, err = env.CreateQuarksSecret(env.Namespace, qSecret)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(qs).NotTo(Equal(nil))
-		defer func(tdf machine.TearDownFunc) { Expect(tdf()).To(Succeed()) }(tearDown)
+		AfterEach(func() {
+			Expect(env.TearDownAll(tearDowns)).To(Succeed())
+		})
 
-		// check for generated secret
-		secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(secret.Data["certificate"]).To(ContainSubstring("BEGIN CERTIFICATE"))
-		Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
+		It("creates the certificate", func() {
+			By("checking for the generated secret")
+			secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Data["certificate"]).To(ContainSubstring("BEGIN CERTIFICATE"))
+			Expect(secret.Data["private_key"]).To(ContainSubstring("RSA PRIVATE KEY"))
 
-		// delete QuarksSecret
-		err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
-		Expect(err).NotTo(HaveOccurred())
-		err = env.WaitForSecretDeletion(env.Namespace, "generated-cert-secret")
-		Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+			By("waiting for the generated secret to disappear, when deleting the quarks secret")
+			err = env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+			Expect(err).NotTo(HaveOccurred())
+			err = env.WaitForSecretDeletion(env.Namespace, "generated-cert-secret")
+			Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+		})
+
+		Context("when signer type is cluster", func() {
+			BeforeEach(func() {
+				qSecret.Spec.Request.CertificateRequest.SignerType = qsv1a1.ClusterSigner
+			})
+
+			It("updates existing secret", func() {
+				By("waiting for the generated secret")
+				oldSecret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
+				Expect(err).NotTo(HaveOccurred())
+
+				By("deleting quarks secret and generated secret")
+				env.DeleteQuarksSecret(env.Namespace, qSecret.Name)
+
+				err = env.WaitForSecretDeletion(env.Namespace, "generated-cert-secret")
+				Expect(err).NotTo(HaveOccurred(), "dependent secret not deleted")
+
+				By("creating an updated qsec")
+				qSecret.Spec.Request.CertificateRequest.AlternativeNames = []string{"qux.com", "example.org"}
+				_, _, err = env.CreateQuarksSecret(env.Namespace, qSecret)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("checking for a working generated secret")
+				secret, err := env.CollectSecret(env.Namespace, "generated-cert-secret")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(oldSecret.Data["ca"]).To(Equal(secret.Data["ca"]))
+				Expect(oldSecret.Data["private_key"]).NotTo(Equal(secret.Data["private_key"]))
+				Expect(oldSecret.Data["certificate"]).NotTo(Equal(secret.Data["certificate"]))
+			})
+		})
 	})
 })

--- a/pkg/kube/apis/quarkssecret/v1alpha1/types.go
+++ b/pkg/kube/apis/quarkssecret/v1alpha1/types.go
@@ -40,6 +40,8 @@ var (
 	LabelKind = fmt.Sprintf("%s/secret-kind", apis.GroupName)
 	// AnnotationCertSecretName is the annotation key for certificate secret name
 	AnnotationCertSecretName = fmt.Sprintf("%s/cert-secret-name", apis.GroupName)
+	// AnnotationQSecName is the annotation key for the name of the owning quarks secret
+	AnnotationQSecName = fmt.Sprintf("%s/quarks-secret-name", apis.GroupName)
 	// AnnotationQSecNamespace is the annotation key for quarks secret namespace
 	AnnotationQSecNamespace = fmt.Sprintf("%s/quarks-secret-namespace", apis.GroupName)
 	// LabelSecretRotationTrigger is set on a config map to trigger secret

--- a/pkg/kube/controllers/quarkssecret/certificatesigningrequest_controller.go
+++ b/pkg/kube/controllers/quarkssecret/certificatesigningrequest_controller.go
@@ -7,6 +7,7 @@ import (
 	certv1 "k8s.io/api/certificates/v1beta1"
 	certv1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -26,7 +27,7 @@ func AddCertificateSigningRequest(ctx context.Context, config *config.Config, mg
 	if err != nil {
 		return errors.Wrap(err, "Could not get kube client")
 	}
-	r := NewCertificateSigningRequestReconciler(ctx, config, mgr, certClient)
+	r := NewCertificateSigningRequestReconciler(ctx, config, mgr, certClient, controllerutil.SetControllerReference)
 
 	// Create a new controller
 	c, err := controller.New("certificate-signing-request-controller", mgr, controller.Options{

--- a/testing/catalog_qsecv1.go
+++ b/testing/catalog_qsecv1.go
@@ -22,6 +22,27 @@ func (c *Catalog) DefaultQuarksSecret(name string) qsv1a1.QuarksSecret {
 	}
 }
 
+// CertificateQuarksSecret for use in tests, creates a certificate
+func (c *Catalog) CertificateQuarksSecret(name string, secretref string, cacertref string, keyref string) qsv1a1.QuarksSecret {
+	return qsv1a1.QuarksSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: qsv1a1.QuarksSecretSpec{
+			SecretName: "generated-cert-secret",
+			Type:       "certificate",
+			Request: qsv1a1.Request{
+				CertificateRequest: qsv1a1.CertificateRequest{
+					CommonName:       "example.com",
+					CARef:            qsv1a1.SecretReference{Name: secretref, Key: cacertref},
+					CAKeyRef:         qsv1a1.SecretReference{Name: secretref, Key: keyref},
+					AlternativeNames: []string{"qux.com"},
+				},
+			},
+		},
+	}
+}
+
 // RotationConfig is a config map, which triggers secret rotation
 func (c *Catalog) RotationConfig(name string) corev1.ConfigMap {
 	return corev1.ConfigMap{


### PR DESCRIPTION
If the quarks secret signer type is set to cluster, a CSR is created
instead of directly creating a certificate. Kubernetes will create a
cert and private key for that  CSR. The
certificatesigningrequest reconciler takes these values and writes them
into the "certificate secret". The private key was deleted afterwards,
the CSR was not. Now both are deleted.

Additionally the owner was not set on the certificate secret, since the
CSR is a cluster wide resource. The owner is now set to the quarks
secret, so that the certificate secret is cleaned up properly.

[#171530959](https://www.pivotaltracker.com/story/show/171530959)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
