### PR TITLE
Do not restart errands on failure

### DIFF
--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -331,6 +331,12 @@ func (kc *BPMConverter) errandToQuarksJob(
 		strategy = qjv1a1.TriggerOnce
 	}
 
+	restartPolicy := corev1.RestartPolicyOnFailure
+	if instanceGroup.LifeCycle == bdm.IGTypeErrand {
+		// Manually triggered errands are not auto-restarted
+		restartPolicy = corev1.RestartPolicyNever
+	}
+
 	qJob := qjv1a1.QuarksJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        instanceGroup.Name,
@@ -351,7 +357,7 @@ func (kc *BPMConverter) errandToQuarksJob(
 							Annotations: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Annotations,
 						},
 						Spec: corev1.PodSpec{
-							RestartPolicy:  corev1.RestartPolicyOnFailure,
+							RestartPolicy:  restartPolicy,
 							Containers:     containers,
 							InitContainers: initContainers,
 							Volumes:        volumes,

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -113,6 +113,8 @@ var _ = Describe("BPM Converter", func() {
 					// Test affinity & tolerations
 					Expect(qJob.Spec.Template.Spec.Template.Spec.Affinity).To(BeNil())
 					Expect(len(qJob.Spec.Template.Spec.Template.Spec.Tolerations)).To(Equal(0))
+
+					Expect(qJob.Spec.Template.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
 				})
 
 				It("converts the instance group to an quarksJob when this the lifecycle is set to auto-errand", func() {
@@ -124,6 +126,8 @@ var _ = Describe("BPM Converter", func() {
 					// Test trigger strategy
 					qJob := resources.Errands[0]
 					Expect(qJob.Spec.Trigger.Strategy).To(Equal(qjv1a1.TriggerOnce))
+
+					Expect(qJob.Spec.Template.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
 				})
 
 				It("converts the AgentEnvBoshConfig information", func() {


### PR DESCRIPTION
## Description
Change the job templates so that errands do not restart on failure.  Auto-errands will continue to restart on failure.

I'm totally open to discussion on if a change somewhere else is appropriate (e.g. if restart-never should be opt-in via job properties).

## Motivation and Context
Fixes cloudfoundry-incubator/kubecf#324 — manually triggered tests were automatically restarting, making it difficult to read the error logs or otherwise inspect results.

## How Has This Been Tested?
`make test` locally (minikube).  Unit test has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is technically breaking; not sure there are any consumers that care.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
