### PR TITLE
Run cf-operator as numeric user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base
 RUN groupadd -g 1000 vcap && \
     useradd -r -u 1000 -g vcap vcap
 RUN cp /usr/sbin/dumb-init /usr/bin/dumb-init
-USER vcap
+USER 1000
 COPY --from=build /usr/local/bin/cf-operator /usr/local/bin/cf-operator
 COPY --from=build /usr/local/bin/container-run /usr/local/bin/container-run
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "cf-operator"]


### PR DESCRIPTION
## Description
In order to run cf-operator right now, you need a permissive PSP in the cluster which allows it to run as root. Even though you are running it as `vcap`, Kubernetes PSPs can only validate against numeric user ids.


## Motivation and Context
cf-operator cannot be run without providing an additional permissive PSP. This can be easily avoided with this change. 

## How Has This Been Tested?
It hasn't been tested with cf-operator, but it should work because it's a Kubernetes feature anyway.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

cc @herrjulz