### PR TITLE
Backoff limit for errands should be configurable

### DIFF
--- a/bin/include/dependencies
+++ b/bin/include/dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git_sha="491e84a"
+git_sha="770abf2"
 quarks_job_release="v0.0.0-0.g$git_sha"
 quarks_job_helm_release="0.0.0+0.g$git_sha"
 

--- a/docs/from_bosh_to_kube.md
+++ b/docs/from_bosh_to_kube.md
@@ -313,6 +313,9 @@ instance_groups:
           # on the QuarksStatefulSet of the instance group, and it will use that PVC for all volume
           # mounts for ephemeral disks
           ephemeralAsPVC: false
+          # This sets the backoffLimit for the jobs running errands. If not set, it will use the Kube default which is 6.
+          # https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#handling-pod-and-container-failures
+          jobBackoffLimit: 6
           # An array of disks to be mounted on the containers
           disks:
             # A PersistentVolumeClaim to be used as a template in the StatefulSet of the instance group.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/cf-operator
 
 require (
-	code.cloudfoundry.org/quarks-job v0.0.0-20200402132051-aa1b50c5cc0c
+	code.cloudfoundry.org/quarks-job v0.0.0-20200413001825-770abf29e906
 	code.cloudfoundry.org/quarks-utils v0.0.0-20200331122601-bc0838ffea60
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 code.cloudfoundry.org/quarks-job v0.0.0-20200402132051-aa1b50c5cc0c h1:W12orAahE0oN5UQK0SFu0BZAgA6FQz7x62pf8zMH9Iw=
 code.cloudfoundry.org/quarks-job v0.0.0-20200402132051-aa1b50c5cc0c/go.mod h1:sUVpg32Ks2/cIxsN0Jn0jzqUF70Sv8uB9ndXSf9z5+8=
+code.cloudfoundry.org/quarks-job v0.0.0-20200412181021-b0f08870818a h1:sD4j8+ryw7PriVq8vU7xjN3oZHpnpBwatoPg4ZUwQF4=
+code.cloudfoundry.org/quarks-job v0.0.0-20200412181021-b0f08870818a/go.mod h1:sUVpg32Ks2/cIxsN0Jn0jzqUF70Sv8uB9ndXSf9z5+8=
+code.cloudfoundry.org/quarks-job v0.0.0-20200413001825-770abf29e906 h1:/E5aUwMcPreis3UK4PtotpHQHRKFLP79NIuBb0EWL1k=
+code.cloudfoundry.org/quarks-job v0.0.0-20200413001825-770abf29e906/go.mod h1:sUVpg32Ks2/cIxsN0Jn0jzqUF70Sv8uB9ndXSf9z5+8=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200331122601-bc0838ffea60 h1:1FNLU6zVwDXkLXvJS7RvSScxNpO01NfyiR6Za9Un5Cg=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200331122601-bc0838ffea60/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=

--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -350,6 +350,7 @@ func (kc *BPMConverter) errandToQuarksJob(
 			},
 			Template: batchv1b1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
+					BackoffLimit: instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.JobBackoffLimit,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        instanceGroup.Name,

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -230,6 +230,7 @@ type AgentSettings struct {
 	Tolerations                  []corev1.Toleration           `json:"tolerations,omitempty"`
 	EphemeralAsPVC               bool                          `json:"ephemeralAsPVC,omitempty"`
 	Disks                        Disks                         `json:"disks,omitempty"`
+	JobBackoffLimit              *int32                        `json:"jobBackoffLimit,omitempty"`
 }
 
 // Set overrides labels and annotations with operator-owned metadata.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Errands would always be re-run on failure. This allows users to set a custom `backoffLimit`  for jobs.
Also bumps quarks-job to fix #878 

## Motivation and Context
Failing test errands on kubecf don't need to be re-run.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
