### PR TITLE
Remove bosh manifest pkg dependency from statefulset controller

### DIFF
--- a/pkg/bosh/manifest/update_watch_time.go
+++ b/pkg/bosh/manifest/update_watch_time.go
@@ -1,0 +1,26 @@
+package manifest
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ExtractWatchTime computes the watch time from a range or an absolute value
+// This parses the time string used in the BOSH manifest's update config:
+// https://bosh.io/docs/manifest-v2/#update
+func ExtractWatchTime(rawWatchTime string) (string, error) {
+	if rawWatchTime == "" {
+		return "", nil
+	}
+
+	rangeRegex := regexp.MustCompile(`^\s*(\d+)\s*-\s*(\d+)\s*$`) // https://github.com/cloudfoundry/bosh/blob/914edca5278b994df7d91620c4f55f1c6665f81c/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb#L128
+	if matches := rangeRegex.FindStringSubmatch(rawWatchTime); len(matches) > 0 {
+		// Ignore the lower boundary, because the API-Server triggers reconciles
+		return matches[2], nil
+	}
+	absoluteRegex := regexp.MustCompile(`^\s*(\d+)\s*$`) // https://github.com/cloudfoundry/bosh/blob/914edca5278b994df7d91620c4f55f1c6665f81c/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb#L130
+	if matches := absoluteRegex.FindStringSubmatch(rawWatchTime); len(matches) > 0 {
+		return matches[1], nil
+	}
+	return "", fmt.Errorf("watch time string did not match regexp: %s", rawWatchTime)
+}

--- a/pkg/kube/controllers/statefulset/statefulset_rollout_util.go
+++ b/pkg/kube/controllers/statefulset/statefulset_rollout_util.go
@@ -3,7 +3,6 @@ package statefulset
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	crc "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"code.cloudfoundry.org/cf-operator/pkg/bosh/manifest"
 	bdv1 "code.cloudfoundry.org/cf-operator/pkg/kube/apis/boshdeployment/v1alpha1"
 	"code.cloudfoundry.org/cf-operator/pkg/kube/util"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
@@ -51,54 +49,6 @@ func FilterLabels(labels map[string]string) map[string]string {
 		}
 	}
 	return statefulSetLabels
-}
-
-//ComputeAnnotations computes annotations from the instance group
-func ComputeAnnotations(ig *manifest.InstanceGroup) (map[string]string, error) {
-	statefulSetAnnotations := ig.Env.AgentEnvBoshConfig.Agent.Settings.Annotations
-	if statefulSetAnnotations == nil {
-		statefulSetAnnotations = make(map[string]string)
-	}
-	if ig.Update == nil {
-		return statefulSetAnnotations, nil
-	}
-
-	canaryWatchTime, err := ExtractWatchTime(ig.Update.CanaryWatchTime, "canary_watch_time")
-	if err != nil {
-		return nil, err
-	}
-	if canaryWatchTime != "" {
-		statefulSetAnnotations[AnnotationCanaryWatchTime] = canaryWatchTime
-	}
-
-	updateWatchTime, err := ExtractWatchTime(ig.Update.UpdateWatchTime, "update_watch_time")
-	if err != nil {
-		return nil, err
-	}
-
-	if updateWatchTime != "" {
-		statefulSetAnnotations[AnnotationUpdateWatchTime] = updateWatchTime
-	}
-
-	return statefulSetAnnotations, nil
-}
-
-//ExtractWatchTime computes the watch time from a range or an absolute value
-func ExtractWatchTime(rawWatchTime string, field string) (string, error) {
-	if rawWatchTime == "" {
-		return "", nil
-	}
-
-	rangeRegex := regexp.MustCompile(`^\s*(\d+)\s*-\s*(\d+)\s*$`) // https://github.com/cloudfoundry/bosh/blob/914edca5278b994df7d91620c4f55f1c6665f81c/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb#L128
-	if matches := rangeRegex.FindStringSubmatch(rawWatchTime); len(matches) > 0 {
-		// Ignore the lower boundary, because the API-Server triggers reconciles
-		return matches[2], nil
-	}
-	absoluteRegex := regexp.MustCompile(`^\s*(\d+)\s*$`) // https://github.com/cloudfoundry/bosh/blob/914edca5278b994df7d91620c4f55f1c6665f81c/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb#L130
-	if matches := absoluteRegex.FindStringSubmatch(rawWatchTime); len(matches) > 0 {
-		return matches[1], nil
-	}
-	return "", fmt.Errorf("invalid %s", field)
 }
 
 // CleanupNonReadyPod deletes all pods, that are not ready


### PR DESCRIPTION
The controller should be usable without knowledge of the BOSH manifest.

[#171842803](https://www.pivotaltracker.com/story/show/171842803)
