### PR TITLE
Change to use AZ name instead of index and support spliters for max-i…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/go-test/deep v1.0.7
 	github.com/gonvenience/bunt v1.1.4
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/hpcloud/tail v1.0.0
 	github.com/imdario/mergo v0.3.11
 	github.com/mattn/go-isatty v0.0.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=

--- a/pkg/bosh/bpmconverter/resources_test.go
+++ b/pkg/bosh/bpmconverter/resources_test.go
@@ -231,6 +231,7 @@ var _ = Describe("BPM Converter", func() {
 						bdv1.LabelDeploymentName:    deploymentName,
 						bdv1.LabelInstanceGroupName: stS.Name,
 						qstsv1a1.LabelAZIndex:       "0",
+						qstsv1a1.LabelAZName:        "z1",
 						qstsv1a1.LabelPodOrdinal:    "0",
 						qstsv1a1.LabelActivePod:     "active",
 					}))
@@ -266,11 +267,12 @@ var _ = Describe("BPM Converter", func() {
 
 					// Test services for the quarks statefulSet
 					service0 := resources.Services[0]
-					Expect(service0.Name).To(Equal(fmt.Sprintf("%s-z%d-0", stS.Name, 0)))
+					Expect(service0.Name).To(Equal(fmt.Sprintf("%s-%s-0-0", stS.Name, m.InstanceGroups[1].AZs[0])))
 					Expect(service0.Spec.Selector).To(Equal(map[string]string{
 						bdv1.LabelDeploymentName:    deploymentName,
 						bdv1.LabelInstanceGroupName: stS.Name,
 						qstsv1a1.LabelAZIndex:       "0",
+						qstsv1a1.LabelAZName:        "z1",
 						qstsv1a1.LabelPodOrdinal:    "0",
 					}))
 					Expect(service0.Spec.Ports).To(Equal([]corev1.ServicePort{
@@ -282,11 +284,12 @@ var _ = Describe("BPM Converter", func() {
 					}))
 
 					service1 := resources.Services[1]
-					Expect(service1.Name).To(Equal(fmt.Sprintf("%s-z%d-1", stS.Name, 0)))
+					Expect(service1.Name).To(Equal(fmt.Sprintf("%s-%s-0-1", stS.Name, m.InstanceGroups[1].AZs[0])))
 					Expect(service1.Spec.Selector).To(Equal(map[string]string{
 						bdv1.LabelDeploymentName:    deploymentName,
 						bdv1.LabelInstanceGroupName: stS.Name,
 						qstsv1a1.LabelAZIndex:       "0",
+						qstsv1a1.LabelAZName:        "z1",
 						qstsv1a1.LabelPodOrdinal:    "1",
 					}))
 					Expect(service1.Spec.Ports).To(Equal([]corev1.ServicePort{
@@ -298,11 +301,12 @@ var _ = Describe("BPM Converter", func() {
 					}))
 
 					service2 := resources.Services[2]
-					Expect(service2.Name).To(Equal(fmt.Sprintf("%s-z%d-0", stS.Name, 1)))
+					Expect(service2.Name).To(Equal(fmt.Sprintf("%s-%s-1-0", stS.Name, m.InstanceGroups[1].AZs[1])))
 					Expect(service2.Spec.Selector).To(Equal(map[string]string{
 						bdv1.LabelDeploymentName:    deploymentName,
 						bdv1.LabelInstanceGroupName: stS.Name,
 						qstsv1a1.LabelAZIndex:       "1",
+						qstsv1a1.LabelAZName:        "z2",
 						qstsv1a1.LabelPodOrdinal:    "0",
 					}))
 					Expect(service2.Spec.Ports).To(Equal([]corev1.ServicePort{
@@ -314,11 +318,12 @@ var _ = Describe("BPM Converter", func() {
 					}))
 
 					service3 := resources.Services[3]
-					Expect(service3.Name).To(Equal(fmt.Sprintf("%s-z%d-1", stS.Name, 1)))
+					Expect(service3.Name).To(Equal(fmt.Sprintf("%s-%s-1-1", stS.Name, m.InstanceGroups[1].AZs[1])))
 					Expect(service3.Spec.Selector).To(Equal(map[string]string{
 						bdv1.LabelDeploymentName:    deploymentName,
 						bdv1.LabelInstanceGroupName: stS.Name,
 						qstsv1a1.LabelAZIndex:       "1",
+						qstsv1a1.LabelAZName:        "z2",
 						qstsv1a1.LabelPodOrdinal:    "1",
 					}))
 					Expect(service3.Spec.Ports).To(Equal([]corev1.ServicePort{

--- a/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
+++ b/pkg/bosh/manifest/cmd_instance_group_resolver_test.go
@@ -134,8 +134,8 @@ var _ = Describe("InstanceGroupResolver", func() {
 				Expect(bpm.Processes[0].Env["FOOBARWITHLINKVALUES"]).To(Equal("10001"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHLINKNESTEDVALUES"]).To(Equal("7765"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHLINKINSTANCESAZ"]).To(Equal("z1"))
-				Expect(bpm.Processes[0].Env["FOOBARWITHLINKINSTANCESADDRESS"]).To(Equal("doppler-z0-0"))
-				Expect(bpm.Processes[0].Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-z0-0"))
+				Expect(bpm.Processes[0].Env["FOOBARWITHLINKINSTANCESADDRESS"]).To(Equal("doppler-z1-0-0"))
+				Expect(bpm.Processes[0].Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-z1-0-0"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECDEPLOYMENT"]).To(Equal("cf"))
 
 				// The following block of assertions are related to the usage of
@@ -147,11 +147,11 @@ var _ = Describe("InstanceGroupResolver", func() {
 				// We do not support different indexes in BPM data.
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECAZ"]).To(Equal("z1"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECBOOTSTRAP"]).To(Equal("true"))
-				Expect(bpm.Processes[0].Env["FOOBARWITHSPECID"]).To(Equal("log-api-z0-0"))
+				Expect(bpm.Processes[0].Env["FOOBARWITHSPECID"]).To(Equal("log-api-z1-0-0"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECINDEX"]).To(Equal("0"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNAME"]).To(Equal("log-api-loggregator_trafficcontroller"))
 				Expect(bpm.Processes[0].Env["FOOBARWITHSPECNETWORKS"]).To(Equal(""))
-				Expect(bpm.Processes[0].Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-z0-0"))
+				Expect(bpm.Processes[0].Env["FOOBARWITHSPECADDRESS"]).To(Equal("log-api-z1-0-0"))
 
 				Expect(bpm.Ports).To(ContainElement(bpmConfig.Port{
 					Name:     "outgoing_dropsonde_port",

--- a/pkg/bosh/manifest/cmd_render_job_tmpls.go
+++ b/pkg/bosh/manifest/cmd_render_job_tmpls.go
@@ -126,7 +126,7 @@ func RenderJobTemplates(
 			}
 
 			// Find job instance that's being rendered
-			currentJobInstance := job.Properties.Quarks.jobInstance(ig.AZs, specIndex)
+			currentJobInstance := job.Properties.Quarks.jobInstance(ig.AZs, azIndex, specIndex)
 			if currentJobInstance == nil {
 				return errors.Errorf("no job instance found for spec index '%d'", specIndex)
 			}

--- a/pkg/bosh/manifest/containerization.go
+++ b/pkg/bosh/manifest/containerization.go
@@ -43,14 +43,14 @@ type JobInstance struct {
 	Network   map[string]interface{} `json:"networks"`
 }
 
-func (q Quarks) jobInstance(azs []string, specIndex int) *JobInstance {
+func (q Quarks) jobInstance(azs []string, azIndex int, specIndex int) *JobInstance {
 	for _, instance := range q.Instances {
 		if len(azs) > 0 {
-			for i, az := range azs {
-				if instance.AZ == az {
-					if names.SpecIndex(i+1, instance.Instance) == specIndex {
-						return &instance
-					}
+			instancesPerZone := len(q.Instances) / len(azs)
+			zoneStart := (azIndex - 1) * instancesPerZone
+			if instance.AZ == azs[azIndex-1] && instance.Index >= zoneStart {
+				if names.SpecIndex(azIndex, instance.Instance) == specIndex {
+					return &instance
 				}
 			}
 		} else {

--- a/pkg/bosh/manifest/instance_group.go
+++ b/pkg/bosh/manifest/instance_group.go
@@ -109,10 +109,10 @@ func (ig *InstanceGroup) IsErrand() bool {
 
 // IndexedServiceName constructs an indexed service name. It's used to construct the service
 // names other than the headless service.
-func (ig *InstanceGroup) IndexedServiceName(index int, azIndex int) string {
+func (ig *InstanceGroup) IndexedServiceName(index int, azIndex int, azName string) string {
 	sn := boshnames.TruncatedServiceName(ig.Name, 53)
 	if azIndex > -1 {
-		return fmt.Sprintf("%s-z%d-%d", sn, azIndex, index)
+		return fmt.Sprintf("%s-%s-%d-%d", sn, azName, azIndex, index)
 	}
 	return fmt.Sprintf("%s-%d", sn, index)
 }
@@ -144,7 +144,7 @@ func (ig *InstanceGroup) jobInstances(
 		//specIndex := names.SpecIndex(azIndex+1, i))
 
 		jobsInstances = append(jobsInstances, JobInstance{
-			Address:   ig.IndexedServiceName(i, -1),
+			Address:   ig.IndexedServiceName(i, -1, ""),
 			AZ:        "",
 			Bootstrap: i == bootstrapIndex,
 			Index:     i,
@@ -174,13 +174,13 @@ func (ig *InstanceGroup) jobInstancesAZ(
 			index := len(jobsInstances)
 
 			jobsInstances = append(jobsInstances, JobInstance{
-				Address:   ig.IndexedServiceName(i, azIndex),
+				Address:   ig.IndexedServiceName(i, azIndex, az),
 				AZ:        az,
 				Bootstrap: index == bootstrapIndex,
 				Index:     index,
 				Instance:  i,
 				Name:      fmt.Sprintf("%s-%s", igName, jobName),
-				ID:        fmt.Sprintf("%s-z%d-%d", igName, azIndex, index%ig.Instances),
+				ID:        fmt.Sprintf("%s-%s-%d-%d", igName, az, azIndex, index%ig.Instances),
 			})
 		}
 	}

--- a/pkg/kube/util/boshdns/bosh_test.go
+++ b/pkg/kube/util/boshdns/bosh_test.go
@@ -265,9 +265,9 @@ var _ = Describe("BOSHDomainNameService", func() {
 
 				By("checking for entries for diego-cells in mutli-zone")
 				Expect(corefile).To(ContainSubstring(`
-	template IN A diego-cell-z0-0.cell.service.cf.internal {
-		match ^diego-cell-z0-0\.cell\.service\.cf\.internal\.$
-		answer "{{ .Name }} 60 IN CNAME diego-cell-z0-0.default.svc."
+	template IN A diego-cell-az1-0-0.cell.service.cf.internal {
+		match ^diego-cell-az1-0-0\.cell\.service\.cf\.internal\.$
+		answer "{{ .Name }} 60 IN CNAME diego-cell-az1-0-0.default.svc."
 		fallthrough`))
 			})
 		})

--- a/pkg/kube/util/boshdns/corefile.go
+++ b/pkg/kube/util/boshdns/corefile.go
@@ -131,12 +131,13 @@ func gatherAllRewrites(rewrites []string,
 	alias Alias) []string {
 	if target.Query == "_" {
 		if len(instanceGroup.AZs) > 0 {
-			for azIndex := range instanceGroup.AZs {
+			for azIndex, azName := range instanceGroup.AZs {
 				rewrites = gatherRewritesForInstances(rewrites,
 					instanceGroup,
 					target,
 					namespace,
 					azIndex,
+					azName,
 					alias)
 			}
 		} else {
@@ -145,6 +146,7 @@ func gatherAllRewrites(rewrites []string,
 				target,
 				namespace,
 				-1,
+				"",
 				alias)
 		}
 	} else {
@@ -164,16 +166,17 @@ func gatherRewritesForInstances(rewrites []string,
 	target Target,
 	namespace string,
 	azIndex int,
+	azName string,
 	alias Alias) []string {
 	id := ""
 	for i := 0; i < instanceGroup.Instances; i++ {
 		if azIndex > -1 {
-			id = fmt.Sprintf("%s-z%d-%d", target.InstanceGroup, azIndex, i)
+			id = fmt.Sprintf("%s-%s-%d-%d", target.InstanceGroup, azName, azIndex, i)
 		} else {
 			id = fmt.Sprintf("%s-%d", target.InstanceGroup, i)
 		}
 		from := strings.Replace(alias.Domain, "_", id, 1)
-		serviceName := instanceGroup.IndexedServiceName(i, azIndex)
+		serviceName := instanceGroup.IndexedServiceName(i, azIndex, azName)
 		to := fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain)
 		rewrites = append(rewrites, newTemplate(from, to))
 	}

--- a/testing/assets/templateRenderManifestSameAZ.yml
+++ b/testing/assets/templateRenderManifestSameAZ.yml
@@ -1,0 +1,288 @@
+director_uuid: ""
+instance_groups:
+  - name: log-api
+    instances: 2
+    azs:
+      - a1
+      - a1
+    jobs:
+      - name: loggregator_trafficcontroller
+        release: loggregator
+        properties:
+          quarks:
+            bpm:
+              processes:
+                - name: loggregator_trafficcontroller
+                  executable: /var/vcap/packages/loggregator_trafficcontroller/trafficcontroller
+                  env:
+                    AGENT_GRPC_ADDRESS: 127.0.0.1:3458
+                    AGENT_UDP_ADDRESS: 127.0.0.1:3457
+                    CC_CA_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/mutual_tls_ca.crt
+                    CC_CERT_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.crt
+                    CC_KEY_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/cc_trafficcontroller.key
+                    FOOBARWITHLINKINSTANCESADDRESS: doppler-0-doppler.default.svc.cluster.local
+                    FOOBARWITHLINKINSTANCESAZ: z1
+                    FOOBARWITHLINKINSTANCESINDEX: "0"
+                    FOOBARWITHLINKNESTEDVALUES: "7765"
+                    FOOBARWITHLINKVALUES: "10001"
+                    FOOBARWITHSPECADDRESS: log-api-3-loggregator_trafficcontroller.default.svc.cluster.local
+                    FOOBARWITHSPECDEPLOYMENT: cf
+                    FOOBARWITHSPECIP: ""
+                    ROUTER_CA_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/loggregator_ca.crt
+                    ROUTER_CERT_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.crt
+                    ROUTER_KEY_FILE: /var/vcap/jobs/loggregator_trafficcontroller/config/certs/trafficcontroller.key
+                    TRAFFIC_CONTROLLER_DISABLE_ACCESS_CONTROL: "false"
+                    TRAFFIC_CONTROLLER_HEALTH_ADDR: localhost:14825
+                    TRAFFIC_CONTROLLER_IP: ""
+                    TRAFFIC_CONTROLLER_METRIC_EMITTER_INTERVAL: 1m
+                    TRAFFIC_CONTROLLER_OUTGOING_DROPSONDE_PORT: "8081"
+                    TRAFFIC_CONTROLLER_PPROF_PORT: "0"
+                    TRAFFIC_CONTROLLER_SKIP_CERT_VERIFY: "true"
+                  limits:
+                    open_files: 65536
+            consumes:
+              doppler:
+                instances:
+                  - address: doppler-0-doppler.default.svc.cluster.local
+                    az: z1
+                    id: doppler-0-doppler
+                    index: 0
+                    instance: 0
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: true
+                    networks: {}
+                    ip: ""
+                  - address: doppler-1-doppler.default.svc.cluster.local
+                    az: z2
+                    id: doppler-1-doppler
+                    index: 1
+                    instance: 0
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-2-doppler.default.svc.cluster.local
+                    az: z1
+                    id: doppler-2-doppler
+                    index: 2
+                    instance: 1
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-3-doppler.default.svc.cluster.local
+                    az: z2
+                    id: doppler-3-doppler
+                    index: 3
+                    instance: 1
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-4-doppler.default.svc.cluster.local
+                    az: z1
+                    id: doppler-4-doppler
+                    index: 4
+                    instance: 2
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-5-doppler.default.svc.cluster.local
+                    az: z2
+                    id: doppler-5-doppler
+                    index: 5
+                    instance: 2
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-6-doppler.default.svc.cluster.local
+                    az: z1
+                    id: doppler-6-doppler
+                    index: 6
+                    instance: 3
+                    name: doppler-doppler
+                    bpm:
+                      processes:
+                        - name: doppler
+                          executable: /var/vcap/packages/doppler/doppler
+                          env:
+                            AGENT_GRPC_ADDRESS: foobar.com:3458
+                            ROUTER_CA_FILE: /var/vcap/jobs/doppler/config/certs/loggregator_ca.crt
+                            ROUTER_CERT_FILE: /var/vcap/jobs/doppler/config/certs/doppler.crt
+                            ROUTER_CIPHER_SUITES: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+                            ROUTER_CONTAINER_METRIC_TTL_SECONDS: "120"
+                            ROUTER_HEALTH_ADDR: localhost:14825
+                            ROUTER_KEY_FILE: /var/vcap/jobs/doppler/config/certs/doppler.key
+                            ROUTER_MAX_RETAINED_LOG_MESSAGES: "100"
+                            ROUTER_PORT: "7765"
+                            ROUTER_PPROF_PORT: "0"
+                            ROUTER_SINK_INACTIVITY_TIMEOUT_SECONDS: "3600"
+                          limits:
+                            open_files: 65536
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                  - address: doppler-7-doppler.default.svc.cluster.local
+                    az: z2
+                    id: doppler-7-doppler
+                    index: 7
+                    instance: 3
+                    name: doppler-doppler
+                    bpm: null
+                    fingerprint: null
+                    bootstrap: false
+                    networks: {}
+                    ip: ""
+                properties:
+                  doppler:
+                    grpc_port: 7765
+                    fooprop: 10001
+            instances: null
+            release: loggregator
+            envs:
+            - name: TRAFFIC_CONTROLLER_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          cc:
+            internal_service_hostname: cloud-controller-ng.service.cf.internal
+            mutual_tls:
+              ca_cert: ((service_cf_internal_ca.certificate))
+            tls_port: 9023
+          doppler:
+            grpc_port: 6060
+          loggregator:
+            tls:
+              ca_cert: ((loggregator_ca.certificate))
+              cc_trafficcontroller:
+                cert: ((loggregator_tls_cc_tc.certificate))
+                key: ((loggregator_tls_cc_tc.private_key))
+              trafficcontroller:
+                cert: ((loggregator_tls_tc.certificate))
+                key: ((loggregator_tls_tc.private_key))
+            uaa:
+              client_secret: ((uaa_clients_doppler_secret))
+          ssl:
+            skip_cert_verify: true
+          system_domain: ((system_domain))
+          uaa:
+            ca_cert: ((uaa_ca.certificate))
+            internal_url: https://uaa.service.cf.internal:8443


### PR DESCRIPTION
We need to use the real name of the AZ to differentiate between multiple clusters of cells.   

This also supports a splinter where you can specify the same az more than once to get max-in-flight increases

- [X] Review PRs of changed Quarks dependencies
- [X] Update this PR after the release of Quarks dependencies
