### PR TITLE
fix: Permissions and ownership for copied secrets

### DIFF
--- a/deploy/helm/cf-operator/templates/cluster-role.yaml
+++ b/deploy/helm/cf-operator/templates/cluster-role.yaml
@@ -17,6 +17,14 @@ rules:
   - watch
 
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+
+- apiGroups:
   - certificates.k8s.io
   resources:
   - certificatesigningrequests/approval

--- a/docs/controllers/quarks_secret.md
+++ b/docs/controllers/quarks_secret.md
@@ -101,6 +101,8 @@ quarks.cloudfoundry.org/secret-kind: generated
 
 This ensures that the creator of the `QuarksSecret` must have access to the copy target namespace.
 
+Copied `Secrets` do not have an owner set, and are not cleaned up automatically when the `QuarksSecret` is deleted.
+
 ### **_CertificateSigningRequest Controller_**
 
 ![certsr-controller-flow](quarks_certsrcontroller_flow.png)


### PR DESCRIPTION
## Description
This change allows the operator to have a cache-enabled client that can span multiple namespaces.
Also fixes a bug with cross-namespace ownership.

## Motivation and Context
Required for copies of generated secrets to work.

## How Has This Been Tested?
With e2e tests and KubeCF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
