### PR TITLE
Fix missing quarks properties if a bpm template doesn't exist

### DIFF
--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -325,12 +325,11 @@ func (igr *InstanceGroupResolver) renderBPM() error {
 			return errors.Wrapf(err, "Rendering BPM failed for instance group %s", igr.instanceGroup.Name)
 		}
 
-		if template != "" {
-			err = igr.renderJobBPM(job, jobSpecFile, template)
-			if err != nil {
-				return errors.Wrapf(err, "Rendering BPM failed for instance group %s", igr.instanceGroup.Name)
-			}
+		err = igr.renderJobBPM(job, jobSpecFile, template)
+		if err != nil {
+			return errors.Wrapf(err, "Rendering BPM failed for instance group %s", igr.instanceGroup.Name)
 		}
+
 	}
 
 	return nil
@@ -385,46 +384,51 @@ func (igr *InstanceGroupResolver) renderJobBPM(currentJob *Job, jobSpecFile stri
 
 	jobIndexBPM := make([]bpm.Config, len(jobInstances))
 	for i, jobInstance := range jobInstances {
+		var renderedBPM = bpm.Config{}
+		var err error
+
 		properties := currentJob.Properties.ToMap()
 
-		renderPointer := btg.NewERBRenderer(
-			&btg.EvaluationContext{
-				Properties: properties,
-			},
-			&btg.InstanceInfo{
-				Address:    jobInstance.Address,
-				AZ:         jobInstance.AZ,
-				Bootstrap:  jobInstance.Bootstrap,
-				ID:         jobInstance.ID,
-				Index:      jobInstance.Index,
-				Deployment: igr.deploymentName,
-				Name:       jobInstance.Name,
-			},
-			jobSpecFile,
-		)
+		if erbFilePath != "" {
+			renderPointer := btg.NewERBRenderer(
+				&btg.EvaluationContext{
+					Properties: properties,
+				},
+				&btg.InstanceInfo{
+					Address:    jobInstance.Address,
+					AZ:         jobInstance.AZ,
+					Bootstrap:  jobInstance.Bootstrap,
+					ID:         jobInstance.ID,
+					Index:      jobInstance.Index,
+					Deployment: igr.deploymentName,
+					Name:       jobInstance.Name,
+				},
+				jobSpecFile,
+			)
 
-		// Write to a tmp, this is following the conventions on how the
-		// https://github.com/viovanov/bosh-template-go/ processes the params
-		// when we calling the *.Render().
-		tmpfile, err := ioutil.TempFile("", "rendered.*.yml")
-		if err != nil {
-			return errors.Wrapf(err, "Creation of tmp file %s failed", tmpfile.Name())
-		}
-		defer os.Remove(tmpfile.Name())
+			// Write to a tmp, this is following the conventions on how the
+			// https://github.com/viovanov/bosh-template-go/ processes the params
+			// when we calling the *.Render().
+			tmpfile, err := ioutil.TempFile("", "rendered.*.yml")
+			if err != nil {
+				return errors.Wrapf(err, "Creation of tmp file %s failed", tmpfile.Name())
+			}
+			defer os.Remove(tmpfile.Name())
 
-		if err := renderPointer.Render(erbFilePath, tmpfile.Name()); err != nil {
-			return errors.Wrapf(err, "Rendering file %s failed", erbFilePath)
-		}
+			if err := renderPointer.Render(erbFilePath, tmpfile.Name()); err != nil {
+				return errors.Wrapf(err, "Rendering file %s failed", erbFilePath)
+			}
 
-		bpmBytes, err := ioutil.ReadFile(tmpfile.Name())
-		if err != nil {
-			return errors.Wrapf(err, "Reading of tmp file %s failed", tmpfile.Name())
-		}
+			bpmBytes, err := ioutil.ReadFile(tmpfile.Name())
+			if err != nil {
+				return errors.Wrapf(err, "Reading of tmp file %s failed", tmpfile.Name())
+			}
 
-		// Parse a rendered bpm.yml into the bpm Config struct.
-		renderedBPM, err := bpm.NewConfig(bpmBytes)
-		if err != nil {
-			return errors.Wrapf(err, "Rendering bpm.yaml into bpm config %s failed", string(bpmBytes))
+			// Parse a rendered bpm.yml into the bpm Config struct.
+			renderedBPM, err = bpm.NewConfig(bpmBytes)
+			if err != nil {
+				return errors.Wrapf(err, "Rendering bpm.yaml into bpm config %s failed", string(bpmBytes))
+			}
 		}
 
 		// Merge processes if they also exist in Quarks

--- a/pkg/bosh/manifest/cmd_instance_group_resolver.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver.go
@@ -325,11 +325,9 @@ func (igr *InstanceGroupResolver) renderBPM() error {
 			return errors.Wrapf(err, "Rendering BPM failed for instance group %s", igr.instanceGroup.Name)
 		}
 
-		err = igr.renderJobBPM(job, jobSpecFile, template)
-		if err != nil {
+		if err := igr.renderJobBPM(job, jobSpecFile, template); err != nil {
 			return errors.Wrapf(err, "Rendering BPM failed for instance group %s", igr.instanceGroup.Name)
 		}
-
 	}
 
 	return nil
@@ -385,7 +383,6 @@ func (igr *InstanceGroupResolver) renderJobBPM(currentJob *Job, jobSpecFile stri
 	jobIndexBPM := make([]bpm.Config, len(jobInstances))
 	for i, jobInstance := range jobInstances {
 		var renderedBPM = bpm.Config{}
-		var err error
 
 		properties := currentJob.Properties.ToMap()
 
@@ -433,6 +430,7 @@ func (igr *InstanceGroupResolver) renderJobBPM(currentJob *Job, jobSpecFile stri
 
 		// Merge processes if they also exist in Quarks
 		if currentJob.Properties.Quarks.BPM != nil && len(currentJob.Properties.Quarks.BPM.Processes) > 0 {
+			var err error
 			renderedBPM.Processes, err = renderedBPM.MergeProcesses(currentJob.Properties.Quarks.BPM.Processes)
 			if err != nil {
 				return errors.Wrapf(err, "failed to merge bpm information from quarks for job '%s'", currentJob.Name)

--- a/testing/assets/jobs-src/loggregator-agent/loggr-forwarder-agent/job.MF
+++ b/testing/assets/jobs-src/loggregator-agent/loggr-forwarder-agent/job.MF
@@ -1,0 +1,61 @@
+---
+name: loggr-forwarder-agent
+
+templates:
+  bpm.yml.erb: config/bpm.yml
+  prom_scraper_config.yml.erb: config/prom_scraper_config.yml
+  loggregator_ca.crt.erb: config/certs/loggregator_ca.crt
+  forwarder.crt.erb: config/certs/forwarder.crt
+  forwarder.key.erb: config/certs/forwarder.key
+  metrics_ca.crt.erb: config/certs/metrics_ca.crt
+  metrics.crt.erb: config/certs/metrics.crt
+  metrics.key.erb: config/certs/metrics.key
+
+packages:
+- forwarder-agent
+
+properties:
+  port:
+    description: "Port the agent is serving gRPC via mTLS"
+    default: 3458
+  downstream_ingress_port_glob:
+    description: |
+      Files matching the glob are expected to contain ports of downstream
+      consumers that will be bound to 127.0.0.1:{port} with the provided
+      mTLS configuration. The forwarder assumes the downstream server is
+      serving Loggregator's V2 IngressService. See code.cloudfoundry.org/loggregator-api.
+    default: /var/vcap/jobs/*/config/ingress_port.yml
+
+  deployment:
+    description: "Name of deployment (added as tag on all outgoing v1 envelopes)"
+    default: ""
+  tags:
+    description: "Collection of tags to add on all outgoing v2 envelopes. Bosh deployment, job, index and IP will be merged with this property if they are not provided"
+    default: {}
+    example: {"deployment": "cf"}
+
+  tls.ca_cert:
+    description: |
+      TLS loggregator root CA certificate. It is required for key/cert
+      verification.
+  tls.cert:
+    description: "TLS certificate for forwarder signed by the loggregator CA"
+  tls.key:
+    description: "TLS private key for forwarder signed by the loggregator CA"
+  tls.cipher_suites:
+    description: |
+      An ordered list of supported SSL cipher suites. Allowed cipher suites are
+      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.
+    default: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+
+  metrics.port:
+    description: "Port the agent uses to serve metrics and debug information"
+    default: 14823
+  metrics.ca_cert:
+    description: "TLS CA cert to verify requests to metrics endpoint."
+  metrics.cert:
+    description: "TLS certificate for metrics server signed by the metrics CA"
+  metrics.key:
+    description: "TLS private key for metrics server signed by the metrics CA"
+  metrics.server_name:
+    description: "The server name used in the scrape configuration for the metrics endpoint"

--- a/testing/assets/jobs-src/loggregator-agent/loggregator_agent/job.MF
+++ b/testing/assets/jobs-src/loggregator-agent/loggregator_agent/job.MF
@@ -1,0 +1,80 @@
+---
+name: loggregator_agent
+
+provides:
+- name: loggregator_agent
+  type: loggregator_agent
+  properties:
+  - listening_port
+  - grpc_port
+
+consumes:
+- name: doppler
+  type: doppler
+
+templates:
+  bpm.yml.erb: config/bpm.yml
+  ingress_port.yml.erb: config/ingress_port.yml
+  prom_scraper_config.yml.erb: config/prom_scraper_config.yml
+  loggregator_agent.crt.erb: config/certs/loggregator_agent.crt
+  loggregator_agent.key.erb: config/certs/loggregator_agent.key
+  loggregator_ca.crt.erb: config/certs/loggregator_ca.crt
+  metrics_ca.crt.erb: config/certs/metrics_ca.crt
+  metrics.crt.erb: config/certs/metrics.crt
+  metrics.key.erb: config/certs/metrics.key
+
+packages:
+- loggregator_agent
+
+properties:
+  enabled:
+    description: "Enable v1 Firehose and v2 Logstream"
+    default: true
+  disable_udp:
+    description: "Disable incoming UDP"
+    default: false
+  listening_port:
+    description: "Port the agent is listening on to receive dropsonde log messages"
+    default: 3457
+  grpc_port:
+    description: "Port the agent is listening on to receive gRPC log envelopes"
+    default: 3458
+  zone:
+    description: "Availability zone where this agent is running"
+    default: ""
+  deployment:
+    description: "Name of deployment (added as tag on all outgoing v1 envelopes)"
+    default: ""
+  tags:
+    description: "Collection of tags to add on all outgoing v2 envelopes. Bosh deployment, job, index and IP will be merged with this property if they are not provided"
+    default: {}
+    example: {"deployment": "cf"}
+
+  doppler.grpc_port:
+    description: Port for outgoing log messages via GRPC
+    default: 8082
+
+  loggregator.tls.ca_cert:
+    description: "CA root required for key/cert verification"
+  loggregator.tls.agent.cert:
+    description: "TLS certificate for agent"
+  loggregator.tls.agent.key:
+    description: "TLS key for agent"
+  loggregator.tls.cipher_suites:
+    description: |
+      An ordered list of supported SSL cipher suites. Allowed cipher suites are
+      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.
+    default: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+
+  metrics.port:
+    description: "Port the agent uses to serve metrics and debug information"
+    default: 14824
+  metrics.ca_cert:
+    description: "TLS CA cert to verify requests to metrics endpoint."
+  metrics.cert:
+    description: "TLS certificate for metrics server signed by the metrics CA"
+  metrics.key:
+    description: "TLS private key for metrics server signed by the metrics CA"
+  metrics.server_name:
+    description: "The server name used in the scrape configuration for the metrics endpoint"
+  

--- a/testing/assets/jobs-src/postgres/postgres/job.MF
+++ b/testing/assets/jobs-src/postgres/postgres/job.MF
@@ -1,0 +1,133 @@
+---
+name: postgres
+
+description: "The Postgres server provides a single instance Postgres database that can be used with the Cloud Controller or the UAA. It does not provide highly-available configuration."
+
+templates:
+  pre-start.sh.erb: bin/pre-start
+  postgres_ctl.sh.erb: bin/postgres_ctl
+  pg_janitor_ctl.sh.erb: bin/pg_janitor_ctl
+  pg_janitor.sh.erb: bin/pg_janitor.sh
+  postgres_start.sh.erb: bin/postgres_start.sh
+  pgconfig.sh.erb: bin/pgconfig.sh
+  utils.sh.erb: bin/utils.sh
+  postgresql.conf.erb: config/postgresql.conf
+  pg_hba.conf.erb: config/pg_hba.conf
+  pg_ident.conf.erb: config/pg_ident.conf
+  roles.sql.erb: config/roles.sql
+  server.private_key.erb: config/certificates/server.private_key
+  server.public_cert.erb: config/certificates/server.public_cert
+  server.ca_cert.erb: config/certificates/server.ca_cert
+  hooks/call-hooks.sh.erb: bin/hooks/call-hooks.sh
+  hooks/postgres-pre-start.sh.erb: bin/hooks/postgres-pre-start.sh
+  hooks/janitor.sh.erb: bin/hooks/janitor.sh
+  hooks/postgres-pre-stop.sh.erb: bin/hooks/postgres-pre-stop.sh
+  hooks/postgres-post-start.sh.erb: bin/hooks/postgres-post-start.sh
+  hooks/postgres-post-stop.sh.erb: bin/hooks/postgres-post-stop.sh
+
+packages:
+  - postgres-common
+  - postgres-9.6.10
+  - postgres-11.5
+
+provides:
+- name: postgres
+  type: database
+  properties:
+  - databases.port
+  - databases.databases
+  - databases.roles
+  - databases.tls.ca
+
+properties:
+  databases.port:
+    description: "The database port"
+    default: 5432
+  databases.databases:
+    description: "A list of databases and associated properties to create"
+    example: |
+      - name: sandbox
+        citext: true
+      - name: sandbox2
+        citext: false
+  databases.roles:
+    description: "A list of database roles and associated properties to create"
+    example: |
+      - name: pgadmin
+        password: passwd
+        permissions:
+        - "CONNECTION LIMIT 33"
+      - name: bud_spencer
+        common_name: "Carlo Pedersoli"
+  databases.max_connections:
+    description: "Maximum number of database connections"
+    default: 500
+  databases.log_line_prefix:
+    description: "The postgres `printf` style string that is output at the beginning of each log line"
+    default: "%m: "
+  databases.collect_statement_statistics:
+    description: "Enable the `pg_stat_statements` extension and collect statement execution statistics"
+    default: false
+  databases.additional_config:
+    description: "A map of additional key/value pairs to include as extra configuration properties"
+    example: |
+      shared_buffers: 4GB
+  databases.monit_timeout:
+    description: "Monit timout in seconds for the postgres job start. If not specified, no timeout statement will be added so that the global monit timeout applies."
+    default: 90
+  databases.tls.ca:
+    description: "PEM-encoded certification authority for secure TLS communication"
+    default: ''
+  databases.tls.certificate:
+    description: "PEM-encoded certificate for secure TLS communication"
+    default: ''
+  databases.tls.private_key:
+    description: "PEM-encoded key for secure TLS communication"
+    default: ''
+  databases.trust_local_connections:
+    description: Whether to trust or not local connections. Note that vcap is always trusted.
+    default: true
+  databases.skip_data_copy_in_minor:
+    description: "If false, during a PostgreSQL minor upgrade a copy of the data directory is created."
+    default: false
+  databases.hooks.timeout:
+    description: "Time limit in seconds for the hook script. By default it's set to 0 that means no time limit"
+    default: 0
+  databases.hooks.pre_start:
+    description: "Script to run before starting PostgreSQL"
+    default: ''
+    example: |
+      #!/bin/bash
+      echo "Going to start Postgres"
+      echo "PostgreSQL data directory is ${DATA_DIR}"
+      echo "PostgreSQL port is ${PORT}"
+      echo "Package directory is ${PACKAGE_DIR}"
+  databases.hooks.post_start:
+    description: "Script to run after PostgreSQL has started"
+    default: ''
+    example: |
+      #!/bin/bash
+      echo "The following databases are available:"
+      ${PACKAGE_DIR}/bin/psql -p ${PORT} -U vcap postgres -c "\l"
+  databases.hooks.pre_stop:
+    description: "Script to run before stopping PostgreSQL"
+    default: ''
+  databases.hooks.post_stop:
+    description: "Script to run after PostgreSQL has stopped"
+    default: ''
+  databases.enable_trace:
+    description: "Print additional traces in control scripts"
+    default: false
+  janitor.script:
+    description: "If specified, janitor would periodically run this script"
+    default: ''
+    example: |
+      #!/bin/bash
+      echo "Run VACUUM"
+      ${PACKAGE_DIR}/bin/psql -p ${PORT} -U vcap sandbox -c "VACUUM ANALYZE"
+  janitor.interval:
+    description: "Interval in seconds between two invocations of the janitor script. By default it's set to 1 day."
+    default: 86400
+  janitor.timeout:
+    description: "Time limit in seconds for the janitor script. By default it's set to 0 that means no time limit"
+    default: 0

--- a/testing/boshmanifest/manifests_regressions.go
+++ b/testing/boshmanifest/manifests_regressions.go
@@ -1,0 +1,134 @@
+package boshmanifest
+
+// The manifests in this file are only used in unit tests.  They might not be
+// completely valid, miss implicit variables and docker images are may not be
+// available.
+
+// They represent specific scenarios for past bugs
+
+// FromKubeCF641 is a manifest generated for KubeCF by the operator, which resulted in ports
+// not being generated in BPM secrets, which led to services not being created
+// https://github.com/cloudfoundry-incubator/kubecf/pull/641
+const FromKubeCF641 = `
+addons_applied: true
+director_uuid: ""
+instance_groups:
+- azs: []
+  env:
+    bosh:
+      agent:
+        settings: {}
+      ipv6:
+        enable: false
+  instances: 1
+  jobs:
+  - name: postgres
+    properties:
+      databases:
+        databases:
+        - name: autoscaler
+          tag: default
+        port: 5432
+        roles:
+        - name: postgres
+          password: YUskRrXgEN3exESmKAkK4GEmyt5YXUsg9MBGky5A5zFlX9aWFQxJW19zC5E2ymFG
+          tag: default
+        tls:
+          ca: ca2c629d0ed294dcb4d0a92eb7ecefe2b14f7ede
+          certificate: e9555d89370eeeb28b45fbbb3baa89cd61fab4d4
+          private_key: 829f9baab55b5dfd2358b1da12c7181fa45c7701
+      quarks:
+        bpm:
+          activePassiveProbes: {}
+          debug: false
+          post_start: {}
+          processes:
+          - args:
+            - '-'
+            - vcap
+            - -c
+            - |-
+              #!/usr/bin/env bash
+
+              set -o errexit -o nounset
+
+              wait_for_file() {
+                local file_path="$1"
+                local timeout="${2:-30}"
+                timeout "${timeout}" bash -c "until [[ -f '${file_path}' ]]; do sleep 1; done"
+                return 0
+              }
+
+              # shellcheck disable=SC1091
+              source /var/vcap/jobs/postgres/bin/pgconfig.sh
+
+              # fixes permissions issue for autoscaler db.
+              # https://github.com/cloudfoundry-incubator/kubecf/issues/408
+              chmod --recursive 0700 /var/vcap/store/postgres/
+
+              /var/vcap/jobs/postgres/bin/postgres_ctl start
+              wait_for_file "${PIDFILE}" || {
+                echo "${PIDFILE} did not get created"
+                exit 1
+              }
+              trap '/var/vcap/jobs/postgres/bin/postgres_ctl stop' EXIT
+
+              /var/vcap/jobs/postgres/bin/pg_janitor_ctl start &
+
+              tail \
+                --pid "$(cat "${PIDFILE}")" \
+                --follow \
+                "${LOG_DIR}/startup.log" \
+                "${LOG_DIR}/pg_janitor_ctl.log" \
+                "${LOG_DIR}/pg_janitor_ctl.err.log"
+            executable: /usr/bin/su
+            hooks: {}
+            limits:
+              open_files: 1048576
+            name: postgres
+            persistent_disk: true
+            unsafe: {}
+          run:
+            healthcheck: {}
+            security_context: null
+          unsupported_template: false
+        consumes: {}
+        debug: false
+        envs: []
+        instances: []
+        is_addon: false
+        ports:
+        - internal: 5432
+          name: postgres
+          protocol: TCP
+        post_start: {}
+        pre_render_scripts:
+          bpm: []
+          ig_resolver: []
+          jobs: []
+        release: ""
+        run:
+          healthcheck:
+            postgres:
+              liveness: null
+              readiness:
+                exec:
+                  command:
+                  - /var/vcap/packages/postgres-11.5/bin/pg_isready
+          security_context: null
+    release: postgres
+  name: asdatabase
+  networks:
+  - name: default
+  persistent_disk: 20480
+  properties:
+    quarks: {}
+  stemcell: default
+  update:
+    canaries: 1
+    canary_watch_time: 30000-1200000
+    max_in_flight: "1"
+    serial: false
+    update_watch_time: 5000-1200000
+  vm_resources: null
+`

--- a/testing/catalog.go
+++ b/testing/catalog.go
@@ -87,6 +87,15 @@ func (c *Catalog) BOSHManifestWithProviderAndConsumer() (*manifest.Manifest, err
 	return m, nil
 }
 
+// BOSHManifestFromKubeCF641 for "real-life" tests
+func (c *Catalog) BOSHManifestFromKubeCF641() (*manifest.Manifest, error) {
+	m, err := manifest.LoadYAML([]byte(bm.FromKubeCF641))
+	if err != nil {
+		return &manifest.Manifest{}, errors.Wrapf(err, manifestFailedMessage)
+	}
+	return m, nil
+}
+
 // BOSHManifestWithOverriddenBPMInfo for data gathering tests
 func (c *Catalog) BOSHManifestWithOverriddenBPMInfo() (*manifest.Manifest, error) {
 	m, err := manifest.LoadYAML([]byte(bm.WithOverriddenBPMInfo))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If a job was missing a BPM template, other properties from `quarks.*` wouldn't be merged into final BPM data.

## Motivation and Context
See https://github.com/cloudfoundry-incubator/kubecf/pull/641

## How Has This Been Tested?
A new regression test with a deployment manifest coming from KubeCF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
