### PR TITLE
fix: remove service.cf.internal from DNS search

### DIFF
--- a/pkg/kube/util/boshdns/dns.go
+++ b/pkg/kube/util/boshdns/dns.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	cfDomain = "service.cf.internal"
-	appName  = "bosh-dns"
+	appName = "bosh-dns"
 )
 
 var (
@@ -135,7 +134,6 @@ func (dns *boshDomainNameService) DNSSetting(namespace string) (corev1.DNSPolicy
 			fmt.Sprintf("%s.svc.%s", namespace, clusterDomain),
 			fmt.Sprintf("svc.%s", clusterDomain),
 			clusterDomain,
-			cfDomain,
 		},
 		Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &ndots}},
 	}, nil


### PR DESCRIPTION
## Description

Since CF always use explicit domains, adding service.cf.internal can only confuse the domain name resolution. In fact, it broke one of the KubeCF installations on a bare-metal 1.17.4 k8s cluster.

## Motivation and Context

Got the following from a k8s 1.17.4 cluster:

```
+ /var/vcap/jobs/routing-api/bin/bpm-pre-start
Host uaa.service.cf.internal.service.cf.internal not found: 2(SERVFAIL)
DNS is not up
```

## How Has This Been Tested?

On the same cluster that it failed, with the removal of this specific search entry, the deployment succeeded and passed smoke-tests, SITS and CATS.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
