### PR TITLE
Don't delete successful errand pods by default

### DIFF
--- a/pkg/bosh/bpmconverter/resources.go
+++ b/pkg/bosh/bpmconverter/resources.go
@@ -317,8 +317,6 @@ func (kc *BPMConverter) errandToQuarksJob(
 	}
 
 	podLabels := instanceGroup.Env.AgentEnvBoshConfig.Agent.Settings.Labels
-	// Controller will delete successful job
-	podLabels["delete"] = "pod"
 
 	defaultVolumes := defaultDisks.Volumes()
 	bpmVolumes := bpmDisks.Volumes()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pods belonging to errands should not be deleted by default.

## Motivation and Context
This default behavior was not configurable.
Users can still add this behavior by configuring a `delete=pod` label for the instance group.

## How Has This Been Tested?
Unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
